### PR TITLE
util/fix: Improve testability by reading a file(endpoint-content) as bytes.

### DIFF
--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -161,7 +161,8 @@ def live_server_setup(live_server):
                 return resp
 
             # Tried using a global var here but didn't seem to work, so reading from a file instead.
-            with open("test-datastore/endpoint-content.txt", "r") as f:
+            # 'rb' allows us to test a web page with weird encoding.
+            with open("test-datastore/endpoint-content.txt", "rb") as f:
                 resp = make_response(f.read(), status_code)
                 if uppercase_headers:
                     resp.headers['CONTENT-TYPE'] = ctype if ctype else 'text/html'


### PR DESCRIPTION
The contained test case will prove the usage.
EDIT: https://github.com/dgtlmoon/changedetection.io/pull/1835 replaces #1790 


~~The new code for #1790 requires this commit to test.~~

~~I wrote new codes for https://github.com/dgtlmoon/changedetection.io/pull/1790, but I haven't published them yet. I'm writing test codes right now.~~

~~There are some points you consider and I need help with the new commit of #1790 that I will publish today.~~

