### PR TITLE
Add re: namespace for regEx support in xpath

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -25,7 +25,7 @@ def xpath_filter(xpath_filter, html_content):
     tree = html.fromstring(html_content)
     html_block = ""
 
-    for item in tree.xpath(xpath_filter.strip()):
+    for item in tree.xpath(xpath_filter.strip(), namespaces={'re':'http://exslt.org/regular-expressions'}):
         html_block+= etree.tostring(item, pretty_print=True).decode('utf-8')+"<br/>"
 
     return html_block


### PR DESCRIPTION
Unfortunately lxml only supports XPath 1.0. That is very limitted compared to XPath 2.0. But at least lxml allows usage of EXSLT functions, if you define the namespace: https://lxml.de/xpathxslt.html#regular-expressions-in-xpath
This PR adds a 're' namespace in order to enable re:test, re:math and re:replace.