### PR TITLE
Working arm64 chrome-browser container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       restart: unless-stopped
 
      # Used for fetching pages via WebDriver+Chrome where you need Javascript support.
-     # Does not work on rPi, https://github.com/dgtlmoon/changedetection.io/wiki/Fetching-pages-with-WebDriver
+     # Now working on arm64 (needs testing on rPi - tested on Oracle ARM instance)
+     # replace image with seleniarm/standalone-chromium:4.0.0-20211213
 
 #    browser-chrome:
 #        hostname: browser-chrome


### PR DESCRIPTION
Seleniarm has a working arm64 container for browser-chrome - tested on Oracle Cloud ARM server, not tested on rPi, as I don't have one available to test.

Added notes to the comments for the alternative container, and removed the note regarding rPi.