### PR TITLE
[feature] Filter option - Trigger only when NEW content (lines) are detected ( compared to earlier text snapshots )

### DIFF
--- a/changedetectionio/fetch_site_status.py
+++ b/changedetectionio/fetch_site_status.py
@@ -254,4 +254,10 @@ class perform_site_check():
                 if not watch['title'] or not len(watch['title']):
                     update_obj['title'] = html_tools.extract_element(find='title', html_content=fetcher.content)
 
+
+        if changed_detected:
+            if watch['check_unique_lines']:
+                if not watch.lines_are_unique_in_history(lines=stripped_text_from_html.splitlines()):
+                    changed_detected = False
+
         return changed_detected, update_obj, text_content_before_ignored_filter, fetcher.screenshot, fetcher.xpath_data

--- a/changedetectionio/fetch_site_status.py
+++ b/changedetectionio/fetch_site_status.py
@@ -256,7 +256,7 @@ class perform_site_check():
 
 
         if changed_detected:
-            if watch['check_unique_lines']:
+            if watch.get('check_unique_lines', False):
                 if not watch.lines_are_unique_in_history(lines=stripped_text_from_html.splitlines()):
                     changed_detected = False
 

--- a/changedetectionio/fetch_site_status.py
+++ b/changedetectionio/fetch_site_status.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 import re
 import time
@@ -264,8 +265,13 @@ class perform_site_check():
 
         if changed_detected:
             if watch.get('check_unique_lines', False):
-                if not watch.lines_are_unique_in_history(lines=stripped_text_from_html.splitlines()):
+                has_unique_lines = watch.lines_contain_something_unique_compared_to_history(lines=stripped_text_from_html.splitlines())
+                # One or more lines? unsure?
+                if not has_unique_lines:
+                    logging.debug("check_unique_lines: UUID {} didnt have anything new setting change_detected=False".format(uuid))
                     changed_detected = False
+                else:
+                    logging.debug("check_unique_lines: UUID {} had unique content".format(uuid))
 
         # Always record the new checksum
         update_obj["previous_md5"] = fetched_md5

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -340,7 +340,7 @@ class watchForm(commonSettingsForm):
     body = TextAreaField('Request body', [validators.Optional()])
     method = SelectField('Request method', choices=valid_method, default=default_method)
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
-    check_unique_lines = BooleanField('Ensure content contains something new by checking against history', default=False)
+    check_unique_lines = BooleanField('Only trigger when new lines appear', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
     text_should_not_be_present = StringListField('Block change-detection if text matches', [validators.Optional(), ValidateListRegex()])
 

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -340,6 +340,7 @@ class watchForm(commonSettingsForm):
     body = TextAreaField('Request body', [validators.Optional()])
     method = SelectField('Request method', choices=valid_method, default=default_method)
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
+    check_unique_lines = BooleanField('Ensure content contains something new by checking against history', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
     save_and_preview_button = SubmitField('Save & Preview', render_kw={"class": "pure-button pure-button-primary"})

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -171,6 +171,7 @@ class model(dict):
         for k, v in self.history.items():
             alist = [line.decode('utf-8').strip().lower() for line in open(v, 'rb')]
             diff = set(alist) - set(local_lines)
+            # @todo what about empty lines? iterate over diff and find a non-zero length line?
             if len(diff):
                 return False
 

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -38,6 +38,7 @@ class model(dict):
             'css_filter': '',
             'extract_text': [],  # Extract text by regex after filters
             'subtractive_selectors': [],
+            'check_unique_lines': False,
             'trigger_text': [],  # List of text or regex to wait for until a change is detected
             'fetch_backend': None,
             'extract_title_as_title': False,
@@ -163,3 +164,14 @@ class model(dict):
             if x:
                 seconds += x * n
         return seconds
+
+    # Iterate over all history texts and see if something new exists
+    def lines_are_unique_in_history(self, lines=[]):
+        local_lines = [l.decode('utf-8').strip().lower() for l in lines]
+        for k, v in self.history.items():
+            alist = [line.decode('utf-8').strip().lower() for line in open(v, 'rb')]
+            diff = set(alist) - set(local_lines)
+            if len(diff):
+                return False
+
+        return True

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -166,13 +166,14 @@ class model(dict):
         return seconds
 
     # Iterate over all history texts and see if something new exists
-    def lines_are_unique_in_history(self, lines=[]):
+    def lines_contain_something_unique_compared_to_history(self, lines=[]):
         local_lines = [l.decode('utf-8').strip().lower() for l in lines]
+
+        # Compare each lines (set) against each history text file (set) looking for something new..
         for k, v in self.history.items():
             alist = [line.decode('utf-8').strip().lower() for line in open(v, 'rb')]
-            diff = set(alist) - set(local_lines)
-            # @todo what about empty lines? iterate over diff and find a non-zero length line?
-            if len(diff):
-                return False
+            res = set(alist) != set(local_lines)
+            if res:
+                return True
 
-        return True
+        return False

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -37,7 +37,6 @@ class model(dict):
             'css_filter': '',
             'extract_text': [],  # Extract text by regex after filters
             'subtractive_selectors': [],
-            'check_unique_lines': False,
             'trigger_text': [],  # List of text or regex to wait for until a change is detected
             'text_should_not_be_present': [], # Text that should not present
             'fetch_backend': None,

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -42,6 +42,7 @@ class model(dict):
             'text_should_not_be_present': [], # Text that should not present
             'fetch_backend': None,
             'extract_title_as_title': False,
+            'check_unique_lines': False, # On change-detected, compare against all history if its something new
             'proxy': None, # Preferred proxy connection
             # Re #110, so then if this is set to None, we know to use the default value instead
             # Requires setting to None on submit if it's the same as the default

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -210,6 +210,11 @@ nav
                         </span>
                     </div>
                 </fieldset>
+                <fieldset>
+                    <div class="pure-control-group">
+                        {{ render_field(form.check_unique_lines) }}
+                    </div>
+                </fieldset>
             </div>
 
             <div class="tab-pane-inner visual-selector-ui" id="visualselector">

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -147,6 +147,12 @@ User-Agent: wonderbra 1.0") }}
                                 </li>
                             </ul>
                     </div>
+                    <fieldset>
+                        <div class="pure-control-group">
+                            {{ render_checkbox_field(form.check_unique_lines) }}
+                            <span class="pure-form-message-inline">Good for websites that just move the content around, and you want to know when NEW content is added.</span>
+                        </div>
+                    </fieldset>
                     <div class="pure-control-group">
                         {{ render_field(form.css_filter, placeholder=".class-name or #some-id, or other CSS selector rule.",
                         class="m-d") }}
@@ -228,11 +234,6 @@ Unavailable") }}
                         <li>One line per regular-expression.</li>
                     </ul>
                         </span>
-                    </div>
-                </fieldset>
-                <fieldset>
-                    <div class="pure-control-group">
-                        {{ render_field(form.check_unique_lines) }}
                     </div>
                 </fieldset>
             </div>

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -150,7 +150,7 @@ User-Agent: wonderbra 1.0") }}
                     <fieldset>
                         <div class="pure-control-group">
                             {{ render_checkbox_field(form.check_unique_lines) }}
-                            <span class="pure-form-message-inline">Good for websites that just move the content around, and you want to know when NEW content is added.</span>
+                            <span class="pure-form-message-inline">Good for websites that just move the content around, and you want to know when NEW content is added, compares new lines against all history for this watch.</span>
                         </div>
                     </fieldset>
                     <div class="pure-control-group">

--- a/changedetectionio/tests/test_unique_lines.py
+++ b/changedetectionio/tests/test_unique_lines.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+
+import time
+from flask import url_for
+from .util import live_server_setup
+
+
+def set_original_ignore_response():
+    test_return_data = """<html>
+     <body>
+     <p>Some initial text</p>
+     <p>Which is across multiple lines</p>
+     <p>So let's see what happens.</p>
+     </body>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+# The same but just re-ordered the text
+def set_modified_swapped_lines():
+    # Re-ordered and with some whitespacing, should get stripped() too.
+    test_return_data = """<html>
+     <body>
+     <p>Some initial text</p>
+     <p>   So let's see what happens.</p>
+     <p>&nbsp;Which is across multiple lines</p>     
+     </body>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def set_modified_with_trigger_text_response():
+    test_return_data = """<html>
+     <body>
+     <p>Some initial text</p>
+     <p>So let's see what happens.</p>
+     <p>and a new line!</p>
+     <p>Which is across multiple lines</p>     
+     </body>
+     </html>
+    """
+
+    with open("test-datastore/endpoint-content.txt", "w") as f:
+        f.write(test_return_data)
+
+
+def test_unique_lines_functionality(client, live_server):
+    live_server_setup(live_server)
+
+    sleep_time_for_fetch_thread = 3
+
+    set_original_ignore_response()
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # Add our URL to the import page
+    test_url = url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # Add our URL to the import page
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"check_unique_lines": "y",
+              "url": test_url,
+              "fetch_backend": "html_requests"},
+        follow_redirects=True
+    )
+    assert b"Updated watch." in res.data
+    assert b'unviewed' not in res.data
+
+    #  Make a change
+    set_modified_swapped_lines()
+
+    time.sleep(sleep_time_for_fetch_thread)
+    # Trigger a check
+    client.get(url_for("form_watch_checknow"), follow_redirects=True)
+
+    # Give the thread time to pick it up
+    time.sleep(sleep_time_for_fetch_thread)
+
+    # It should report nothing found (no new 'unviewed' class)
+    res = client.get(url_for("index"))
+    assert b'unviewed' not in res.data
+
+
+    # Now set the content which contains the new text and re-ordered existing text
+    set_modified_with_trigger_text_response()
+    client.get(url_for("form_watch_checknow"), follow_redirects=True)
+    time.sleep(sleep_time_for_fetch_thread)
+    res = client.get(url_for("index"))
+    assert b'unviewed' in res.data
+


### PR DESCRIPTION
- [x] needs test
- [x] tidy up field titles and description
~~- [ ] limit to last x? (as a main system setting?)~~

![image](https://user-images.githubusercontent.com/275001/173242627-05bc4677-18f6-4387-bce6-a57241d1c68b.png)

Super handy for pages that just shuffle the content around! or when new products appear in a listing.

Don't trigger a change unless there is no content available when compared to all history saved