### PR TITLE
fix #137

### DIFF
--- a/backend/fetch_site_status.py
+++ b/backend/fetch_site_status.py
@@ -63,7 +63,7 @@ class perform_site_check():
         extra_headers = self.datastore.get_val(uuid, 'headers')
 
         # Tweak the base config with the per-watch ones
-        request_headers = self.datastore.data['settings']['headers']
+        request_headers = self.datastore.data['settings']['headers'].copy()
         request_headers.update(extra_headers)
 
         # https://github.com/psf/requests/issues/4525


### PR DESCRIPTION
Partially revert 47e5a7cf0990bc958061ce57de8ae88f3fbd39aa
Copy HTTP headers from the global template instead of updating the global template when fetching a site.

fixes #137