### PR TITLE
Re #117 Jsonpath based JSON change detection filter

### DIFF
--- a/backend/fetch_site_status.py
+++ b/backend/fetch_site_status.py
@@ -99,7 +99,8 @@ class perform_site_check():
                     json_data = json.loads(html)
                     jsonpath_expression = parse(css_filter_rule.replace('json:',''))
                     match = jsonpath_expression.find(json_data)
-                    stripped_text_from_html = str(match[0].value)
+                    stripped_text_from_html = json.dumps(match[0].value, indent=4)
+
                     is_html = False
 
                 else:

--- a/backend/fetch_site_status.py
+++ b/backend/fetch_site_status.py
@@ -88,12 +88,26 @@ class perform_site_check():
 
             html = r.text
 
-            # CSS Filter, extract the HTML that matches and feed that into the existing inscriptis::get_text
+            is_html = True
             css_filter_rule = self.datastore.data['watching'][uuid]['css_filter']
             if css_filter_rule and len(css_filter_rule.strip()):
-                html = html_tools.css_filter(css_filter=css_filter_rule, html_content=r.content)
+                if 'json:' in css_filter_rule:
+                    # POC hack, @todo rename vars, see how it fits in with the javascript version
+                    import json
+                    from jsonpath_ng import jsonpath, parse
 
-            stripped_text_from_html = get_text(html)
+                    json_data = json.loads(html)
+                    jsonpath_expression = parse(css_filter_rule.replace('json:',''))
+                    match = jsonpath_expression.find(json_data)
+                    stripped_text_from_html = str(match[0].value)
+                    is_html = False
+
+                else:
+                    # CSS Filter, extract the HTML that matches and feed that into the existing inscriptis::get_text
+                    html = html_tools.css_filter(css_filter=css_filter_rule, html_content=r.content)
+
+            if is_html:
+                stripped_text_from_html = get_text(html)
 
         # Usually from networkIO/requests level
         except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout) as e:

--- a/backend/forms.py
+++ b/backend/forms.py
@@ -111,7 +111,7 @@ class watchForm(Form):
     tag = StringField('Tag', [validators.Optional(), validators.Length(max=35)])
     minutes_between_check = html5.IntegerField('Maximum time in minutes until recheck',
                                                [validators.Optional(), validators.NumberRange(min=1)])
-    css_filter = StringField('CSS Filter')
+    css_filter = StringField('CSS/JSON Filter')
     title = StringField('Title')
 
     ignore_text = StringListField('Ignore Text', [ListRegex()])

--- a/backend/forms.py
+++ b/backend/forms.py
@@ -82,7 +82,7 @@ class StringDictKeyValue(StringField):
         else:
             self.data = {}
 
-class ListRegex(object):
+class ValidateListRegex(object):
     """
     Validates that anything that looks like a regex passes as a regex
     """
@@ -114,7 +114,7 @@ class watchForm(Form):
     css_filter = StringField('CSS/JSON Filter')
     title = StringField('Title')
 
-    ignore_text = StringListField('Ignore Text', [ListRegex()])
+    ignore_text = StringListField('Ignore Text', [ValidateListRegex()])
     notification_urls = StringListField('Notification URL List')
     headers = StringDictKeyValue('Request Headers')
     trigger_check = BooleanField('Send test notification on save')

--- a/backend/templates/edit.html
+++ b/backend/templates/edit.html
@@ -23,9 +23,12 @@
             </div>
             <div class="pure-control-group">
                 {{ render_field(form.css_filter, size=25, placeholder=".class-name or #some-id, or other CSS selector rule.") }}
-                <span class="pure-form-message-inline">Limit text to this CSS rule, only text matching this CSS rule is included.<br/>
-                    Please be sure that you thoroughly understand how to write CSS selector rules before filing an issue on GitHub!<br/>
-                    Go <a href="https://github.com/dgtlmoon/changedetection.io/wiki/CSS-Selector-help">here for more CSS selector help</a>
+                <span class="pure-form-message-inline">
+                    <ul>
+                        <li>CSS - Limit text to this CSS rule, only text matching this CSS rule is included.</li>
+                        <li>JSON - Limit text to this JSON rule, using <a href="https://pypi.org/project/jsonpath-ng/">JSONPath</a>, prefix with "json:"</li>
+                    </ul>
+                    Please be sure that you thoroughly understand how to write CSS or JSONPath selector rules before filing an issue on GitHub! <a href="https://github.com/dgtlmoon/changedetection.io/wiki/CSS-Selector-help">here for more CSS selector help</a>.<br/>
                 </span>
             </div>
             <!-- @todo: move to tabs --->

--- a/backend/templates/edit.html
+++ b/backend/templates/edit.html
@@ -26,7 +26,7 @@
                 <span class="pure-form-message-inline">
                     <ul>
                         <li>CSS - Limit text to this CSS rule, only text matching this CSS rule is included.</li>
-                        <li>JSON - Limit text to this JSON rule, using <a href="https://pypi.org/project/jsonpath-ng/">JSONPath</a>, prefix with "json:"</li>
+                        <li>JSON - Limit text to this JSON rule, using <a href="https://pypi.org/project/jsonpath-ng/">JSONPath</a>, prefix with <b>"json:"</b>, <a href="https://jsonpath.com/" target="new">test your JSONPath here</a></li>
                     </ul>
                     Please be sure that you thoroughly understand how to write CSS or JSONPath selector rules before filing an issue on GitHub! <a href="https://github.com/dgtlmoon/changedetection.io/wiki/CSS-Selector-help">here for more CSS selector help</a>.<br/>
                 </span>

--- a/backend/tests/test_jsonpath_selector.py
+++ b/backend/tests/test_jsonpath_selector.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python3
+
+import time
+from flask import url_for
+from . util import live_server_setup
+
+from ..html_tools import *
+
+def test_setup(live_server):
+    live_server_setup(live_server)
+
+def set_original_response():
+    test_return_data = """
+    {
+      "employees": [
+        {
+          "id": 1,
+          "name": "Pankaj",
+          "salary": "10000"
+        },
+        {
+          "name": "David",
+          "salary": "5000",
+          "id": 2
+        }
+      ],
+      "boss": {
+        "name": "Fat guy"
+      }
+    }
+    """
+    with open("test-datastore/output.txt", "w") as f:
+        f.write(test_return_data)
+    return None
+
+def set_modified_response():
+    test_return_data = """
+    {
+      "employees": [
+        {
+          "id": 1,
+          "name": "Pankaj",
+          "salary": "10000"
+        },
+        {
+          "name": "David",
+          "salary": "5000",
+          "id": 2
+        }
+      ],
+      "boss": {
+        "name": "Foobar"
+      }
+    }
+        """
+
+    with open("test-datastore/output.txt", "w") as f:
+        f.write(test_return_data)
+
+    return None
+
+
+# Test that the CSS extraction works how we expect, important here is the right placing of new lines \n's
+def test_json_filter_output():
+    return
+    import json
+    from jsonpath_ng import jsonpath, parse
+
+#    html_blob = json_filter(css_filter=".parts", html_content=content)
+
+    json_string = """
+    """
+    json_data = json.loads(json_string)
+
+    jsonpath_expression = parse('employees[1].salary')
+    match = jsonpath_expression.find(json_data)
+    assert match[0].value == "5000"
+
+
+def test_check_json_filter(client, live_server):
+    live_server_setup(live_server)
+
+    json_filter = 'json:boss.name'
+
+    set_original_response()
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # Add our URL to the import page
+    test_url = url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+
+    # Trigger a check
+    client.get(url_for("api_watch_checknow"), follow_redirects=True)
+
+    # Give the thread time to pick it up
+    time.sleep(3)
+
+    # Goto the edit page, add our ignore text
+    # Add our URL to the import page
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"css_filter": json_filter, "url": test_url, "tag": "", "headers": ""},
+        follow_redirects=True
+    )
+    assert b"Updated watch." in res.data
+
+    # Check it saved
+    res = client.get(
+        url_for("edit_page", uuid="first"),
+    )
+    assert bytes(json_filter.encode('utf-8')) in res.data
+
+    # Trigger a check
+    client.get(url_for("api_watch_checknow"), follow_redirects=True)
+
+    # Give the thread time to pick it up
+    time.sleep(3)
+    #  Make a change
+    set_modified_response()
+
+    # Trigger a check
+    client.get(url_for("api_watch_checknow"), follow_redirects=True)
+    # Give the thread time to pick it up
+    time.sleep(3)
+
+    # It should have 'unviewed' still
+    # Because it should be looking at only that 'sametext' id
+    res = client.get(url_for("index"))
+    assert b'unviewed' in res.data

--- a/backend/tests/test_jsonpath_selector.py
+++ b/backend/tests/test_jsonpath_selector.py
@@ -4,8 +4,6 @@ import time
 from flask import url_for
 from . util import live_server_setup
 
-from ..html_tools import *
-
 def test_setup(live_server):
     live_server_setup(live_server)
 
@@ -60,25 +58,8 @@ def set_modified_response():
     return None
 
 
-# Test that the CSS extraction works how we expect, important here is the right placing of new lines \n's
-def test_json_filter_output():
-    return
-    import json
-    from jsonpath_ng import jsonpath, parse
-
-#    html_blob = json_filter(css_filter=".parts", html_content=content)
-
-    json_string = """
-    """
-    json_data = json.loads(json_string)
-
-    jsonpath_expression = parse('employees[1].salary')
-    match = jsonpath_expression.find(json_data)
-    assert match[0].value == "5000"
-
 
 def test_check_json_filter(client, live_server):
-    #live_server_setup(live_server)
 
     json_filter = 'json:boss.name'
 
@@ -131,6 +112,10 @@ def test_check_json_filter(client, live_server):
     time.sleep(3)
 
     # It should have 'unviewed' still
-    # Because it should be looking at only that 'sametext' id
     res = client.get(url_for("index"))
     assert b'unviewed' in res.data
+
+    # Should not see this, because its not in the JSONPath we entered
+    res = client.get(url_for("diff_history_page", uuid="first"))
+    # But the change should be there, tho its hard to test the change was detected because it will show old and new versions
+    assert b'Foobar' in res.data

--- a/backend/tests/test_jsonpath_selector.py
+++ b/backend/tests/test_jsonpath_selector.py
@@ -78,7 +78,7 @@ def test_json_filter_output():
 
 
 def test_check_json_filter(client, live_server):
-    live_server_setup(live_server)
+    #live_server_setup(live_server)
 
     json_filter = 'json:boss.name'
 

--- a/changedetection.py
+++ b/changedetection.py
@@ -60,7 +60,7 @@ def main(argv):
 
     @app.context_processor
     def inject_version():
-        return dict(version=datastore.data['version_tag'],
+        return dict(right_sticky="v{}".format(datastore.data['version_tag']),
                     new_version_available=app.config['NEW_VERSION_AVAILABLE'],
                     has_password=datastore.data['settings']['application']['password'] != False
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flask-login ~= 0.5
 pytz
 urllib3
 wtforms ~= 2.3.3
-
+jsonpath-ng ~= 1.5.3
 
 
 # Notification library


### PR DESCRIPTION
Re #117 jsonpath JSON change detection filter

For example

https://api.coindesk.com/v1/bpi/currentprice.json

![image](https://user-images.githubusercontent.com/275001/125165842-0ce01980-e1dc-11eb-9e73-d8137dd162dc.png)

This will re-parse the JSON and apply indent to the conversion

![image](https://user-images.githubusercontent.com/275001/125165995-d9ea5580-e1dc-11eb-8030-f0deced2661a.png)

Todo:

- See how it fits in with the `javascript-browser` branch 
- rename vars? 
- Test how it works with errors (bad jsonpath rule, bad json document etc)