### PR TITLE
[feature] Check stability of changes

### DIFF
--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -326,6 +326,7 @@ class watchForm(commonSettingsForm):
     tag = StringField('Group tag', [validators.Optional()], default='')
 
     time_between_check = FormField(TimeBetweenCheckForm)
+    stability_checks = IntegerField('Ensure X times before notify about change (stability check)', validators=[validators.Optional(), validators.NumberRange(min=1, message="Should be greater than or equal to 1")] )
 
     css_filter = StringField('CSS/JSON/XPATH Filter', [ValidateCSSJSONXPATHInput()], default='')
 

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -13,6 +13,7 @@ from changedetectionio.notification import (
 class model(dict):
     __newest_history_key = None
     __history_n=0
+    __stability_checks_made = 0
     __base_config = {
             'url': None,
             'tag': None,
@@ -46,6 +47,7 @@ class model(dict):
             # Should be all None by default, so we use the system default in this case.
             'time_between_check': {'weeks': None, 'days': None, 'hours': None, 'minutes': None, 'seconds': None},
             'webdriver_delay': None
+            'stability_checks': None
         }
     jitter_seconds = 0
     mtable = {'seconds': 1, 'minutes': 60, 'hours': 3600, 'days': 86400, 'weeks': 86400 * 7}
@@ -162,3 +164,13 @@ class model(dict):
             if x:
                 seconds += x * n
         return seconds
+
+    @property
+    def is_change_stable(self):
+        return self.__stability_checks_made >= self.get('stability_checks', 0)
+
+    def incr_stability_checks(self):
+        self.__stability_checks_made += 1
+
+    def reset_stability_checks(self):
+        self.__stability_checks_made = 0

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -167,7 +167,7 @@ class model(dict):
 
     @property
     def is_change_stable(self):
-        return self.__stability_checks_made >= self.get('stability_checks', 0)
+        return self.__stability_checks_made == self.get('stability_checks', 0)
 
     def incr_stability_checks(self):
         self.__stability_checks_made += 1

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -46,7 +46,7 @@ class model(dict):
             # Requires setting to None on submit if it's the same as the default
             # Should be all None by default, so we use the system default in this case.
             'time_between_check': {'weeks': None, 'days': None, 'hours': None, 'minutes': None, 'seconds': None},
-            'webdriver_delay': None
+            'webdriver_delay': None,
             'stability_checks': None
         }
     jitter_seconds = 0

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -50,6 +50,8 @@
                     </div>
                     <div class="pure-control-group">
                         {{ render_field(form.time_between_check, class="time-check-widget") }}
+                        {{ render_field(form.stability_checks) }}
+                        <span class="pure-form-message-inline">If changes are frequent, stabilization may never occur and a notification will never be sent</span>
                         {% if has_empty_checktime %}
                         <span class="pure-form-message-inline">Currently using the <a
                                 href="{{ url_for('settings_page', uuid=uuid) }}">default global settings</a>, change to another value if you want to be specific.</span>


### PR DESCRIPTION
Closes https://github.com/dgtlmoon/changedetection.io/issues/35

I added an option to set number of additional checks before notify, to ensure the change is stable.

In the future, as I said in mentioned issue: "it would be nice to have also an option for "more intense checks" (like X times often than normal) when change is found and "stability check" is set (so as not to wait e.g. to the next day when the watch is set to long intervals)".

I'm not a python developer, so I will need some guidance if additional code changes are needed.