### PR TITLE
Add option to sync watch filters/triggers to other watches with same tags

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -520,9 +520,9 @@ def changedetection_app(config=None, datastore_o=None):
 
         # More for testing, possible to return the first/only or last
         if uuid == 'first':
-            uuid = list(datastore.data['watching'])[0]
-        if uuid == 'last':
             uuid = list(datastore.data['watching'])[-1]
+        if uuid == 'last':
+            uuid = list(datastore.data['watching'])[0]
 
         if request.method == 'GET':
             if not uuid in datastore.data['watching']:

--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -518,10 +518,11 @@ def changedetection_app(config=None, datastore_o=None):
         from changedetectionio import forms
         form = forms.watchForm(request.form)
 
-        # More for testing, possible to return the first/only
+        # More for testing, possible to return the first/only or last
         if uuid == 'first':
-            uuid = list(datastore.data['watching'].keys()).pop()
-
+            uuid = list(datastore.data['watching'])[0]
+        if uuid == 'last':
+            uuid = list(datastore.data['watching'])[-1]
 
         if request.method == 'GET':
             if not uuid in datastore.data['watching']:

--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -544,7 +544,7 @@ def changedetection_app(config=None, datastore_o=None):
                 form.fetch_backend.data = None
 
             update_watch(uuid, form)
-            if form.share_filters_across_tags:
+            if form.sync_filters_across_tags:
                 tags = datastore.get_tags(uuid)
                 tag_index = datastore.get_tag_uuid_index()
                 # Copy settings only to watches where all tags match, and remove uuid to prevent updating it twice
@@ -559,7 +559,7 @@ def changedetection_app(config=None, datastore_o=None):
 
             # Queue the watch for immediate recheck
             update_q.put(uuid)
-            if form.share_filters_across_tags:
+            if form.sync_filters_across_tags:
                 for extra_uuid in copy_settings_to:
                     update_q.put(extra_uuid)
 

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -328,6 +328,8 @@ class watchForm(commonSettingsForm):
     ignore_status_codes = BooleanField('Ignore Status Codes (process non-2xx status codes as normal)', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
 
+    share_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with the same tags')
+
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})
 

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -328,7 +328,7 @@ class watchForm(commonSettingsForm):
     ignore_status_codes = BooleanField('Ignore Status Codes (process non-2xx status codes as normal)', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
 
-    share_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with the same tags')
+    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with the same tags')
 
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})

--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 import uuid as uuid_builder
+from collections import defaultdict
 from copy import deepcopy
 from os import mkdir, path, unlink
 from threading import Lock
@@ -229,6 +230,18 @@ class ChangeDetectionStore:
         self.__data['has_unviewed'] = has_unviewed
 
         return self.__data
+
+    def get_tags(self, uuid):
+        return [x.strip() for x in self.data['watching'][uuid]['tag'].split(',')]
+
+    def get_tag_uuid_index(self):
+        index = defaultdict(set)
+        for uuid, watch in self.data['watching'].items():
+            # Support for comma separated list of tags.
+            for tag in watch['tag'].split(','):
+                tag = tag.strip()
+                index[tag].add(uuid)
+        return index
 
     def get_all_tags(self):
         tags = []

--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -232,9 +232,12 @@ class ChangeDetectionStore:
         return self.__data
 
     def get_tags(self, uuid):
+        # Get list of tags given a watches uuid
         return [x.strip() for x in self.data['watching'][uuid]['tag'].split(',')]
 
     def get_tag_uuid_index(self):
+        # Create a dict of {tag: set(uuids)} for all tags in use, usable as a search
+        # index to find which watches belong to a given tag.
         index = defaultdict(set)
         for uuid, watch in self.data['watching'].items():
             # Support for comma separated list of tags.

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -170,7 +170,7 @@ nav
                 </fieldset>
                 <fieldset>
                   <div class="pure-control-group">
-                    {{ render_field(form.share_filters_across_tags) }}
+                    {{ render_field(form.sync_filters_across_tags) }}
                   </div>
                 </fieldset>
             </div>

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -168,6 +168,11 @@ nav
                         </span>
                     </div>
                 </fieldset>
+                <fieldset>
+                  <div class="pure-control-group">
+                    {{ render_field(form.share_filters_across_tags) }}
+                  </div>
+                </fieldset>
             </div>
 
             <div id="actions">

--- a/changedetectionio/tests/test_tag_shared_settings.py
+++ b/changedetectionio/tests/test_tag_shared_settings.py
@@ -71,7 +71,7 @@ def set_modified_response():
         f.write(test_return_data)
 
 
-def test_share_filters_across_tags(client, live_server):
+def test_sync_filters_across_tags(client, live_server):
     sleep_time_for_fetch_thread = 3
 
     set_original_response()
@@ -102,7 +102,7 @@ def test_share_filters_across_tags(client, live_server):
             "tag": "one,two,three",  # the first watch we added is supposed to have these tags
             "headers": "",
             "fetch_backend": "html_requests",
-            "share_filters_across_tags": True,
+            "sync_filters_across_tags": True,
         },
         follow_redirects=True,
     )

--- a/changedetectionio/tests/test_tag_shared_settings.py
+++ b/changedetectionio/tests/test_tag_shared_settings.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python3
+
+import time
+
+from changedetectionio import store
+from flask import url_for
+
+from ..html_tools import *
+from .util import live_server_setup
+
+
+def test_setup(live_server):
+    live_server_setup(live_server)
+
+
+def set_original_response():
+    test_return_data = """<html>
+    <header>
+    <h2>Header</h2>
+    </header>
+    <nav>
+    <ul>
+      <li><a href="#">A</a></li>
+      <li><a href="#">B</a></li>
+      <li><a href="#">C</a></li>
+    </ul>
+    </nav>
+       <body>
+     Some initial text</br>
+     <p>Which is across multiple lines</p>
+     </br>
+     So let's see what happens.  </br>
+    <div id="changetext">Some text that will change</div>
+     </body>
+    <footer>
+    <p>Footer</p>
+    </footer>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def set_modified_response():
+    test_return_data = """<html>
+    <header>
+    <h2>Header changed</h2>
+    </header>
+    <nav>
+    <ul>
+      <li><a href="#">A changed</a></li>
+      <li><a href="#">B</a></li>
+      <li><a href="#">C</a></li>
+    </ul>
+    </nav>
+       <body>
+     Some initial text</br>
+     <p>Which is across multiple lines</p>
+     </br>
+     So let's see what happens.  </br>
+    <div id="changetext">Some text that changes</div>
+     </body>
+    <footer>
+    <p>Footer changed</p>
+    </footer>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def test_share_filters_across_tags(client, live_server):
+    sleep_time_for_fetch_thread = 3
+
+    set_original_response()
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # Add our URLs to the import page
+    test_url = url_for("test_endpoint", _external=True)
+    # Add tags - the settings will be set for the first instance and should be copied to
+    # the third if everything works correctly
+    tags = [" one,two,three", " one,two", " one,two,three"]
+    test_urls = "\n".join([test_url + x for x in tags])
+
+    res = client.post(
+        url_for("import_page"), data={"urls": test_urls}, follow_redirects=True
+    )
+    assert b"3 Imported" in res.data
+
+    # Goto the edit page, add the filter data
+    # Not sure why \r needs to be added - absent of the #changetext this is not necessary
+    subtractive_selectors_data = "header\r\nfooter\r\nnav\r\n#changetext"
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={
+            "subtractive_selectors": subtractive_selectors_data,
+            "url": test_url,
+            "tag": "one,two,three",  # the first watch we added is supposed to have these tags
+            "headers": "",
+            "fetch_backend": "html_requests",
+            "share_filters_across_tags": True,
+        },
+        follow_redirects=True,
+    )
+    assert b"Updated watch." in res.data
+
+    # Check it saved
+    res = client.get(
+        url_for("edit_page", uuid="first"),
+    )
+    assert bytes(subtractive_selectors_data.encode("utf-8")) in res.data
+
+    # Check the settings also persist in the last watch
+    res = client.get(
+        url_for("edit_page", uuid="last"),
+    )
+    assert bytes(subtractive_selectors_data.encode("utf-8")) in res.data
+
+    # Trigger a check
+    res = client.get(url_for("api_watch_checknow"), follow_redirects=True)
+    # Give the thread time to pick it up
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # No change yet - first check
+    res = client.get(url_for("index"))
+    assert b"unviewed" not in res.data
+    #  Make a change to header/footer/nav
+    set_modified_response()
+
+    # Trigger a check
+    client.get(url_for("api_watch_checknow"), follow_redirects=True)
+
+    # Give the thread time to pick it up
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # There should be exactly one unviewed change, as changes should be removed for the
+    # first and last watch because of the propagated removal
+    res = client.get(url_for("index"))
+    assert res.data.count(b"unviewed") == 1


### PR DESCRIPTION
This PR adds a checkbox on the filters/triggers watch edit page which, when ticked, copies the settings from that page to all other watches with the same tags.

**Motivation:** 
Someone may watch several subpages of the same domain, which share some boilerplate HTML. When some text changes in the boilerplate, all those watches will exhibit the same change. To prevent having to edit all those pages one by one, with this setting you can now filter/remove those elements for all those watches at once (given that those pages share the same tags).


In the process, I tidied up the watch updating process a little - I moved it into a function which can update all settings, or just the filters/triggers. I also moved all settings into the `update_obj` dict, if possible, and ordered them according to the settings page.

For the test, I had to add an API parameter `/edit/last`, which returns the last watch. The test adds 3 pages, the first and last of which share tags. The test then shows that the changed setting is copied over only to the last, but not the second, watch.