### PR TITLE
Regex clarification

### DIFF
--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -190,7 +190,7 @@ nav
                     <span class="pure-form-message-inline">
                         <ul>
                             <li>Each line processed separately, any line matching will be ignored (removed before creating the checksum)</li>
-                            <li>Regular Expression support, wrap the line in forward slash <code>/regex/</code></li>
+                            <li>Regular Expression support, wrap the entire line in forward slash <code>/regex/</code></li>
                             <li>Changing this will affect the comparison checksum which may trigger an alert</li>
                             <li>Use the preview/show current tab to see ignores</li>
                         </ul>

--- a/changedetectionio/templates/settings.html
+++ b/changedetectionio/templates/settings.html
@@ -148,7 +148,7 @@ nav
                         <ul>
                             <li>Note: This is applied globally in addition to the per-watch rules.</li>
                             <li>Each line processed separately, any line matching will be ignored (removed before creating the checksum)</li>
-                            <li>Regular Expression support, wrap the line in forward slash <code>/regex/</code></li>
+                            <li>Regular Expression support, wrap the entire line in forward slash <code>/regex/</code></li>
                             <li>Changing this will affect the comparison checksum which may trigger an alert</li>
                             <li>Use the preview/show current tab to see ignores</li>
                         </ul>


### PR DESCRIPTION
TL;DR:  I'm an idiot.  This took *way* longer to figure out than it should have.

I was creating ignore regexes in individual watches and they were not working.  I was trying to watch some stuff on github, which has the annoying "rocket357 committed 2 minutes ago" type of stuff, so I formed the following regexes:

`/[0-9]* [a-zA-Z]*/ ago`

This obviously (now, after scratching my head for entirely too long heh) should be:

`/[0-9]* [a-zA-Z]* ago/`

The commits here just clarify that the regex needs to span the entire line as opposed to only having partial coverage of the ignore lines.

Probably overkill, but some of us need training wheels =)