### PR TITLE
Add socksVersion mapping

### DIFF
--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -70,7 +70,7 @@ class html_webdriver(Fetcher):
     # In the ENV vars, is prefixed with "webdriver_", so it is for example "webdriver_sslProxy"
     selenium_proxy_settings_mappings = ['ftpProxy', 'httpProxy', 'noProxy',
                                         'proxyAutoconfigUrl', 'sslProxy', 'autodetect',
-                                        'socksProxy', 'socksUsername', 'socksPassword']
+                                        'socksProxy', 'socksVersion', 'socksUsername', 'socksPassword']
     proxy=None
 
     def __init__(self):


### PR DESCRIPTION
Thanks for your changes in https://github.com/dgtlmoon/changedetection.io/pull/326 to solve https://github.com/dgtlmoon/changedetection.io/issues/267. 

I'm getting the following error from the webdriver which this PR should solve it:

```
org.openqa.selenium.InvalidArgumentException: invalid argument: entry 0 of 'firstMatch' is invalid
from invalid argument: cannot parse capability: proxy
from invalid argument: Specifying 'socksProxy' requires an integer for 'socksVersion'
```