### PR TITLE
Add option to sync watch filters/triggers to other watches with matching watch groups

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -504,18 +504,19 @@ def changedetection_app(config=None, datastore_o=None):
     @login_required
     # https://stackoverflow.com/questions/42984453/wtforms-populate-form-with-data-if-data-exists
     # https://wtforms.readthedocs.io/en/3.0.x/forms/#wtforms.form.Form.populate_obj ?
-
     def edit_page(uuid):
         from changedetectionio import forms
 
         using_default_check_time = True
-        # More for testing, possible to return the first/only
+        # More for testing, possible to return the first/only or last
         if not datastore.data['watching'].keys():
             flash("No watches to edit", "error")
             return redirect(url_for('index'))
 
         if uuid == 'first':
-            uuid = list(datastore.data['watching'].keys()).pop()
+            uuid = list(datastore.data['watching'])[-1]
+        if uuid == 'last':
+            uuid = list(datastore.data['watching'])[0]
 
         if not uuid in datastore.data['watching']:
             flash("No watch with the UUID %s found." % (uuid), "error")

--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -485,6 +485,20 @@ def changedetection_app(config=None, datastore_o=None):
 
         return datastore.data['watching'][uuid]['previous_md5']
 
+    def update_watch_filters(uuid, filter_dict):
+        prev_css_filter = datastore.data['watching'][uuid]['css_filter']
+        datastore.data['watching'][uuid].update(filter_dict)
+
+        # Reset the previous_md5 so we process a new snapshot including stripping ignore text.
+        if filter_dict['ignore_text']:
+            if len(datastore.data['watching'][uuid]['history']):
+                datastore.data['watching'][uuid]['previous_md5'] = get_current_checksum_include_ignore_text(uuid=uuid)
+
+        # Reset the previous_md5 so we process a new snapshot including stripping ignore text.
+        if prev_css_filter != filter_dict['css_filter']:
+            if len(datastore.data['watching'][uuid]['history']):
+                datastore.data['watching'][uuid]['previous_md5'] = get_current_checksum_include_ignore_text(uuid=uuid)
+
 
     @app.route("/edit/<string:uuid>", methods=['GET', 'POST'])
     @login_required

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -15,6 +15,7 @@ from wtforms import (
     validators,
     widgets,
 )
+from wtforms.fields import FormField
 from wtforms.validators import ValidationError
 
 from changedetectionio import content_fetcher
@@ -24,8 +25,6 @@ from changedetectionio.notification import (
     default_notification_title,
     valid_notification_formats,
 )
-
-from wtforms.fields import FormField
 
 valid_method = {
     'GET',
@@ -134,6 +133,7 @@ class ValidateContentFetcherIsReady(object):
 
     def __call__(self, form, field):
         import urllib3.exceptions
+
         from changedetectionio import content_fetcher
 
         # Better would be a radiohandler that keeps a reference to each class
@@ -338,6 +338,8 @@ class watchForm(commonSettingsForm):
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
 
+    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with the same tags')
+
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})
 
@@ -382,4 +384,3 @@ class globalSettingsForm(Form):
     requests = FormField(globalSettingsRequestForm)
     application = FormField(globalSettingsApplicationForm)
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
-

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -338,7 +338,7 @@ class watchForm(commonSettingsForm):
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
 
-    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with the same tags')
+    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with matching watch groups')
 
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -338,7 +338,7 @@ class watchForm(commonSettingsForm):
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
 
-    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to all watches with matching watch groups')
+    sync_filters_across_tags = BooleanField('Copy filter/trigger settings to watches with the same watch groups')
 
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})

--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -5,6 +5,7 @@ import re
 import threading
 import time
 import uuid as uuid_builder
+from collections import defaultdict
 from copy import deepcopy
 from os import mkdir, path, unlink
 from threading import Lock

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -173,6 +173,11 @@ nav
                         </span>
                     </div>
                 </fieldset>
+                <fieldset>
+                  <div class="pure-control-group">
+                    {{ render_field(form.sync_filters_across_tags) }}
+                  </div>
+                </fieldset>
             </div>
 
             <div id="actions">

--- a/changedetectionio/tests/test_tag_sync_settings.py
+++ b/changedetectionio/tests/test_tag_sync_settings.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python3
+
+import time
+
+from changedetectionio import store
+from flask import url_for
+
+from ..html_tools import *
+from .util import live_server_setup
+
+
+def test_setup(live_server):
+    live_server_setup(live_server)
+
+
+def set_original_response():
+    test_return_data = """<html>
+    <header>
+    <h2>Header</h2>
+    </header>
+    <nav>
+    <ul>
+      <li><a href="#">A</a></li>
+      <li><a href="#">B</a></li>
+      <li><a href="#">C</a></li>
+    </ul>
+    </nav>
+       <body>
+     Some initial text</br>
+     <p>Which is across multiple lines</p>
+     </br>
+     So let's see what happens.  </br>
+    <div id="changetext">Some text that will change</div>
+     </body>
+    <footer>
+    <p>Footer</p>
+    </footer>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def set_modified_response():
+    test_return_data = """<html>
+    <header>
+    <h2>Header changed</h2>
+    </header>
+    <nav>
+    <ul>
+      <li><a href="#">A changed</a></li>
+      <li><a href="#">B</a></li>
+      <li><a href="#">C</a></li>
+    </ul>
+    </nav>
+       <body>
+     Some initial text</br>
+     <p>Which is across multiple lines</p>
+     </br>
+     So let's see what happens.  </br>
+    <div id="changetext">Some text that changes</div>
+     </body>
+    <footer>
+    <p>Footer changed</p>
+    </footer>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def test_sync_filters_across_tags(client, live_server):
+    sleep_time_for_fetch_thread = 3
+
+    set_original_response()
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # Add our URLs to the import page
+    test_url = url_for("test_endpoint", _external=True)
+    # Add tags - the settings will be set for the first instance and should be copied to
+    # the third if everything works correctly
+    tags = [" one,two,three", " one,two", " one,two,three"]
+    test_urls = "\n".join([test_url + x for x in tags])
+
+    res = client.post(url_for("import_page"), data={"urls": test_urls}, follow_redirects=True)
+    assert b"3 Imported" in res.data
+
+    # Goto the edit page, add the filter data
+    # Not sure why \r needs to be added - absent of the #changetext this is not necessary
+    subtractive_selectors_data = "header\r\nfooter\r\nnav\r\n#changetext"
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={
+            "subtractive_selectors": subtractive_selectors_data,
+            "url": test_url,
+            "tag": "one,two,three",  # the first watch we added is supposed to have these tags
+            "headers": "",
+            "fetch_backend": "html_requests",
+            "sync_filters_across_tags": True,
+        },
+        follow_redirects=True,
+    )
+    assert b"Updated watch." in res.data
+
+    # Check it saved
+    res = client.get(
+        url_for("edit_page", uuid="first"),
+    )
+    assert bytes(subtractive_selectors_data.encode("utf-8")) in res.data
+
+    # Check the settings also persist in the last watch
+    res = client.get(
+        url_for("edit_page", uuid="last"),
+    )
+    assert bytes(subtractive_selectors_data.encode("utf-8")) in res.data
+
+    # Trigger a check
+    res = client.get(url_for("api_watch_checknow"), follow_redirects=True)
+    # Give the thread time to pick it up
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # No change yet - first check
+    res = client.get(url_for("index"))
+    assert b"unviewed" not in res.data
+    #  Make a change to header/footer/nav
+    set_modified_response()
+
+    # Trigger a check
+    client.get(url_for("api_watch_checknow"), follow_redirects=True)
+
+    # Give the thread time to pick it up
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # There should be exactly one unviewed change, as changes should be removed for the
+    # first and last watch because of the propagated removal
+    res = client.get(url_for("index"))
+    assert res.data.count(b"unviewed") == 1


### PR DESCRIPTION
Same, but slightly updated, content as #505, merging onto master with suggested changes:

This PR adds a checkbox on the filters/triggers watch edit page which, when ticked, copies the settings from that page to all other watches with the same watch groups.

**Motivation:**
Someone may watch several subpages of the same domain, which share some boilerplate HTML. When some text changes in the boilerplate, all those watches will exhibit the same change. To prevent having to edit all those pages one by one, with this setting you can now filter/remove those elements for all those watches at once (given that those pages share the same tags).

For the test, I had to add an API parameter /edit/last, which returns the last watch. The test adds 3 pages, the first and last of which share tags. The test then shows that the changed setting is copied over only to the last, but not the second, watch.
