### PR TITLE
Regex extra options in `ignore` and `trigger` were not processing correctly

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -197,21 +197,21 @@ def strip_ignore_text(content, wordlist, mode="content"):
     ignore_regex = []
 
     ignored_line_numbers = []
-    # Copy into a new buffer only those lines which match
 
     for k in wordlist:
         # Is it a regex?
-        if k[0] == '/':  # maybe if there are two? or regex?
-            # strip first last, convert re.search(r'(?i)maN', x)
-            # Build the regex from '/xxxx/n' type perl-ish to python opts
+        x = re.search('^\/(.*)\/(.*)', k.strip())
+        if x:
+            # Starts with / but doesn't look like a regex
+            p = x.group(1)
             try:
-                x = re.search('^\/(.*)\/(.*)', k.strip())
-                p = x.group(1)
+                # @Todo python regex options can go before the regex str, but not really many of the options apply on a per-line basis
                 ignore_regex.append(re.compile(rf"{p}", re.IGNORECASE))
             except Exception as e:
-                # Didnt work as a regex, just treat it as text
+                # Badly formed regex, treat as text
                 ignore_text.append(k.strip())
         else:
+            # Had a / but doesn't work as regex
             ignore_text.append(k.strip())
 
     for line in content.splitlines():
@@ -225,7 +225,7 @@ def strip_ignore_text(content, wordlist, mode="content"):
 
             if not got_match:
                 for r in ignore_regex:
-                    if r.match(line):
+                    if r.search(line):
                         got_match = True
 
             if not got_match:
@@ -233,7 +233,6 @@ def strip_ignore_text(content, wordlist, mode="content"):
                 output.append(line.encode('utf8'))
             else:
                 ignored_line_numbers.append(i)
-
 
 
     # Used for finding out what to highlight

--- a/changedetectionio/tests/test_ignore_regex_text.py
+++ b/changedetectionio/tests/test_ignore_regex_text.py
@@ -15,11 +15,21 @@ def test_strip_regex_text_func():
     but sometimes we want to remove the lines.
     
     but 1 lines
+    skip 5 lines
+    really? yes man
     but including 1234 lines
     igNORe-cAse text we dont want to keep    
     but not always."""
 
-    ignore_lines = ["sometimes", "/\s\d{2,3}\s/", "/ignore-case text/"]
+
+    ignore_lines = [
+        "sometimes",
+        "/\s\d{2,3}\s/",
+        "/ignore-case text/",
+        "really?",
+        "/skip \d lines/i"
+    ]
+
 
     fetcher = fetch_site_status.perform_site_check(datastore=False)
     stripped_content = html_tools.strip_ignore_text(test_content, ignore_lines)
@@ -27,4 +37,4 @@ def test_strip_regex_text_func():
     assert b"but 1 lines" in stripped_content
     assert b"igNORe-cAse text" not in stripped_content
     assert b"but 1234 lines" not in stripped_content
-
+    assert b"really" not in stripped_content

--- a/changedetectionio/tests/test_ignore_regex_text.py
+++ b/changedetectionio/tests/test_ignore_regex_text.py
@@ -17,6 +17,7 @@ def test_strip_regex_text_func():
     but 1 lines
     skip 5 lines
     really? yes man
+    /not this
     but including 1234 lines
     igNORe-cAse text we dont want to keep    
     but not always."""
@@ -27,7 +28,8 @@ def test_strip_regex_text_func():
         "/\s\d{2,3}\s/",
         "/ignore-case text/",
         "really?",
-        "/skip \d lines/i"
+        "/skip \d lines/i",
+        "/not"
     ]
 
 
@@ -38,3 +40,4 @@ def test_strip_regex_text_func():
     assert b"igNORe-cAse text" not in stripped_content
     assert b"but 1234 lines" not in stripped_content
     assert b"really" not in stripped_content
+    assert b"not this" not in stripped_content

--- a/changedetectionio/tests/test_ignore_regex_text.py
+++ b/changedetectionio/tests/test_ignore_regex_text.py
@@ -42,3 +42,8 @@ def test_strip_regex_text_func():
     assert b"but 1234 lines" not in stripped_content
     assert b"really" not in stripped_content
     assert b"not this" not in stripped_content
+
+    # Check line number reporting
+    stripped_content = html_tools.strip_ignore_text(test_content, ignore_lines, mode="line numbers")
+    assert stripped_content == [2, 5, 6, 7, 8, 10]
+

--- a/changedetectionio/tests/test_ignore_regex_text.py
+++ b/changedetectionio/tests/test_ignore_regex_text.py
@@ -17,7 +17,8 @@ def test_strip_regex_text_func():
     but 1 lines
     skip 5 lines
     really? yes man
-    /not this
+#/not this tries weirdly formed regex or just strings starting with /
+/not this
     but including 1234 lines
     igNORe-cAse text we dont want to keep    
     but not always."""


### PR DESCRIPTION
Closes #1745 
Closes #1757

- [x] Needs a test added for `/is` etc, or maybe theres one already?
- [x] Use pre-compiled regex for less CPU overhead
