### PR TITLE
Add option for tags on import

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -11,24 +11,20 @@
 # proxy per check
 #  - flask_cors, itsdangerous,MarkupSafe
 
-import time
+import datetime
 import os
-import timeago
-import flask_login
-from flask_login import login_required
-
+import queue
 import threading
+import time
+from copy import deepcopy
 from threading import Event
 
-import queue
-
-from flask import Flask, render_template, request, send_from_directory, abort, redirect, url_for, flash
-
-from feedgen.feed import FeedGenerator
-from flask import make_response
-import datetime
+import flask_login
 import pytz
-from copy import deepcopy
+import timeago
+from feedgen.feed import FeedGenerator
+from flask import Flask, abort, flash, make_response, redirect, render_template, request, send_from_directory, url_for
+from flask_login import login_required
 
 __version__ = '0.39.7'
 
@@ -139,8 +135,8 @@ class User(flask_login.UserMixin):
 
     def check_password(self, password):
 
-        import hashlib
         import base64
+        import hashlib
 
         # Getting the values back out
         raw_salt_pass = base64.b64decode(datastore.data['settings']['application']['password'])
@@ -400,6 +396,7 @@ def changedetection_app(config=None, datastore_o=None):
     def get_current_checksum_include_ignore_text(uuid):
 
         import hashlib
+
         from changedetectionio import fetch_site_status
 
         # Get the most recent one
@@ -548,8 +545,7 @@ def changedetection_app(config=None, datastore_o=None):
     @login_required
     def settings_page():
 
-        from changedetectionio import forms
-        from changedetectionio import content_fetcher
+        from changedetectionio import content_fetcher, forms
 
         form = forms.globalSettingsForm(request.form)
 
@@ -628,9 +624,10 @@ def changedetection_app(config=None, datastore_o=None):
             urls = request.values.get('urls').split("\n")
             for url in urls:
                 url = url.strip()
+                url, *tags = url.split(" ")
                 # Flask wtform validators wont work with basic auth, use validators package
                 if len(url) and validators.url(url):
-                    new_uuid = datastore.add_watch(url=url.strip(), tag="")
+                    new_uuid = datastore.add_watch(url=url.strip(), tag=",".join(tags))
                     # Straight into the queue.
                     update_q.put(new_uuid)
                     good += 1
@@ -936,7 +933,6 @@ def changedetection_app(config=None, datastore_o=None):
 # Check for new version and anonymous stats
 def check_for_new_version():
     import requests
-
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 

--- a/changedetectionio/templates/import.html
+++ b/changedetectionio/templates/import.html
@@ -5,7 +5,14 @@
      <div class="inner">
         <form class="pure-form pure-form-aligned" action="{{url_for('import_page')}}" method="POST">
             <fieldset class="pure-group">
-                <legend>One URL per line, URLs that do not pass validation will stay in the textarea.</legend>
+              <legend>
+                Enter one URL per line, and optionally add tags for each URL after a space, delineated by comma (,):
+                <br>
+                <code>https://example.com tag1, tag2, last tag</code>
+                <br>
+                URLs which do not pass validation will stay in the textarea.
+              </legend>
+              
 
                 <textarea name="urls" class="pure-input-1-2" placeholder="https://"
                           style="width: 100%;
@@ -20,4 +27,3 @@
 </div>
 
 {% endblock %}
-

--- a/changedetectionio/tests/test_import.py
+++ b/changedetectionio/tests/test_import.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+
+import time
+
+from flask import url_for
+
+from .util import live_server_setup
+
+
+def test_import(client, live_server):
+
+    live_server_setup(live_server)
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    res = client.post(
+        url_for("import_page"),
+        data={
+            "urls": """https://example.com
+https://example.com tag1
+https://example.com tag1, other tag"""
+        },
+        follow_redirects=True,
+    )
+    assert b"3 Imported" in res.data
+    assert b"tag1" in res.data
+    assert b"other tag" in res.data


### PR DESCRIPTION
With this small change, tags can be added inside the import by adding them after whitespace, ie:

```https://google.com search other``` 
will add google with two tags, `search` and `other`.

We are looking at using changedetection to track a larger number of websites, the URLs for which are added automatically and should be categorized. Hence I thought this was a useful change.

I had disabled black, but isort was still running, so the imports in `__init__.py` have been sorted as well. I thought it's fine to leave, as better organized imports don't hurt. If you'd rather not do this, I'm happy to revert those changes.

Also, PR onto `master` because `dev` seems to have been abandoned a short while ago?