### PR TITLE
Update README.md docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ Please :star: star :star: this project and help it grow! https://github.com/dgtl
 With Docker composer, just clone this repository and..
 
 ```bash
+# if you are using docker composer v2 (from 2020 and up)
 docker compose up -d
+
+# if you still on docker composer v1
+# (note: docker composer v1 no longer receive update after July 2023)
+docker-compose up -d
 ```
 
 Docker standalone
@@ -139,6 +144,10 @@ docker run -d --restart always -p "127.0.0.1:5000:5000" -v datastore-volume:/dat
 ### Docker Compose
 
 ```bash
+# docker composer v1
+docker-compose pull && docker-compose up -d
+
+# docker composer v2
 docker compose pull && docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ Please :star: star :star: this project and help it grow! https://github.com/dgtl
 With Docker composer, just clone this repository and..
 
 ```bash
-$ docker-compose up -d
+docker compose up -d
 ```
 
 Docker standalone
 ```bash
-$ docker run -d --restart always -p "127.0.0.1:5000:5000" -v datastore-volume:/datastore --name changedetection.io dgtlmoon/changedetection.io
+docker run -d --restart always -p "127.0.0.1:5000:5000" -v datastore-volume:/datastore --name changedetection.io dgtlmoon/changedetection.io
 ```
 
 `:latest` tag is our latest stable release, `:dev` tag is our bleeding edge `master` branch.
@@ -136,10 +136,10 @@ docker rm $(docker ps -a -f name=changedetection.io -q)
 docker run -d --restart always -p "127.0.0.1:5000:5000" -v datastore-volume:/datastore --name changedetection.io dgtlmoon/changedetection.io
 ```
 
-### docker-compose
+### Docker Compose
 
 ```bash
-docker-compose pull && docker-compose up -d
+docker compose pull && docker compose up -d
 ```
 
 See the wiki for more information https://github.com/dgtlmoon/changedetection.io/wiki


### PR DESCRIPTION
- in newer docker version, they include compose into docker, in fact, `docker-compose` would be hard to install on ubuntu (can only install old version), see https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2
- also I remove `$` character since github have copy button, it would copy `$` and I have to manually remove it.