### PR TITLE
Use cookies instead of store for darkmode

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -203,7 +203,8 @@ def changedetection_app(config=None, datastore_o=None):
                            resource_class_kwargs={'datastore': datastore, 'update_q': update_q})
 
     def getDarkModeSetting():
-      return datastore.data['settings']['application'].get('css_dark_mode')
+      css_dark_mode = request.cookies.get('css_dark_mode')
+      return True if (css_dark_mode == 'true' or css_dark_mode == True) else False
 
     # Setup cors headers to allow all domains
     # https://flask-cors.readthedocs.io/en/latest/
@@ -1212,15 +1213,6 @@ def changedetection_app(config=None, datastore_o=None):
                     i += 1
         flash("{} watches are queued for rechecking.".format(i))
         return redirect(url_for('index', tag=tag))
-
-    @app.route("/toggle-darkmode-state", methods=['GET'])
-    @login_required
-    def toggle_darkmode_state():
-      current_mode = datastore.data['settings']['application'].get('css_dark_mode')
-      new_mode = not current_mode
-      datastore.data['settings']['application']['css_dark_mode'] = new_mode
-      datastore.needs_write = True
-      return ''
 
     @app.route("/form/checkbox-operations", methods=['POST'])
     @login_required

--- a/changedetectionio/static/js/toggle-theme.js
+++ b/changedetectionio/static/js/toggle-theme.js
@@ -3,24 +3,22 @@
  * Toggles theme between light and dark mode.
  */
 $(document).ready(function () {
-  const url = "/toggle-darkmode-state";
-
   const button = document.getElementsByClassName("toggle-theme")[0];
 
   button.onclick = () => {
-    fetch(url)
-      .then(function () {
-        const htmlElement = document.getElementsByTagName("html");
-        const isDarkMode = htmlElement[0].dataset.darkmode === "true";
-        htmlElement[0].dataset.darkmode = !isDarkMode;
-        if (isDarkMode) {
-          button.classList.remove("dark");
-        } else {
-          button.classList.add("dark");
-        }
-      })
-      .catch(function (e) {
-        console.log("Can't toggle the theme. Error was: ", e);
-      });
+    const htmlElement = document.getElementsByTagName("html");
+    const isDarkMode = htmlElement[0].dataset.darkmode === "true";
+    htmlElement[0].dataset.darkmode = !isDarkMode;
+    if (isDarkMode) {
+      button.classList.remove("dark");
+      setCookieValue(false);
+    } else {
+      button.classList.add("dark");
+      setCookieValue(true);
+    }
   };
+
+  const setCookieValue = (value) => {
+    document.cookie = `css_dark_mode=${value};max-age=31536000`
+  }
 });


### PR DESCRIPTION
Removes the route and instead sets a cookie on toggle using javascript.

`getDarkModeSetting` reads the cookie on the server side to ensure the correct mode is set on page refreshes.