### PR TITLE
When the document was the same, always assume there was no error, clear any previous errors

### DIFF
--- a/changedetectionio/update_worker.py
+++ b/changedetectionio/update_worker.py
@@ -262,6 +262,7 @@ class update_worker(threading.Thread):
                         # Yes fine, so nothing todo, don't continue to process.
                         process_changedetection_results = False
                         changed_detected = False
+                        self.datastore.update_watch(uuid=uuid, update_obj={'last_error': False})
 
                     except content_fetcher.BrowserStepsStepTimout as e:
 


### PR DESCRIPTION
Sometimes you might get an error like connection error

And then the app would fetch the document again, and decide not to do any processing because the checksum was the same

but then the old error was still showing.