### PR TITLE
Fix dark mode toggle

### DIFF
--- a/changedetectionio/static/js/toggle-theme.js
+++ b/changedetectionio/static/js/toggle-theme.js
@@ -9,13 +9,7 @@ $(document).ready(function () {
     const htmlElement = document.getElementsByTagName("html");
     const isDarkMode = htmlElement[0].dataset.darkmode === "true";
     htmlElement[0].dataset.darkmode = !isDarkMode;
-    if (isDarkMode) {
-      button.classList.remove("dark");
-      setCookieValue(false);
-    } else {
-      button.classList.add("dark");
-      setCookieValue(true);
-    }
+    setCookieValue(!isDarkMode);
   };
 
   const setCookieValue = (value) => {

--- a/changedetectionio/static/styles/styles.css
+++ b/changedetectionio/static/styles/styles.css
@@ -283,6 +283,10 @@ html[data-darkmode="true"] {
   --color-icon-github-hover: var(--color-grey-700);
   --color-watch-table-error: var(--color-light-red);
   --color-watch-table-row-text: var(--color-grey-800); }
+  html[data-darkmode="true"] #toggle-light-mode .icon-light {
+    display: none; }
+  html[data-darkmode="true"] #toggle-light-mode .icon-dark {
+    display: block; }
   html[data-darkmode="true"] .icon-spread {
     filter: hue-rotate(-10deg) brightness(1.5); }
   html[data-darkmode="true"] .watch-table .title-col a[target="_blank"]::after,
@@ -335,10 +339,6 @@ a.github-link {
   width: 3rem; }
   #toggle-light-mode .icon-dark {
     display: none; }
-  #toggle-light-mode.dark .icon-light {
-    display: none; }
-  #toggle-light-mode.dark .icon-dark {
-    display: block; }
 
 #toggle-search {
   width: 2rem; }

--- a/changedetectionio/templates/base.html
+++ b/changedetectionio/templates/base.html
@@ -93,10 +93,7 @@
             </form>
           </li>
           <li class="pure-menu-item">
-            {% if dark_mode %}
-            {% set darkClass = 'dark' %}
-            {% endif %}
-            <button class="toggle-button {{darkClass}}"  id ="toggle-light-mode" type="button" title="Toggle Light/Dark Mode">
+            <button class="toggle-button" id ="toggle-light-mode" type="button" title="Toggle Light/Dark Mode">
               <span class="visually-hidden">Toggle light/dark mode</span>
               <span class="icon-light">
                 {% include "svgs/light-mode-toggle-icon.svg" %}


### PR DESCRIPTION
Fixes an issue where the initial state of the dark mode toggle is wrong when you are on dark mode.

The `dark` class was not being set properly on load. Removed the `dark` class manipulation so that `html[data-darkmode]` is the single source of dark mode state.

Before|After
-------|----
![changedetection_](https://github.com/dgtlmoon/changedetection.io/assets/371507/7a1f6c69-7734-425e-aca8-272c1f7c53f4)|![changedetection_2](https://github.com/dgtlmoon/changedetection.io/assets/371507/ac09954a-e258-43ce-9e10-edaa2ad9aef3)

#### Repro Steps:
1. Enable dark mode.
2. Refresh the page.