### PR TITLE
html_tools/fix: Let etree decide file type and encoding.

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -53,7 +53,11 @@ def element_removal(selectors: List[str], html_content):
 def xpath_filter(xpath_filter, html_content, append_pretty_line_formatting=False):
     from lxml import etree, html
 
-    tree = html.fromstring(bytes(html_content, encoding='utf-8'))
+    try:
+        tree = etree.HTML(html_content)
+    except:
+        #Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
+        tree = html.fromstring(bytes(html_content, encoding='utf-8'))
     html_block = ""
 
     r = tree.xpath(xpath_filter.strip(), namespaces={'re': 'http://exslt.org/regular-expressions'})

--- a/changedetectionio/tests/test_xpath_selector.py
+++ b/changedetectionio/tests/test_xpath_selector.py
@@ -277,3 +277,54 @@ def test_check_with_prefix_include_filters(client, live_server):
     assert b"Some text that will change" not in res.data #not in selector
 
     client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+
+
+def test_non_UTF_8_XPath_double_encoded(client, live_server):
+    res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+    assert b'Deleted' in res.data
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # A poorly configured non-utf-8 HTML of server-side.
+    d = b'<html lang="ko">\n<head>\n<met'
+    d += b'a http-equiv="Content-Type" c'
+    d += b'ontent="text/html; charset=EUC'
+    d += b'-KR">\n<style>\np {\n  @charset'
+    d += b' EUC-KR;\n  color: orange;\n  }'
+    d += b'\n</style>\n</head>\n<body>\n<p>'
+    d += b'\xc8\xa5\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd '
+    d += b'\xef\xbf\xbd\xe7\xbf\xac\xef\xbf\xbd\xcf\xb4\xef\xbf\xbd.<'
+    d += b'/p>\n<p>Chaos is natural.</p>\n</body>\n</html>\n'
+
+    with open("test-datastore/endpoint-content.txt", "wb") as f:
+        f.write(d)
+
+    # Add our URL to the import page
+    test_url = url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    time.sleep(3)
+
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"include_filters":  "xpath://p", "url": test_url, "tags": "", "headers": "", 'fetch_backend': "html_requests"},
+        follow_redirects=True
+    )
+
+    assert b"Updated watch." in res.data
+    time.sleep(3)
+
+    res = client.get(
+        url_for("preview_page", uuid="first"),
+        follow_redirects=True
+    )
+    # b'\xed\x98\xbc\xe5\x8d\xa0\xec\x8f\x99\xec\x98\x99\xe5\x8d\xa0\xec\x8f\x99\xec\x98\x99 \xe5\x8d\xa0\xec\x8d\xb9\xec\x97\xb0\xe5\x8d\xa0\xec\x8b\xb9\xeb\x8c\x90\xec\x98\x99.' is a wrong encoding result.
+    # Above wrong answer is `answer_below.decode('euc-kr').encode('utf-8')`.
+    assert b'\xc8\xa5\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd \xef\xbf\xbd\xe7\xbf\xac\xef\xbf\xbd\xcf\xb4\xef\xbf\xbd.' in res.data #in selector
+
+    client.get(url_for("form_delete", uuid="all"), follow_redirects=True)


### PR DESCRIPTION
closes #1044 #1546
Fix broken text encoding when using XPath