### PR TITLE
Bump apprise to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ wtforms ~= 3.0
 jsonpath-ng ~= 1.5.3
 
 # Notification library
-apprise ~= 0.9.9
+apprise ~= 1.0.0
 
 # apprise mqtt https://github.com/dgtlmoon/changedetection.io/issues/315
 paho-mqtt


### PR DESCRIPTION
Changelog: https://github.com/caronc/apprise/releases/tag/v1.0.0
Compare: https://github.com/caronc/apprise/compare/v0.9.9...v1.0.0

For me especially interesting due to https://github.com/caronc/apprise/pull/627 (enabling better notifications to Home Assistant)

