### PR TITLE
utf-8 char encoding bug when viewing Chinese chars - Update diff.py

### DIFF
--- a/changedetectionio/diff.py
+++ b/changedetectionio/diff.py
@@ -23,12 +23,12 @@ def customSequenceMatcher(before, after, include_equal=False):
 # only_differences - only return info about the differences, no context
 # line_feed_sep could be "<br/>" or "<li>" or "\n" etc
 def render_diff(previous_file, newest_file, include_equal=False, line_feed_sep="\n"):
-    with open(newest_file, 'r') as f:
+    with open(newest_file, 'r', encoding='UTF-8') as f:
         newest_version_file_contents = f.read()
         newest_version_file_contents = [line.rstrip() for line in newest_version_file_contents.splitlines()]
 
     if previous_file:
-        with open(previous_file, 'r') as f:
+        with open(previous_file, 'r', encoding='UTF-8') as f:
             previous_version_file_contents = f.read()
             previous_version_file_contents = [line.rstrip() for line in previous_version_file_contents.splitlines()]
     else:


### PR DESCRIPTION
Raise error: ‘gbk‘ codec can‘t decode byte 0xbf in position 2: illegal multibyte sequence‘, when handle chinese.