### PR TITLE
Fix tab navigation adding extra route in history

### DIFF
--- a/changedetectionio/static/js/tabs.js
+++ b/changedetectionio/static/js/tabs.js
@@ -12,7 +12,8 @@ window.addEventListener('hashchange', function () {
 var has_errors = document.querySelectorAll(".messages .error");
 if (!has_errors.length) {
     if (document.location.hash == "") {
-        document.querySelector(".tabs ul li:first-child a").click();
+        const hash = document.querySelector(".tabs ul li:first-child a").href;
+        window.location.replaceState(undefined, undefined, hash);
     } else {
         set_active_tab();
     }

--- a/changedetectionio/templates/watch-overview.html
+++ b/changedetectionio/templates/watch-overview.html
@@ -153,10 +153,10 @@
                        class="recheck pure-button pure-button-primary">{% if watch.uuid in queued_uuids %}Queued{% else %}Recheck{% endif %}</a>
                     <a href="{{ url_for('edit_page', uuid=watch.uuid)}}" class="pure-button pure-button-primary">Edit</a>
                     {% if watch.history_n >= 2 %}
-                    <a href="{{ url_for('diff_history_page', uuid=watch.uuid) }}" target="{{watch.uuid}}" class="pure-button pure-button-primary diff-link">Diff</a>
+                    <a href="{{ url_for('diff_history_page', uuid=watch.uuid) }}" class="pure-button pure-button-primary diff-link">Diff</a>
                     {% else %}
                         {% if watch.history_n == 1 or (watch.history_n ==0 and watch.error_text_ctime )%}
-                            <a href="{{ url_for('preview_page', uuid=watch.uuid)}}" target="{{watch.uuid}}" class="pure-button pure-button-primary">Preview</a>
+                            <a href="{{ url_for('preview_page', uuid=watch.uuid)}}" class="pure-button pure-button-primary">Preview</a>
                         {% endif %}
                     {% endif %}
                 </td>


### PR DESCRIPTION
Currently, when navigating to `/preview/<uuid>` (or other pages with tabs) you first land on the route, then the javascript clicks on the `a` tag of the first tab. This causes an extra route in the browser history so you have to hit back twice to go back to the previous page.

This fixes that by using `replaceState` instead of clicking on the `a` tag to navigate you to the hash of the first tab without adding another route to history.

Also changes the `target` prop for Preview on watch overview as it causes inconsistent behavior when opening preview. Edit opens in current browsing context so I believe Preview should as well. Along with the changes to the tab navigation it creates a better experience for navigating around the UI.