### PR TITLE
Use environment variables to override settings (user-agent, timeout, workers)

### DIFF
--- a/changedetectionio/model/App.py
+++ b/changedetectionio/model/App.py
@@ -21,7 +21,7 @@ class model(dict):
                     'Accept-Language': 'en-GB,en-US;q=0.9,en;'
                 },
                 'requests': {
-                    'timeout': 15,  # Default 15 seconds
+                    'timeout': int(os.getenv("SETTINGS_REQUESTS_TIMEOUT", 45)),  # Default 45 seconds
                     'time_between_check': {'weeks': None, 'days': None, 'hours': 3, 'minutes': None, 'seconds': None},
                     'jitter_seconds': 0,
                     'workers': 10,  # Number of threads, lower is better for slow connections

--- a/changedetectionio/model/App.py
+++ b/changedetectionio/model/App.py
@@ -15,16 +15,16 @@ class model(dict):
             'watching': {},
             'settings': {
                 'headers': {
-                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36',
+                    'User-Agent': os.getenv("SETTINGS_HEADERS_USERAGENT", 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36'),
                     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
                     'Accept-Encoding': 'gzip, deflate',  # No support for brolti in python requests yet.
                     'Accept-Language': 'en-GB,en-US;q=0.9,en;'
                 },
                 'requests': {
-                    'timeout': int(os.getenv("SETTINGS_REQUESTS_TIMEOUT", 45)),  # Default 45 seconds
+                    'timeout': int(os.getenv("SETTINGS_REQUESTS_TIMEOUT", "45")),  # Default 45 seconds
                     'time_between_check': {'weeks': None, 'days': None, 'hours': 3, 'minutes': None, 'seconds': None},
                     'jitter_seconds': 0,
-                    'workers': 10,  # Number of threads, lower is better for slow connections
+                    'workers': int(os.getenv("SETTINGS_REQUESTS_WORKERS", "10")),  # Number of threads, lower is better for slow connections
                     'proxy': None # Preferred proxy connection
                 },
                 'application': {


### PR DESCRIPTION
Following up on the ticket #369 