### PR TITLE
Selenium and playwright configurable actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv
 test-datastore
 *.egg-info*
 .vscode/settings.json
+.venv

--- a/changedetectionio/fetch_site_status.py
+++ b/changedetectionio/fetch_site_status.py
@@ -101,6 +101,8 @@ class perform_site_check():
 
         if watch['webdriver_js_execute_code'] is not None and watch['webdriver_js_execute_code'].strip():
             fetcher.webdriver_js_execute_code = watch['webdriver_js_execute_code']
+        if watch['webdriver_custom_code'] is not None and watch['webdriver_custom_code'].strip():
+            fetcher.webdriver_custom_code = watch['webdriver_custom_code']
 
         fetcher.run(url, timeout, request_headers, request_body, request_method, ignore_status_codes, watch['css_filter'])
         fetcher.quit()

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -367,6 +367,7 @@ class watchForm(commonSettingsForm):
     text_should_not_be_present = StringListField('Block change-detection if text matches', [validators.Optional(), ValidateListRegex()])
 
     webdriver_js_execute_code = TextAreaField('Execute JavaScript before change detection', render_kw={"rows": "5"}, validators=[validators.Optional()])
+    webdriver_custom_code = TextAreaField('Execute webdriver operations before change detection', render_kw={"rows": "5"}, validators=[validators.Optional()])
 
     save_button = SubmitField('Save', render_kw={"class": "pure-button pure-button-primary"})
 

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -52,6 +52,7 @@ class model(dict):
             'time_between_check': {'weeks': None, 'days': None, 'hours': None, 'minutes': None, 'seconds': None},
             'webdriver_delay': None,
             'webdriver_js_execute_code': None, # Run before change-detection
+            'webdriver_custom_code': None # Run before change-detection
         }
     jitter_seconds = 0
 

--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -289,7 +289,8 @@ class ChangeDetectionStore:
                           'subtractive_selectors', 'trigger_text',
                           'extract_title_as_title', 'extract_text',
                           'text_should_not_be_present',
-                          'webdriver_js_execute_code']:
+                          'webdriver_js_execute_code',
+                          'webdriver_custom_code']:
                     if res.get(k):
                         apply_extras[k] = res[k]
 

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -109,6 +109,12 @@
                             Run this code before performing change detection, handy for filling in fields and other actions <a href="https://github.com/dgtlmoon/changedetection.io/wiki/Run-JavaScript-before-change-detection">More help and examples here</a>
                         </div>
                     </div>
+                    <div class="pure-control-group">
+                        {{ render_field(form.webdriver_custom_code) }}
+                        <div class="pure-form-message-inline">
+                            Run webdriver operations before performing change detection. This is using selenium or playwright and is more reliable for clicking and filling elements than doing this by pure javascript.
+                        </div>
+                    </div>
                 </fieldset>
                 <fieldset class="pure-group" id="requests-override-options">
                     {% if not playwright_enabled %}

--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+import multiprocessing
+import platform
 
 from flask import make_response, request
 from flask import url_for
@@ -96,6 +98,11 @@ def wait_for_all_checks(client):
         attempt += 1
 
 def live_server_setup(live_server):
+
+    # Pickling error on OS X - pytest-flask
+    # see this: https://github.com/pytest-dev/pytest-flask/issues/104
+    if platform.system() == 'Darwin':
+        multiprocessing.set_start_method("fork")
 
     @live_server.app.route('/test-endpoint')
     def test_endpoint():

--- a/changedetectionio/webdriver_custom_code_runner.py
+++ b/changedetectionio/webdriver_custom_code_runner.py
@@ -1,0 +1,125 @@
+import argparse
+import shlex
+from enum import Enum
+
+
+class WebdriverMode(Enum):
+    PLAYWRIGHT = 1
+    SELENIUM = 2
+
+
+class WebdriverCustomCodeRunner:
+    def __init__(self, webdriver_object, webdriver_mode: WebdriverMode):
+        self._webdriver_object = webdriver_object
+        self._webdriver_mode = webdriver_mode
+        self._parser = None
+
+    def run(self, code: str):
+        if not (code and code.strip()):
+            return
+
+        webdriver_command = code.strip()
+        runner = None
+
+        if self._webdriver_mode == WebdriverMode.PLAYWRIGHT:
+            self._parser = WebdriverCustomCodeRunner._get_parser_playwright()
+            runner = lambda command: self._run_playwright(command)
+        elif self._webdriver_mode == WebdriverMode.SELENIUM:
+            self._parser = WebdriverCustomCodeRunner._get_parser_selenium()
+            runner = lambda command: self._run_selenium(command)
+
+        for webdriver_command in webdriver_command.split('\n'):
+            webdriver_command = webdriver_command.strip()
+            if not webdriver_command:
+                continue
+
+            runner(webdriver_command)
+
+    @staticmethod
+    def _get_parser_selenium():
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--action', type=str, nargs=1, choices=['click', 'send_keys'], required=True)
+        parser.add_argument('--selector', type=str, nargs=1, required=True)
+        parser.add_argument('--selector_type', type=str, nargs=1,
+                            choices=['id', 'name', 'xpath', 'link_text', 'partial_link_text', 'tag_name', 'class_name',
+                                     'css_selector'], required=True)
+        parser.add_argument('--send_keys_value', type=str, nargs=1)
+        return parser
+
+    @staticmethod
+    def _get_parser_playwright():
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--action', type=str, nargs=1, choices=['click', 'fill', 'press'], required=True)
+        parser.add_argument('--selector', type=str, nargs=1, required=True)
+        parser.add_argument('--first', action='store_true', default=False)
+        parser.add_argument('--fill_value', type=str, nargs=1)
+        parser.add_argument('--press_value', type=str, nargs=1)
+        return parser
+
+    def _run_selenium(self, command: str):
+        from selenium.webdriver import Keys
+
+        args = self._parser.parse_args(shlex.split(command))
+
+        if args.action[0] == 'click':
+            self._selenium_find_element_by_selector_type(args.selector_type[0], args.selector[0]).click()
+        elif args.action[0] == 'send_keys':
+            send_keys_value_mapped = args.send_keys_value[0]
+            selenium_keys_dict = {key: value for key, value in Keys.__dict__.items() if
+                                  not key.startswith('__') and not callable(key)}
+            if send_keys_value_mapped and send_keys_value_mapped in selenium_keys_dict.keys():
+                send_keys_value_mapped = selenium_keys_dict[send_keys_value_mapped]
+
+            if not args.send_keys_value:
+                raise argparse.ArgumentError('missing "--send_keys_value" argument')
+            else:
+                self._selenium_find_element_by_selector_type(args.selector_type[0], args.selector[0]).send_keys(
+                    send_keys_value_mapped)
+        else:
+            raise argparse.ArgumentError(f'action "{args.action[0]}" is not supported!')
+
+    def _selenium_find_element_by_selector_type(self, selector_type: str, value: str):
+        from selenium.webdriver.common.by import By
+
+        if selector_type == 'id':
+            return self._webdriver_object.find_element(by=By.ID, value=value)
+        elif selector_type == 'name':
+            return self._webdriver_object.find_element(by=By.NAME, value=value)
+        elif selector_type == 'xpath':
+            return self._webdriver_object.find_element(by=By.XPATH, value=value)
+        elif selector_type == 'link_text':
+            return self._webdriver_object.find_element(by=By.LINK_TEXT, value=value)
+        elif selector_type == 'partial_link_text':
+            return self._webdriver_object.find_element(by=By.PARTIAL_LINK_TEXT, value=value)
+        elif selector_type == 'tag_name':
+            return self._webdriver_object.find_element(by=By.TAG_NAME, value=value)
+        elif selector_type == 'class_name':
+            return self._webdriver_object.find_element(by=By.CLASS_NAME, value=value)
+        elif selector_type == 'css_selector':
+            return self._webdriver_object.find_element(by=By.CSS_SELECTOR, value=value)
+        else:
+            raise argparse.ArgumentError(f'selector_type "{selector_type}" is not supported!')
+
+    def _run_playwright(self, command: str):
+        args = self._parser.parse_args(shlex.split(command))
+
+        def auto_locator(selector: str, first: bool):
+            if first:
+                return self._webdriver_object.locator(selector).first
+            else:
+                return self._webdriver_object.locator(selector)
+
+        if args.action[0] == 'click':
+            auto_locator(args.selector[0], args.first).click()
+        elif args.action[0] == 'fill':
+            if not args.fill_value:
+                raise argparse.ArgumentError('missing "--fill_value" argument')
+            else:
+                auto_locator(args.selector[0], args.first).fill(args.fill_value[0])
+        elif args.action[0] == 'press':
+            if not args.press_value:
+                raise argparse.ArgumentError('missing "--press_value" argument')
+            else:
+                auto_locator(args.selector[0], args.first).press(args.press_value[0])
+        else:
+            raise argparse.ArgumentError(f'action "{args.action[0]}" is not supported!')


### PR DESCRIPTION
Hi everyone,

When I started using changedetection.io I missed the option to execute selenium or playwright commands in addition to the option of running javascript before checking for changes.

I added another field to the fetcher options with a new "syntax". I decided to go with this parsing option, by using python argparse, because I do not want to call python eval to run arbitrary code which might not be limited to playwright or selenium commands.
I would be happy to update the wiki and add a link to the user interface.

I created an example with a google search searching for "changedetection.io".
URL: https://www.google.com/?&hl=en-GB

Selenium webdriver code:
```
--action click --selector '//button[contains(., "Reject all")]' --selector_type xpath
--action click --selector '//input' --selector_type xpath
--action send_keys --selector '//input' --selector_type xpath --send_keys_value 'changedetection.io'
--action send_keys --selector '//input' --selector_type xpath --send_keys_value "ENTER"
--action click --selector '//h3[contains(text(), "changedetection.io")]' --selector_type xpath
```

Playwright webdriver code:
```
--action click --selector 'button:has-text("Reject all")'
--action click --selector '[aria-label="Search"]'
--action fill --selector '[aria-label="Search"]' --fill_value 'changedetection.io'
--action press --selector '[aria-label="Search"]' --press_value 'Enter'
--action click --selector 'text=changedetection.io - The best and simplest self ... - GitHub'
```