### PR TITLE
fix Playwright URI Env example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   #             https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.common.proxy
   #
   #       Alternative Playwright URL, do not use "'s or 's!
-  #      - PLAYWRIGHT_DRIVER_URL=ws://playwright-chrome:3000&stealth=1&--disable-web-security=true
+  #      - PLAYWRIGHT_DRIVER_URL=ws://playwright-chrome:3000/&stealth=1&--disable-web-security=true
   #
   #       Playwright proxy settings playwright_proxy_server, playwright_proxy_bypass, playwright_proxy_username, playwright_proxy_password
   #


### PR DESCRIPTION
The missing `/` seems like a copy-and-paste typo. Without it I get an error during fetch.