### PR TITLE
Docker container updates - use specific debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pip dependencies install stage
-FROM python:3.10-slim as builder
+FROM python:3.10-slim-bullseye as builder
 
 # See `cryptography` pin comment in requirements.txt
 ARG CRYPTOGRAPHY_DONT_BUILD_RUST=1
@@ -29,7 +29,7 @@ RUN pip install --target=/dependencies playwright~=1.27.1 \
     || echo "WARN: Failed to install Playwright. The application can still run, but the Playwright option will be disabled."
 
 # Final image stage
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl1.1 \


### PR DESCRIPTION
python:3.10-slim is now debian bookworm which libssl1.1 not provided.

So Dockerfile build is broken.
```
[21:49:16.600] #14 5.173 E: Unable to locate package libssl1.1
[21:49:16.603] #14 5.173 E: Couldn't find any package by glob 'libssl1.1'
[21:49:16.606] #14 5.173 E: Couldn't find any package by regex 'libssl1.1'
[21:49:16.725] #14 ERROR: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends     libssl1.1     libxslt1.1     poppler-utils     zlib1g     && apt-get clean && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
[21:49:16.811] #11 CANCELED
```

python:3.10-slim-bullseye will help.

```
$ docker run -it python:3.10-slim /bin/bash
root@435673e149be:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
...
# apt update && apt search libssl1.1
#
```

```
$ docker run -it python:3.10-slim-bullseye /bin/bash
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
...
# apt search libssl1.1
libssl1.1/oldstable-security,now 1.1.1n-0+deb11u5 amd64 [installed]
```