### PR TITLE
html_tools/fix: Fix double encoding, use bytes data if possible, support XML

### DIFF
--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -73,8 +73,10 @@ def is_safe_url(test_url):
 
     # Remove 'source:' prefix so we dont get 'source:javascript:' etc
     # 'source:' is a valid way to tell us to return the source
+    special_document_prefix = ['source:','xml:']
+    re_escape_pattern = '|'.join(map(re.escape, special_document_prefix))
 
-    r = re.compile(re.escape('source:'), re.IGNORECASE)
+    r = re.compile(re_escape_pattern, re.IGNORECASE)
     test_url = r.sub('', test_url)
 
     pattern = re.compile(os.getenv('SAFE_PROTOCOL_REGEX', SAFE_PROTOCOL_REGEX), re.IGNORECASE)

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -164,7 +164,8 @@ class perform_site_check(difference_detection_processor):
             is_html = False
             is_json = False
 
-        if watch.is_pdf or 'application/pdf' in fetcher.get_all_headers().get('content-type', '').lower():
+        is_pdf = watch.is_pdf or 'application/pdf' in fetcher.get_all_headers().get('content-type', '').lower()
+        if is_pdf:
             from shutil import which
             tool = os.getenv("PDF_TO_HTML_TOOL", "pdftohtml")
             if not which(tool):
@@ -241,7 +242,7 @@ class perform_site_check(difference_detection_processor):
                 # FYI, There is no intersection between is_html, is_json, is_binary, is_source.
                 # If child class(driver) of class Fetcher provides binary data, use it.
                 # This is for non filter.
-                if is_html and hasattr(fetcher, 'raw_content'):
+                if is_html and hasattr(fetcher, 'raw_content') and not is_pdf:
                     from bs4 import BeautifulSoup
 
                     if is_xml:
@@ -265,7 +266,7 @@ class perform_site_check(difference_detection_processor):
                         if filter_rule[0] == '/' or filter_rule.startswith('xpath:'):
                             # Use bytes content if the driver provides.
                             # Some fetcher driver(html_requests) provides raw_content of binary type.
-                            if hasattr(fetcher, 'raw_content'):
+                            if hasattr(fetcher, 'raw_content') and not is_pdf:
                                 fetcher_content = fetcher.raw_content
                             else:
                                 fetcher_content = fetcher.content

--- a/changedetectionio/tests/test_xpath_selector.py
+++ b/changedetectionio/tests/test_xpath_selector.py
@@ -277,3 +277,140 @@ def test_check_with_prefix_include_filters(client, live_server):
     assert b"Some text that will change" not in res.data #not in selector
 
     client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+
+def test_XML_but_with_html_parser(client, live_server):
+    '''
+    the case HTML parser goes wrong with XML.
+    '''
+    res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+    assert b'Deleted' in res.data
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    d = b"<?xml version='1.0' encoding='UTF-8'?><note><from>Melissa</from><to>Constantin</to><body>The document you asked for</body></note>"
+
+    with open("test-datastore/endpoint-content.txt", "wb") as f:
+        f.write(d)
+
+    # Add our URL to the import page
+    test_url = url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    time.sleep(3)
+
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"include_filters":  "xpath://body", "url": test_url, "tags": "", "headers": "", 'fetch_backend': "html_requests"},
+        follow_redirects=True
+    )
+
+    assert b"Updated watch." in res.data
+    time.sleep(3)
+
+    res = client.get(
+        url_for("preview_page", uuid="first"),
+        follow_redirects=True
+    )
+
+    # XPATH pattern was //body. But default HTML parser fix body in the content.
+    # So In specific case for XML, user needs 'xml:' tag.
+    # https://stackoverflow.com/a/5642982/20307768
+    assert b'MelissaConstantinThe' in res.data # in selector
+    client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+
+def test_XML_with_xml_flag(client, live_server):
+    res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+    assert b'Deleted' in res.data
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    d = b"<?xml version='1.0' encoding='UTF-8'?><note><from>Melissa</from><to>Constantin</to><body>The document you asked for</body></note>"
+
+    with open("test-datastore/endpoint-content.txt", "wb") as f:
+        f.write(d)
+
+    # Add our URL to the import page
+    test_url = 'xml:'+url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    time.sleep(3)
+
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"include_filters":  "xpath://body", "url": test_url, "tags": "", "headers": "", 'fetch_backend': "html_requests"},
+        follow_redirects=True
+    )
+
+    assert b"Updated watch." in res.data
+    time.sleep(3)
+
+    res = client.get(
+        url_for("preview_page", uuid="first"),
+        follow_redirects=True
+    )
+
+    assert b'MelissaConstantinThe' not in res.data #not in selector
+    assert b'Melissa' not in res.data #not in selector
+    assert b'Constantin' not in res.data #not in selector
+    assert b'The document you asked for' in res.data #in selector
+
+    client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+
+def test_soup_html_requests_bytes_healing_encoding(client, live_server):
+    res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
+    assert b'Deleted' in res.data
+
+    # Give the endpoint time to spin up
+    time.sleep(1)
+
+    # A poorly configured non-UTF-8 HTML of server-side.
+    # This cannot be read without open() with bytes option on server side.
+    d = b'<html lang="ko">\n<head>\n<meta http-equiv="Content-Type" content="text/html; charset=EUC-KR">\n<style>\np {\n  @charset EUC-KR;\n  color: orange;\n  }\n</style>\n</head>\n<body>\n<p>\xc8\xa5\xb5\xb7\xc0\xba \xb4\xe7\xbf\xac\xc7\xcf\xb4\xd9..</p>\n<p>Chaos is natural.</p>\n</body>\n</html>\n'
+
+    # This file cannot be read with UTF-8.
+    with open("test-datastore/endpoint-content.txt", "wb") as f:
+        f.write(d)
+
+    # Add our URL to the import page
+    test_url = url_for('test_endpoint', _external=True)
+    res = client.post(
+        url_for("import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    time.sleep(3)
+
+    res = client.post(
+        url_for("edit_page", uuid="first"),
+        data={"include_filters":  "xpath://p", "url": test_url, "tags": "", "headers": "", 'fetch_backend': "html_requests"},
+        follow_redirects=True
+    )
+
+    assert b"Updated watch." in res.data
+    time.sleep(3)
+
+    res = client.get(
+        url_for("preview_page", uuid="first"),
+        follow_redirects=True
+    )
+    import sys
+    print('###res.data###', file=sys.stderr)
+    print(res.data, file=sys.stderr)
+    print('###res.data###', file=sys.stderr)
+
+    # b'\xc8\xa5\xb5\xb7\xc0\xba \xb4\xe7\xbf\xac\xc7\xcf\xb4\xd9' (EUC-KR?)becomes below.
+    # '혼돈은 당연하다'.encode()
+    assert b'\xed\x98\xbc\xeb\x8f\x88\xec\x9d\x80 \xeb\x8b\xb9\xec\x97\xb0\xed\x95\x98\xeb\x8b\xa4' in res.data #in selector
+
+    client.get(url_for("form_delete", uuid="all"), follow_redirects=True)

--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -161,7 +161,7 @@ def live_server_setup(live_server):
                 return resp
 
             # Tried using a global var here but didn't seem to work, so reading from a file instead.
-            with open("test-datastore/endpoint-content.txt", "r") as f:
+            with open("test-datastore/endpoint-content.txt", "rb") as f:
                 resp = make_response(f.read(), status_code)
                 if uppercase_headers:
                     resp.headers['CONTENT-TYPE'] = ctype if ctype else 'text/html'


### PR DESCRIPTION
commit 37925e32f6921b3b08a01b23e6f821c2ee63187a
Author: Constantin Hong <hongconstantin@gmail.com>
Date:   Tue Oct 3 03:37:58 2023 +0900

    html_tools/fix: Fix double encoding, use bytes data if possible, support XML
    Use the best material(bytes) whenever possible.
    Web browsers render html files with their own policies. the default
    Chrome doesn't show the raw HTML response body. the one we use is
    already rendered(shredded).
    Also, the playwright doesn't provide raw html sources via their python
    lib.(https://playwright.dev/python/docs/api/class-page#page-content)
    Therefore playwright will show the rendered HTML source, which means the
    wrong encoded source is not recoverable when a user uses
    'fetch_backend': 'html_webdriver'.
    But, we don't have to mind it. Because of Chrome's market share, wrong
    encoded sites are continuously decreasing.
    So, In this case, This commit prevents wrong double encoding via letting
    etree decide.

    If the user uses webdriver to get XML without an XML-stylesheet tag,
    it's not XML but HTML.(check with your browser) If XML has an XML-stylesheet
    tag, the browser shows the document as an XML.

    'xml:'
    If we let bs4 decide file types, when it goes wrong, user might
    test two cases 'xml:' and 'html:'(for xhtml) manually. But If we consider the
    content as HTML only, the user only needs to test 'xml:'


Also, this PR contains demonstration purpose commit. the commit will be https://github.com/dgtlmoon/changedetection.io/pull/1832 (This PR requires https://github.com/dgtlmoon/changedetection.io/pull/1832.)
This PR replaces https://github.com/dgtlmoon/changedetection.io/pull/1790

closes https://github.com/dgtlmoon/changedetection.io/issues/1044 https://github.com/dgtlmoon/changedetection.io/issues/1546