### PR TITLE
Remove duplicate environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,9 +78,6 @@ services:
 #            - SCREEN_HEIGHT=1024
 #            - SCREEN_DEPTH=16
 #            - ENABLE_DEBUGGER=false
-#            - SCREEN_WIDTH=1280
-#            - SCREEN_HEIGHT=1024
-#            - SCREEN_DEPTH=16
 #            - PREBOOT_CHROME=true
 #            - CONNECTION_TIMEOUT=300000
 #            - MAX_CONCURRENT_SESSIONS=10


### PR DESCRIPTION
Remove duplicate environment variables from playwright-chrome sample config in docker-compose.yml