### PR TITLE
feat: Support XPath2.0-3.1

### DIFF
--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -318,10 +318,13 @@ class ValidateCSSJSONXPATHInput(object):
                 if not self.allow_xpath:
                     raise ValidationError("XPath not permitted in this field!")
                 from lxml import etree, html
+                import elementpath
+                # xpath 2.0-3.1
+                from elementpath.xpath3 import XPath3Parser
                 tree = html.fromstring("<html></html>")
 
                 try:
-                    tree.xpath(line.strip())
+                    elementpath.select(tree, line.strip(), parser=XPath3Parser)
                 except etree.XPathEvalError as e:
                     message = field.gettext('\'%s\' is not a valid XPath expression. (%s)')
                     raise ValidationError(message % (line, str(e)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,9 @@ beautifulsoup4
 # XPath filtering, lxml is required by bs4 anyway, but put it here to be safe.
 lxml
 
+# XPath 2.0-3.1 support
+elementpath
+
 # 3.141 was missing socksVersion, 3.150 was not in pypi, so we try 4.1.0
 selenium~=4.1.0
 


### PR DESCRIPTION
[Is XPath 3.1 100% upwardly compatible with XPath 2.0?](https://stackoverflow.com/a/62438044/20307768)
[What are the differences between versions of XPath (1.0, 2.0, 3.1)](https://stackoverflow.com/a/51377660/20307768)

This update allows syntax like this.
`//*[matches(@id,"container")]/section[1]/article[2]/div[2]/table/tbody/tr[position()>3]/td[2]/a[1]`

I didn't catch or test other 3.1 functions.
Also because of incompatibility(1.0 vs 2.0), something works differently.

#1631 