### PR TITLE
Don't allow duplicate URLs on import / Some tests not tearing down old data

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -629,7 +629,7 @@ def changedetection_app(config=None, datastore_o=None):
             for url in urls:
                 url = url.strip()
                 # Flask wtform validators wont work with basic auth, use validators package
-                if len(url) and validators.url(url):
+                if len(url) and validators.url(url) and not datastore.url_exists(url):
                     new_uuid = datastore.add_watch(url=url.strip(), tag="")
                     # Straight into the queue.
                     update_q.put(new_uuid)

--- a/changedetectionio/tests/test_request.py
+++ b/changedetectionio/tests/test_request.py
@@ -20,13 +20,6 @@ def test_headers_in_request(client, live_server):
     )
     assert b"1 Imported" in res.data
 
-    res = client.post(
-        url_for("import_page"),
-        data={"urls": test_url},
-        follow_redirects=True
-    )
-    assert b"1 Imported" in res.data
-
     cookie_header = '_ga=GA1.2.1022228332; cookie-preferences=analytics:accepted;'
 
 
@@ -41,7 +34,6 @@ def test_headers_in_request(client, live_server):
         follow_redirects=True
     )
     assert b"Updated watch." in res.data
-
 
     # Give the thread time to pick up the first version
     time.sleep(5)
@@ -76,14 +68,6 @@ def test_headers_in_request(client, live_server):
 def test_body_in_request(client, live_server):
     # Add our URL to the import page
     test_url = url_for('test_body', _external=True)
-
-    # Add the test URL twice, we will check
-    res = client.post(
-        url_for("import_page"),
-        data={"urls": test_url},
-        follow_redirects=True
-    )
-    assert b"1 Imported" in res.data
 
     res = client.post(
         url_for("import_page"),
@@ -145,14 +129,6 @@ def test_body_in_request(client, live_server):
 def test_method_in_request(client, live_server):
     # Add our URL to the import page
     test_url = url_for('test_method', _external=True)
-
-    # Add the test URL twice, we will check
-    res = client.post(
-        url_for("import_page"),
-        data={"urls": test_url},
-        follow_redirects=True
-    )
-    assert b"1 Imported" in res.data
 
     res = client.post(
         url_for("import_page"),


### PR DESCRIPTION
Re #377

At the front end "quick add" widget, you cannot add duplicate URLs

Interesting thing

Some tests weren't acting as we thought, because if this causes a test to fail it means the test is maybe running with test-data from a previous test-case!

Some tests are not tearing down old data between test cases (live_server setup etc)

maybe related to https://stackoverflow.com/questions/57312603/how-to-completely-teardown-flask-app-after-each-test-in-pytest but I don't know enough about flask just yet.. digging..