### PR TITLE
Hide the Referer header from monitored websites

### DIFF
--- a/changedetectionio/changedetection.py
+++ b/changedetectionio/changedetection.py
@@ -102,6 +102,14 @@ def main():
                     has_password=datastore.data['settings']['application']['password'] != False
                     )
 
+    # Monitored websites will not receive a Referer header
+    # when a user clicks on an outgoing link.
+    @app.after_request
+    def hide_referrer(response):
+        if os.getenv("HIDE_REFERER", False):
+            response.headers["Referrer-Policy"] = "no-referrer"
+        return response
+
     # Proxy sub-directory support
     # Set environment var USE_X_SETTINGS=1 on this script
     # And then in your proxy_pass settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
   #        Respect proxy_pass type settings, `proxy_set_header Host "localhost";` and `proxy_set_header X-Forwarded-Prefix /app;`
   #        More here https://github.com/dgtlmoon/changedetection.io/wiki/Running-changedetection.io-behind-a-reverse-proxy-sub-directory
   #      - USE_X_SETTINGS=1
+  #
+  #        Hides the `Referer` header so that monitored websites can't see the changedetection.io hostname.
+  #      - HIDE_REFERER=true
 
       # Comment out ports: when using behind a reverse proxy , enable networks: etc.
       ports:


### PR DESCRIPTION
Today changedetection will send a `Referer` header when a user clicks on one of the monitored websites. This leaks the hostname of where changedetection is running. This PR adds an option to hide the `Referer` header from monitored websites.