### PR TITLE
Bump notification library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ jsonpath-ng~=1.5.3
 # jq not available on Windows so must be installed manually
 
 # Notification library
-apprise~=1.2.0
+apprise~=1.2.1
 
 # apprise mqtt https://github.com/dgtlmoon/changedetection.io/issues/315
 paho-mqtt


### PR DESCRIPTION
Changelog: https://github.com/caronc/apprise/releases/tag/v1.2.1

Don't know why line 65 shows as changed, didn't do anything there (nor do I see an actual change)