### PR TITLE
Add autofocus attribute to password login field

### DIFF
--- a/changedetectionio/templates/login.html
+++ b/changedetectionio/templates/login.html
@@ -9,7 +9,7 @@
             <div class="pure-control-group">
                 <label for="password">Password</label>
                 <input type="password" id="password" required="" name="password" value=""
-                       size="15"/>
+                       size="15" autofocus />
                 <input type="hidden" id="email" name="email" value="defaultuser@changedetection.io" />
             </div>
             <div class="pure-control-group">


### PR DESCRIPTION
to allow to start typing the password immediately, without a need for a mouse click.

Since typing the password is the only thing that can be done on the Login page, I think it would make sense to automatically focus the password input field.