### PR TITLE
Fix back navigation

### DIFF
--- a/changedetectionio/static/js/tabs.js
+++ b/changedetectionio/static/js/tabs.js
@@ -12,7 +12,7 @@ window.addEventListener('hashchange', function () {
 var has_errors = document.querySelectorAll(".messages .error");
 if (!has_errors.length) {
     if (document.location.hash == "") {
-        document.querySelector(".tabs ul li:first-child a").click();
+        location.replace(document.querySelector(".tabs ul li:first-child a").hash);
     } else {
         set_active_tab();
     }


### PR DESCRIPTION
Fixes back navigation when accessing tabbed pages.

The `.click()` added a new history entry and going back from there left the page in a broken state.

Changed `.click()` to `location.replace()` to replace the history state instead. Note `history.replaceState()` cannot be used here as it does not update the `:target` element which is what's currently used to display the active tab content or trigger a `hashchange` event used to update the active tab.

Fixes #1200