### PR TITLE
lang: prefer 'purge' instead of 'scrub'

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -457,37 +457,37 @@ def changedetection_app(config=None, datastore_o=None):
         return 'OK'
 
 
-    @app.route("/scrub/<string:uuid>", methods=['GET'])
+    @app.route("/purge/<string:uuid>", methods=['GET'])
     @login_required
-    def scrub_watch(uuid):
+    def purge_watch(uuid):
         try:
-            datastore.scrub_watch(uuid)
+            datastore.purge_watch(uuid)
         except KeyError:
             flash('Watch not found', 'error')
         else:
-            flash("Scrubbed watch {}".format(uuid))
+            flash("Purged snapshots for watch {}".format(uuid))
 
         return redirect(url_for('index'))
 
-    @app.route("/scrub", methods=['GET', 'POST'])
+    @app.route("/purge", methods=['GET', 'POST'])
     @login_required
-    def scrub_page():
+    def purge_page():
 
         if request.method == 'POST':
             confirmtext = request.form.get('confirmtext')
 
-            if confirmtext == 'scrub':
+            if confirmtext == 'purge':
                 changes_removed = 0
                 for uuid in datastore.data['watching'].keys():
-                    datastore.scrub_watch(uuid)
+                    datastore.purge_watch(uuid)
 
-                flash("Cleared all snapshot history")
+                flash("Purged all snapshots")
             else:
                 flash('Incorrect confirmation text.', 'error')
 
             return redirect(url_for('index'))
 
-        output = render_template("scrub.html")
+        output = render_template("purge.html")
         return output
 
 
@@ -854,7 +854,7 @@ def changedetection_app(config=None, datastore_o=None):
             uuid = list(datastore.data['watching'].keys()).pop()
 
         # Normally you would never reach this, because the 'preview' button is not available when there's no history
-        # However they may try to scrub and reload the page
+        # However they may try to purge snapshots and reload the page
         if datastore.data['watching'][uuid].history_n == 0:
             flash("Preview unavailable - No fetch/check completed or triggers not reached", "error")
             return redirect(url_for('index'))

--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -250,7 +250,7 @@ class ChangeDetectionStore:
         return self.data['watching'][uuid].get(val)
 
     # Remove a watchs data but keep the entry (URL etc)
-    def scrub_watch(self, uuid):
+    def purge_watch(self, uuid):
         import pathlib
 
         self.__data['watching'][uuid].update(

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -275,8 +275,8 @@ Unavailable") }}
 
                     <a href="{{url_for('form_delete', uuid=uuid)}}"
                        class="pure-button button-small button-error ">Delete</a>
-                    <a href="{{url_for('scrub_watch', uuid=uuid)}}"
-                       class="pure-button button-small button-error ">Scrub</a>
+                    <a href="{{url_for('purge_watch', uuid=uuid)}}"
+                       class="pure-button button-small button-error ">Clear History</a>
                     <a href="{{url_for('form_clone', uuid=uuid)}}"
                        class="pure-button button-small ">Create Copy</a>
                 </div>

--- a/changedetectionio/templates/scrub.html
+++ b/changedetectionio/templates/scrub.html
@@ -3,22 +3,22 @@
 {% block content %}
 <div class="edit-form">
     <div class="box-wrap inner">
-    <form class="pure-form pure-form-stacked" action="{{url_for('scrub_page')}}" method="POST">
+    <form class="pure-form pure-form-stacked" action="{{url_for('purge_page')}}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <fieldset>
             <div class="pure-control-group">
-                This will remove ALL version snapshots/data, but keep your list of URLs. <br/>
+                This will remove version history (snapshots) for ALL watches, but keep your list of URLs. <br/>
                 You may like to use the <strong>BACKUP</strong> link first.<br/>
             </div>
             <br/>
             <div class="pure-control-group">
                 <label for="confirmtext">Confirmation text</label>
                 <input type="text" id="confirmtext" required="" name="confirmtext" value="" size="10"/>
-                <span class="pure-form-message-inline">Type in the word <strong>scrub</strong> to confirm that you understand!</span>
+                <span class="pure-form-message-inline">Type in the word <strong>purge</strong> to confirm that you understand!</span>
             </div>
             <br/>
             <div class="pure-control-group">
-                <button type="submit" class="pure-button pure-button-primary">Scrub!</button>
+                <button type="submit" class="pure-button pure-button-primary">Clear History!</button>
             </div>
             <br/>
             <div class="pure-control-group">

--- a/changedetectionio/templates/settings.html
+++ b/changedetectionio/templates/settings.html
@@ -173,7 +173,7 @@ nav
                 <div class="pure-control-group">
                     {{ render_button(form.save_button) }}
                     <a href="{{url_for('index')}}" class="pure-button button-small button-cancel">Back</a>
-                    <a href="{{url_for('scrub_page')}}" class="pure-button button-small button-cancel">Delete History Snapshot Data</a>
+                    <a href="{{url_for('purge_page')}}" class="pure-button button-small button-cancel">Clear Snapshot History</a>
                 </div>
 
             </div>


### PR DESCRIPTION
\+ other consistency, elaboration in language surrounding the action

Closes #717

***

Scrub is closer to pruning — tidying and trimming, while leaving some. Here we are removing all snapshots.

(watch) **history** is favored over snapshots (more complex). Purge is used in other software (ex: rclone), and feels the proper word for it. It's a complex termin, so **Clear History** is preferred when communicating with the user. 

On the confirmation page, multiple words are expressed for the action in the hopes that the user picks up on one of them.

***

Changed routes as well. If that's ok. It should prevent any future confusion between functions / 'scrub' shown to the user.