### PR TITLE
Fix encoding errors with XPATH Filters from UTF-8 responses

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -39,7 +39,7 @@ def element_removal(selectors: List[str], html_content):
 def xpath_filter(xpath_filter, html_content):
     from lxml import etree, html
 
-    tree = html.fromstring(bytes(html_content, encoding='utf-8')
+    tree = html.fromstring(bytes(html_content, encoding='utf-8'))
     html_block = ""
 
     for item in tree.xpath(xpath_filter.strip(), namespaces={'re':'http://exslt.org/regular-expressions'}):

--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -39,7 +39,7 @@ def element_removal(selectors: List[str], html_content):
 def xpath_filter(xpath_filter, html_content):
     from lxml import etree, html
 
-    tree = html.fromstring(html_content)
+    tree = html.fromstring(bytes(html_content, encoding='utf-8')
     html_block = ""
 
     for item in tree.xpath(xpath_filter.strip(), namespaces={'re':'http://exslt.org/regular-expressions'}):


### PR DESCRIPTION
Loading the HTML content as UTF-8 caused an error when using an XPATH filter. This should should fix it. I ran the XPATH filter tests and they succeeded.