### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# Uncomment following line if you are running into 'Unsupported config option for volumes: 'changedetection-data'' or the like.
+# version: '2'
 services:
     changedetection:
       image: ghcr.io/dgtlmoon/changedetection.io


### PR DESCRIPTION
Added a friendly fix for someone who might be using `version: '2'` `docker-compose.yml` standards.