### PR TITLE
API: support for adding all parameters when creating watch

### DIFF
--- a/changedetectionio/api/api_v1.py
+++ b/changedetectionio/api/api_v1.py
@@ -98,7 +98,7 @@ class CreateWatch(Resource):
         if not validators.url(json_data['url'].strip()):
             return "Invalid or unsupported URL", 400
 
-        extras = {'title': json_data['title'].strip()} if json_data.get('title') else {}
+        extras = {**json_data['extras'],**{'title': json_data['title'].strip()}} if json_data.get('extras') and json_data.get('title') else {'title': json_data['title'].strip()} if json_data.get('title') else {}
 
         new_uuid = self.datastore.add_watch(url=json_data['url'].strip(), tag=tag, extras=extras)
         self.update_q.put(queuedWatchMetaData.PrioritizedItem(priority=1, item={'uuid': new_uuid, 'skip_when_checksum_same': True}))


### PR DESCRIPTION
First of all: GREAT PROJECT! One small fix that will help us very much: 

ATM it is only possible to set the `url`, `title` and `tags` when creating a new watch via the API. 
I think it is useful to create watches with all kind of predefined variables like: 

![image](https://user-images.githubusercontent.com/49652410/209245384-35902d57-7e73-48e0-9f17-3a94c66a2e36.png)

Using that code would make it optional and would save us a lot of time. 🙏🏻 

![image](https://user-images.githubusercontent.com/49652410/209245583-3a657e9b-53da-46f3-bba3-3a5c8d515370.png)

Best regards, 
Chris
