### PR TITLE
fix: setting overflow in mobile view

### DIFF
--- a/backend/static/styles/styles.css
+++ b/backend/static/styles/styles.css
@@ -297,7 +297,7 @@ footer {
       color: #dd0000; }
   .pure-form label {
     font-weight: bold; }
-  .pure-form input[type=url] {
+  .pure-form input {
     width: 100%; }
   .pure-form textarea {
     width: 100%; }

--- a/backend/static/styles/styles.scss
+++ b/backend/static/styles/styles.scss
@@ -401,7 +401,7 @@ footer {
     font-weight: bold;
   }
 
-  input[type=url] {
+  input {
     width: 100%;
   }
 

--- a/backend/templates/settings.html
+++ b/backend/templates/settings.html
@@ -39,7 +39,7 @@ SMTPS - mailtos://user:pass@mail.domain.com?to=receivingAddress@example.com") }}
                 <div id="notification-customisation" style="display:none;">
 
                     <div class="pure-control-group">
-                        {{ render_field(form.notification_title, size=80) }}
+                        {{ render_field(form.notification_title) }}
                         <span class="pure-form-message-inline">Title for all notifications</span>
                     </div>
                     <div class="pure-control-group">


### PR DESCRIPTION
The notification_title input is fixed with size=80, cause the page overflown in mobile view.
Use CSS to fit it instead