### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See the wiki for more information https://github.com/dgtlmoon/changedetection.io
 ## Filters
 
 XPath, JSONPath, jq, and CSS support comes baked in! You can be as specific as you need, use XPath exported from various XPath element query creation tools. 
-(We support LXML `re:test`, `re:math` and `re:replace`.)
+(We support LXML `re:test`, `re:match` and `re:replace`.)
 
 ## Notifications
 


### PR DESCRIPTION
Changed LXML re:math reference to re:match

[EXSLT](https://exslt.github.io/regexp/index.html ) only has re.match, re.test, and re.replace. 
