### PR TITLE
Add Raspberry Pi test workflow

### DIFF
--- a/.github/test/Dockerfile-raspberrypi
+++ b/.github/test/Dockerfile-raspberrypi
@@ -1,0 +1,28 @@
+# pip dependencies install stage
+FROM python:3.9-slim-bullseye as builder
+
+# See `cryptography` pin comment in requirements.txt
+ARG CRYPTOGRAPHY_DONT_BUILD_RUST=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    gcc \
+    libc-dev \
+    libffi-dev \
+    libjpeg-dev \
+    libssl-dev \
+    libxslt-dev \
+    make \
+    zlib1g-dev
+
+RUN mkdir /install
+WORKDIR /install
+
+COPY requirements.txt /requirements.txt
+
+# Instructing pip to fetch wheels from piwheels.org" on ARMv6 and ARMv7 machines
+RUN if [ "$(dpkg --print-architecture)" = "armhf" ] || [ "$(dpkg --print-architecture)" = "armel" ]; then \
+      printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf; \
+    fi;
+
+RUN pip install --target=/dependencies -r /requirements.txt

--- a/.github/workflows/test-container-build.yml
+++ b/.github/workflows/test-container-build.yml
@@ -55,6 +55,14 @@ jobs:
             file: ./.github/test/Dockerfile-alpine
             platforms: linux/amd64,linux/arm64
 
+        - name: Test that the docker containers can build (Raspberry Pi)
+          id: docker_build_rpi
+          uses: docker/build-push-action@v2
+          with:
+            context: ./
+            file: ./.github/test/Dockerfile-raspberrypi
+            platforms: linux/arm/v6,linux/arm/v7
+
         - name: Test that the docker containers can build
           id: docker_build
           uses: docker/build-push-action@v2
@@ -62,7 +70,7 @@ jobs:
           with:
             context: ./
             file: ./Dockerfile
-            platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm/v8
+            platforms: linux/amd64,linux/arm64,linux/arm/v8
             cache-from: type=local,src=/tmp/.buildx-cache
             cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Changes to better represent builds on Raspberry Pi:

Raspberry Pi OS defaults to Python 3.9 (bullseye) and armv6/armv7 wheels are available on piwheels only for Python 3.9, Python 3.7 (buster) and soon Python 3.11 (bookworm).

Building/upload to Docker Hub action (build-push-containers) fails due to Python 3.10 being set on `Dockerfile` as default.

Is it possible to have a different Dockerfile for linux/arm/v6 and linux/arm/v7 (set to Python 3.9) and merge with the default Dockerfile for linux/amd64, linux/arm64 and linux/arm/v8 (set to Python 3.10)?

Maybe something like [this](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)?