### PR TITLE
Add piwheels support for ARMv6 and ARMv7 machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ WORKDIR /install
 
 COPY requirements.txt /requirements.txt
 
+# Instructing pip to fetch wheels from piwheels.org" on ARMv6 and ARMv7 machines
+RUN if [ "$(dpkg --print-architecture)" = "armhf" ] || [ "$(dpkg --print-architecture)" = "armel" ]; then \
+      printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf; \
+    fi;
+
 RUN pip install --target=/dependencies -r /requirements.txt
 
 # Playwright is an alternative to Selenium


### PR DESCRIPTION
Prebuilt armv6/armv7 wheels are available on piwheels for Python 3.7 (buster), Python 3.9 (bullseye) and soon Python 3.11 (bookworm).

In the future, when changedetection supports Python 3.11 we can unpin some requirements (in requirements.txt) and the build workflow won't fail due to missing Rust (it is required to compile some wheels like `rpds-py`).

(This is a repost of #1782)