### PR TITLE
Unpin cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,10 +28,6 @@ apprise ~= 1.1.0
 # apprise mqtt https://github.com/dgtlmoon/changedetection.io/issues/315
 paho-mqtt
 
-# Pinned version of cryptography otherwise
-# ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
-cryptography ~= 3.4
-
 # Used for CSS filtering
 bs4
 


### PR DESCRIPTION
The error should no longer happen and if so pip needs an update rather than pinning a security related dependency.