### PR TITLE
Add a link to the diff page in the notification

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -835,12 +835,16 @@ def notification_runner():
                 for url in n_object['notification_urls']:
                     apobj.add(url.strip())
 
-                n_body = n_object['watch_url']
+                n_body = f"Live: {n_object['watch_url']}"
 
                 # 65 - Append URL of instance to the notification if it is set.
                 base_url = os.getenv('BASE_URL')
+                uuid = n_object['uuid']
+
+                base_url = "http://localhost:5000" if base_url is None else base_url
+
                 if base_url != None:
-                    n_body += "\n" + base_url
+                    n_body += f"\nDiff: {base_url}/diff/{uuid}"
 
                 apobj.notify(
                     body=n_body,

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -841,8 +841,6 @@ def notification_runner():
                 base_url = os.getenv('BASE_URL').strip('"')
                 uuid = n_object['uuid']
 
-                base_url = "http://localhost:5000" if base_url is None else base_url
-
                 if base_url != None:
                     n_body += f"\nDiff: {base_url}/diff/{uuid}"
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -838,7 +838,7 @@ def notification_runner():
                 n_body = f"Live: {n_object['watch_url']}"
 
                 # 65 - Append URL of instance to the notification if it is set.
-                base_url = os.getenv('BASE_URL')
+                base_url = os.getenv('BASE_URL').strip('"')
                 uuid = n_object['uuid']
 
                 base_url = "http://localhost:5000" if base_url is None else base_url

--- a/backend/update_worker.py
+++ b/backend/update_worker.py
@@ -42,23 +42,27 @@ class update_worker(threading.Thread):
                                 if changed_detected:
                                     # A change was detected
                                     self.datastore.save_history_text(uuid=uuid, contents=contents, result_obj=result)
-
                                     watch = self.datastore.data['watching'][uuid]
 
                                     # Did it have any notification alerts to hit?
                                     if len(watch['notification_urls']):
                                         print("Processing notifications for UUID: {}".format(uuid))
-                                        n_object = {'watch_url': self.datastore.data['watching'][uuid]['url'],
-                                                    'notification_urls': watch['notification_urls']}
+                                        n_object = {
+                                            'watch_url': self.datastore.data['watching'][uuid]['url'],
+                                            'notification_urls': watch['notification_urls'],
+                                            'uuid': uuid,
+                                        }
                                         self.notification_q.put(n_object)
 
 
                                     # No? maybe theres a global setting, queue them all
                                     elif len(self.datastore.data['settings']['application']['notification_urls']):
                                         print("Processing GLOBAL notifications for UUID: {}".format(uuid))
-                                        n_object = {'watch_url': self.datastore.data['watching'][uuid]['url'],
-                                                    'notification_urls': self.datastore.data['settings']['application'][
-                                                        'notification_urls']}
+                                        n_object = {
+                                            'watch_url': self.datastore.data['watching'][uuid]['url'],
+                                            'notification_urls': self.datastore.data['settings']['application']['notification_urls'],
+                                            'uuid': uuid
+                                        }
                                         self.notification_q.put(n_object)
                             except Exception as e:
                                 print("!!!! Exception in update_worker !!!\n", e)


### PR DESCRIPTION
Proposed MR to add a link to the diff page in the notifications.

Example of the before and after:
![Discord_Gd8jpBkbFt](https://user-images.githubusercontent.com/53234158/124480893-a30cdd80-dd9f-11eb-9e11-9cb495fab613.png)

I've been using this for some weeks now and it's great, but I found it fustrating to click the link to the live server and scroll through to find and click the diff. This should help especially if you have lots of things being monitored.

I saw in-line comments saying this notification should be customisable (maybe I can help out with this if you're open to it) but this should help in the meantime.

All tests are passing it's just a simple body message change and passing in the UUID to `n_object` in the update worker.