### PR TITLE
requirements/chore: Enable jq package installation on platforms except…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,6 @@ jsonpath-ng~=1.5.3
 # * https://datastax-oss.atlassian.net/browse/PYTHON-1320
 dnspython<2.3.0
 
-# jq not available on Windows so must be installed manually
-
 # Notification library
 apprise~=1.4.5
 
@@ -63,7 +61,8 @@ jinja2-time
 
 # https://peps.python.org/pep-0508/#environment-markers
 # https://github.com/dgtlmoon/changedetection.io/pull/1009
-jq~=1.3 ;python_version >= "3.8" and sys_platform == "linux"
+# jq not available on Windows so must be installed manually
+jq~=1.3 ;python_version >= "3.8" and sys_platform != "win32"
 
 # Any current modern version, required so far for screenshot PNG->JPEG conversion but will be used more in the future
 pillow


### PR DESCRIPTION
… Windows.

jq supports darwin(macos) too. See [jq.py installation](https://github.com/mwilliamson/jq.py#installation)
> Wheels are built for various Python versions and architectures on Linux and Mac OS X.

See also: [Is it safe to use sys.platform=='win32' check on 64-bit Python?](https://stackoverflow.com/a/2145582/20307768)

tested on
<img width="839" alt="image" src="https://github.com/dgtlmoon/changedetection.io/assets/61624808/8a2854d6-ae17-47db-b894-b730fe3240d3">

and mac os.
