### PR TITLE
Add Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ARG CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 # Re #93, #73, excluding rustc (adds another 430Mb~)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
     libssl-dev \
     libffi-dev \
     gcc \
@@ -59,6 +60,9 @@ RUN sed -i 's/^CipherString = .*/CipherString = DEFAULT@SECLEVEL=1/' /etc/ssl/op
 # Copy modules over to the final image and add their dir to PYTHONPATH
 COPY --from=builder /dependencies /usr/local
 ENV PYTHONPATH=/usr/local
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:5000/ || exit 1
 
 EXPOSE 5000
 


### PR DESCRIPTION
The container that runs in my Orange Pi sometimes crashes (every 1-2 months) and I had to manually restart it.

With [Docker healthcheck][1], the container will, hopefully, restart itself automatically when crashed.

### Example 1: healthy

```bash
# curl -f http://localhost:5000
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="/login?next=%2F">/login?next=%2F</a>. If not click the link.
```

### Example 2: crashed

```bash
# curl -f http://localhost:5000
curl: (7) Failed to connect to localhost port 5000: Connection refused
```

[1]:https://docs.docker.com/engine/reference/builder/#healthcheck