### PR TITLE
[draft] add follow redirects options for html_requests fetcher

### DIFF
--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -118,7 +118,8 @@ class Fetcher():
             request_method,
             ignore_status_codes=False,
             current_include_filters=None,
-            is_binary=False):
+            is_binary=False,
+            follow_redirects=True):
         # Should set self.error, self.status_code and self.content
         pass
 
@@ -541,7 +542,8 @@ class html_requests(Fetcher):
             request_method,
             ignore_status_codes=False,
             current_include_filters=None,
-            is_binary=False):
+            is_binary=False,
+            follow_redirects=True):
 
         # Make requests use a more modern looking user-agent
         if not 'User-Agent' in request_headers:
@@ -563,6 +565,7 @@ class html_requests(Fetcher):
                              data=request_body,
                              url=url,
                              headers=request_headers,
+                             allow_redirects=follow_redirects,
                              timeout=timeout,
                              proxies=proxies,
                              verify=False)

--- a/changedetectionio/fetch_site_status.py
+++ b/changedetectionio/fetch_site_status.py
@@ -83,6 +83,7 @@ class perform_site_check():
         request_body = self.datastore.data['watching'][uuid].get('body')
         request_method = self.datastore.data['watching'][uuid].get('method')
         ignore_status_codes = self.datastore.data['watching'][uuid].get('ignore_status_codes', False)
+        follow_redirects = self.datastore.data['watching'][uuid].get('follow_redirects', True)
 
         # source: support
         is_source = False
@@ -124,7 +125,7 @@ class perform_site_check():
         # requests for PDF's, images etc should be passwd the is_binary flag
         is_binary = watch.is_pdf
 
-        fetcher.run(url, timeout, request_headers, request_body, request_method, ignore_status_codes, watch.get('include_filters'), is_binary=is_binary)
+        fetcher.run(url, timeout, request_headers, request_body, request_method, ignore_status_codes, watch.get('include_filters'), is_binary=is_binary, follow_redirects=follow_redirects)
         fetcher.quit()
 
         self.screenshot = fetcher.screenshot

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -387,6 +387,7 @@ class watchForm(commonSettingsForm):
     body = TextAreaField('Request body', [validators.Optional()])
     method = SelectField('Request method', choices=valid_method, default=default_method)
     ignore_status_codes = BooleanField('Ignore status codes (process non-2xx status codes as normal)', default=False)
+    follow_redirects = BooleanField('Follow redirects (follow 30x redirections)', default=True)
     check_unique_lines = BooleanField('Only trigger when new lines appear', default=False)
     trigger_text = StringListField('Trigger/wait for text', [validators.Optional(), ValidateListRegex()])
     if os.getenv("PLAYWRIGHT_DRIVER_URL"):

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -26,6 +26,7 @@ class model(dict):
         'extract_title_as_title': False,
         'fetch_backend': None,
         'filter_failure_notification_send': strtobool(os.getenv('FILTER_FAILURE_NOTIFICATION_SEND_DEFAULT', 'True')),
+        'follow_redirects': True,
         'has_ldjson_price_data': None,
         'track_ldjson_price_data': None,
         'headers': {},  # Extra headers to send

--- a/changedetectionio/templates/edit.html
+++ b/changedetectionio/templates/edit.html
@@ -101,6 +101,9 @@
                     <div  class="pure-control-group inline-radio">
                         {{ render_checkbox_field(form.ignore_status_codes) }}
                     </div>
+                    <div  class="pure-control-group inline-radio">
+                        {{ render_checkbox_field(form.follow_redirects) }}
+                    </div>
                 <fieldset id="webdriver-override-options">
                     <div class="pure-control-group">
                         {{ render_field(form.webdriver_delay) }}


### PR DESCRIPTION
Hi, I started a draft for this issue https://github.com/dgtlmoon/changedetection.io/issues/1257. 

I dont know how to add a follow_redirects option on the `base_html_playwright` and `base_html_webdriver` fetchers, nor if its possible. 

So maybe this would be an option to show only if we use the `html_requests` ? 

