### PR TITLE
Add socks proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Just some examples
 
 <img src="https://raw.githubusercontent.com/dgtlmoon/changedetection.io/master/screenshot-notifications.png" style="max-width:100%;" alt="Self-hosted web page change monitoring notifications"  title="Self-hosted web page change monitoring notifications"  />
 
+### Proxy
+
+A proxy for ChangeDectection.io can be configured by setting environment variables.
+
+For example
+```
+$ export HTTP_PROXY="socks5h://10.10.1.10:1080"
+$ export HTTPS_PROXY="socks5h://10.10.1.10:1080"
+
+# An exclude list (useful for notifcation URLs above) can be specified by following
+$ export NO_PROXY="localhost,192.168.0.0/24"
+```
+For more information see https://docs.python-requests.org/en/master/user/advanced/#proxies
 
 ### Notes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask~= 1.0
 pytest ~=6.2
 pytest-flask ~=1.2
 eventlet>=0.31.0
-requests ~= 2.15
+requests[socks] ~= 2.15
 validators
 timeago ~=1.0
 inscriptis ~= 1.1


### PR DESCRIPTION
Proxy can be passed [via environment variables](https://docs.python-requests.org/en/master/user/advanced/#proxies).

Related to #49