### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pytz
 brotli~=1.0
 requests[socks] ~=2.28
 
-urllib3>1.26
+urllib3>1.26.5
 chardet>2.3.0
 
 wtforms~=3.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.26
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.26 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS