### PR TITLE
Sqlite3 storage for just 'history' information - massively reduce memory footprint

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -932,6 +932,9 @@ def changedetection_app(config=None, datastore_o=None):
             # Add the flask app secret
             zipObj.write(os.path.join(datastore_o.datastore_path, "secret.txt"), arcname="secret.txt")
 
+            # Add the sqlite3 db
+            zipObj.write(os.path.join(datastore_o.datastore_path, "watch.db"), arcname="watch.db")
+
             # Add any snapshot data we find, use the full path to access the file, but make the file 'relative' in the Zip.
             for txt_file_path in Path(datastore_o.datastore_path).rglob('*.txt'):
                 parent_p = txt_file_path.parent

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -27,7 +27,8 @@ class model(dict):
             'headers': {},  # Extra headers to send
             'body': None,
             'method': 'GET',
-            'history': {},  # Dict of timestamp and output stripped filename
+            # now stored in a sqlite3 db to reduce memory usage
+            #'history': {},  # Dict of timestamp and output stripped filename
             'ignore_text': [],  # List of text to ignore when calculating the comparison checksum
             # Custom notification content
             'notification_urls': [],  # List of URLs to add to the notification Queue (Usually AppRise)


### PR DESCRIPTION
Memory usage grows very fast when you have a lot of watches, because it's storing the watch history information also in memory for every watch, so its like `memory_usage = watches * watch_history_count` which grows very fast

This also increases CPU and Disk usage because it's having to rewrite all that history data on every JSON save, and that history data never changes, it only gets added to.

Also changing the watch history 'key' to an `integer` should help with memory usage a little

```
root     3472780  2.5  2.1 1162524 342252 
```

My idea here is to use SQLite just for storing the history list, so that it does not need to store or write that history data every time

- [ ] Figure out the best way to allow single thread access
- [ ] Update the rest of the app

For people who keep the DB on another filesystem via NAS or similar, this should be OK because we are hopefully only just occasionally inserting a new row when there's a change detected