### PR TITLE
Added discord webhook base url to truncation rules

### DIFF
--- a/changedetectionio/notification.py
+++ b/changedetectionio/notification.py
@@ -79,7 +79,7 @@ def process_notification(n_object, datastore):
                     n_title = n_title[0:payload_max_size]
                     n_body = n_body[0:body_limit]
 
-                elif url.startswith('discord://'):
+                elif url.startswith('discord://') or url.startswith('https://discordapp.com/api/webhooks'):
                     # real limit is 2000, but minus some for extra metadata
                     payload_max_size = 1700
                     body_limit = max(0, payload_max_size - len(n_title))


### PR DESCRIPTION
Recreation of #748 after I accidentally broke the branch :)

This is an extension of the feature implemented in https://github.com/dgtlmoon/changedetection.io/pull/531. Apprise supports the link given directly by discord as a notification URL instead of having to modify the link to start with discord://. I have extended the rule that was implemented to include URLs that start with https://discord.com/api/webhooks/