### PR TITLE
Fix typo in Trigger text instructions

### DIFF
--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -162,7 +162,7 @@ nav
                     <ul>
                         <li>Text to wait for before triggering a change/notification, all text and regex are tested <i>case-insensitive</i>.</li>
                         <li>Trigger text is processed from the result-text that comes out of any CSS/JSON Filters for this watch</li>
-                        <li>Each line is process separately (think of each line as "OR")</li>
+                        <li>Each line is processed separately (think of each line as "OR")</li>
                         <li>Note: Wrap in forward slash / to use regex  example: <code>/foo\d/</code></li>
                     </ul>
                         </span>


### PR DESCRIPTION
This PR fixes a typo in Filters & Triggers settings.