### PR TITLE
Use builtin node puppeteer handler browserless

### DIFF
--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -287,6 +287,23 @@ class base_html_playwright(Fetcher):
             current_include_filters=None,
             is_binary=False):
 
+        # Fallback for now to the old way if browsersteps
+        # @todo - need to figure out how to get browsersteps with images on each step working
+        for step in self.browser_steps:
+            if step['operation'] != None:
+                self.run_playwright(
+                               url,
+                               timeout,
+                               request_headers,
+                               request_body,
+                               request_method,
+                               ignore_status_codes,
+                               current_include_filters,
+                               is_binary)
+                return
+
+
+
         extra_wait_ms = (int(os.getenv("WEBDRIVER_DELAY_BEFORE_CONTENT_READY", 5)) + self.render_extract_delay) * 1000
         xpath_element_js = self.xpath_element_js.replace('%ELEMENTS%', visualselector_xpath_selectors)
 

--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -301,6 +301,18 @@ class base_html_playwright(Fetcher):
                                    ignore_status_codes,
                                    current_include_filters,
                                    is_binary)
+        elif os.getenv('FORCE_PLAYWRIGHT_FETCH'):
+            # Temporary backup solution until we rewrite the playwright code
+            return self.run_playwright(
+                url,
+                timeout,
+                request_headers,
+                request_body,
+                request_method,
+                ignore_status_codes,
+                current_include_filters,
+                is_binary)
+
 
         extra_wait_ms = (int(os.getenv("WEBDRIVER_DELAY_BEFORE_CONTENT_READY", 5)) + self.render_extract_delay) * 1000
         xpath_element_js = self.xpath_element_js.replace('%ELEMENTS%', visualselector_xpath_selectors)

--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -329,7 +329,7 @@ class base_html_playwright(Fetcher):
                     }
                 },
                 # @todo /function needs adding ws:// to http:// rebuild this
-                url='http://127.0.0.1:3000/function?--proxy-server=https://my-proxy.com',
+                url='http://127.0.0.1:3000/function',
                 # ? and add nice exception
                 timeout=wait_browserless_seconds)
         except ReadTimeout:

--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -320,8 +320,9 @@ class base_html_playwright(Fetcher):
           return {{
             data: {{
                 'content': html, 
-                'screenshot': b64s, 
                 'headers': r.headers(), 
+                'instock_data': instock_data,
+                'screenshot': b64s,
                 'status_code': r.status(),
                 'xpath_data': xpath_data
             }},
@@ -389,9 +390,10 @@ class base_html_playwright(Fetcher):
                 if x.get('status_code', 200) != 200 and not ignore_status_codes:
                     raise Non200ErrorCodeReceived(url=url, status_code=x.get('status_code', 200), page_html=x['content'])
 
-                self.screenshot = base64.b64decode(x.get('screenshot'))
                 self.content = x.get('content')
                 self.headers = x.get('headers')
+                self.instock_data = x.get('instock_data')
+                self.screenshot = base64.b64decode(x.get('screenshot'))
                 self.xpath_data = x.get('xpath_data')
 
             else:

--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -289,20 +289,18 @@ class base_html_playwright(Fetcher):
 
         # Fallback for now to the old way if browsersteps
         # @todo - need to figure out how to get browsersteps with images on each step working
-        for step in self.browser_steps:
-            if step['operation'] != None:
-                self.run_playwright(
-                               url,
-                               timeout,
-                               request_headers,
-                               request_body,
-                               request_method,
-                               ignore_status_codes,
-                               current_include_filters,
-                               is_binary)
-                return
-
-
+        if self.browser_steps:
+            for step in self.browser_steps:
+                if step.get('operation'):
+                    return self.run_playwright(
+                                   url,
+                                   timeout,
+                                   request_headers,
+                                   request_body,
+                                   request_method,
+                                   ignore_status_codes,
+                                   current_include_filters,
+                                   is_binary)
 
         extra_wait_ms = (int(os.getenv("WEBDRIVER_DELAY_BEFORE_CONTENT_READY", 5)) + self.render_extract_delay) * 1000
         xpath_element_js = self.xpath_element_js.replace('%ELEMENTS%', visualselector_xpath_selectors)

--- a/changedetectionio/content_fetcher.py
+++ b/changedetectionio/content_fetcher.py
@@ -301,7 +301,7 @@ class base_html_playwright(Fetcher):
           
           if(execute_js) {{
             await page.evaluate(execute_js);
-            await page.evaluate(200);
+            await page.waitForTimeout(200);
           }}
           
           const xpath_data = await page.evaluate((include_filters) => {{ {xpath_element_js} }}, include_filters);

--- a/changedetectionio/res/xpath_element_scraper.js
+++ b/changedetectionio/res/xpath_element_scraper.js
@@ -38,15 +38,15 @@ const findUpTag = (el) => {
     if (el.name !== undefined && el.name.length) {
         var proposed = el.tagName + "[name=" + el.name + "]";
         var proposed_element = window.document.querySelectorAll(proposed);
-        if(proposed_element.length) {
+        if (proposed_element.length) {
             if (proposed_element.length === 1) {
                 return proposed;
             } else {
                 // Some sites change ID but name= stays the same, we can hit it if we know the index
                 // Find all the elements that match and work out the input[n]
-                var n=Array.from(proposed_element).indexOf(el);
+                var n = Array.from(proposed_element).indexOf(el);
                 // Return a Playwright selector for nthinput[name=zipcode]
-                return proposed+" >> nth="+n;
+                return proposed + " >> nth=" + n;
             }
         }
     }


### PR DESCRIPTION
- Does not require a new `node` process per URL watch
- Scales way better (rely on browserless instead of local infrastructure)
- Does not yet handle browsersteps but it will in the future
- Much faster spin up time
- Less memory required

This is because browserless's code will manage multiple `/function` calls in one node process, while playwright does not support any threaded ability