### PR TITLE
Fix releases link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,5 +245,5 @@ I offer commercial support, this software is depended on by network security, ae
 [test-shield]: https://github.com/dgtlmoon/changedetection.io/actions/workflows/test-only.yml/badge.svg?branch=master
 
 [license-shield]: https://img.shields.io/github/license/dgtlmoon/changedetection.io.svg?style=for-the-badge
-[release-link]: https://github.com/dgtlmoon.com/changedetection.io/releases
+[release-link]: https://github.com/dgtlmoon/changedetection.io/releases
 [docker-link]: https://hub.docker.com/r/dgtlmoon/changedetection.io


### PR DESCRIPTION
The releases link in the readme.MD file has a typo. Small PR to fix it. 

The rest of the issue template is not relevant here as it's not a product bug. 