### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ paho-mqtt
 cryptography~=3.4
 
 # Used for CSS filtering
-bs4
+beautifulsoup4
 
 # XPath filtering, lxml is required by bs4 anyway, but put it here to be safe.
 lxml


### PR DESCRIPTION
`bs4` is a dummy package. Most distributions don't ship `bs4`. By using the actual module name can downstream patching be avoided.