### PR TITLE
notifications fail on utf8 chars fix

### DIFF
--- a/changedetectionio/diff.py
+++ b/changedetectionio/diff.py
@@ -32,13 +32,15 @@ def customSequenceMatcher(before, after, include_equal=False):
 # only_differences - only return info about the differences, no context
 # line_feed_sep could be "<br/>" or "<li>" or "\n" etc
 def render_diff(previous_file, newest_file, include_equal=False, line_feed_sep="\n"):
-    with open(newest_file, 'r') as f:
+    with open(newest_file, 'r',encoding='utf-8') as f:
         newest_version_file_contents = f.read()
+        newest_version_file_contents = newest_version_file_contents.encode("ascii","ignore").decode("ascii")
         newest_version_file_contents = [line.rstrip() for line in newest_version_file_contents.splitlines()]
 
     if previous_file:
-        with open(previous_file, 'r') as f:
+        with open(previous_file, 'r',encoding='utf-8') as f:
             previous_version_file_contents = f.read()
+            previous_version_file_contents = previous_version_file_contents.encode("ascii","ignore").decode("ascii")
             previous_version_file_contents = [line.rstrip() for line in previous_version_file_contents.splitlines()]
     else:
         previous_version_file_contents = ""


### PR DESCRIPTION
hey I noticed if utf-8 char appears in diff, the diff file presents it, but notification won't send. did some test to approve that this is the situation, minor fix - ignoring utf characters in notification service.
think it will help with bug #1044