### PR TITLE
fix: service restart on changedetection memory leak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,12 @@ services:
       # Comment out ports: when using behind a reverse proxy , enable networks: etc.
       ports:
         - 5000:5000
+      deploy:
+        resources:
+          limits:
+            memory: 1G
+        restart_policy:
+          condition: on-failure
       restart: unless-stopped
 
      # Used for fetching pages via WebDriver+Chrome where you need Javascript support.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,12 +54,14 @@ services:
       # Comment out ports: when using behind a reverse proxy , enable networks: etc.
       ports:
         - 5000:5000
-      deploy:
-        resources:
-          limits:
-            memory: 1G
-        restart_policy:
-          condition: on-failure
+#      # Workaround to fix memory leak
+#      # See https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher#playwright-memory-leak
+#      deploy:
+#        resources:
+#          limits:
+#            memory: 1G
+#        restart_policy:
+#          condition: on-failure
       restart: unless-stopped
 
      # Used for fetching pages via WebDriver+Chrome where you need Javascript support.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,5 +89,27 @@ services:
 #      # Ignore HTTPS errors, like for self-signed certs
 #      - DEFAULT_IGNORE_HTTPS_ERRORS=true
 
+
+#  # Workaround to fix changedetection memory leak
+#  restarter:
+#    image: docker:cli
+#    environment:
+#      - APP_SERVICE_NAME=changedetection
+#      - APP_RESTART_TIME=05:00 # HH:MM
+#      - APP_CHECK_DELAY=60 # seconds
+#    volumes:
+#      - /var/run/docker.sock:/var/run/docker.sock
+#    entrypoint: [ "/bin/sh","-c" ]
+#    command:
+#      - |
+#        while true; do
+#          if [ "$(date +'%H:%M')" = '$${APP_RESTART_TIME}' ]; then
+#            docker restart $${APP_SERVICE_NAME}
+#            echo "$(date) Docker service restart: $${APP_SERVICE_NAME}"
+#          fi
+#          sleep $${APP_CHECK_DELAY}
+#        done
+#    restart: unless-stopped
+
 volumes:
   changedetection-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,114 +1,101 @@
 version: '3.2'
+
 services:
-    changedetection:
-      image: ghcr.io/dgtlmoon/changedetection.io
-      container_name: changedetection
-      hostname: changedetection
-      volumes:
-        - changedetection-data:/datastore
-# Configurable proxy list support, see https://github.com/dgtlmoon/changedetection.io/wiki/Proxy-configuration#proxy-list-support
-#        - ./proxies.json:/datastore/proxies.json
-
-  #    environment:
-  #        Default listening port, can also be changed with the -p option
-  #      - PORT=5000
-
-  #      - PUID=1000
-  #      - PGID=1000
-  #
-  #       Alternative WebDriver/selenium URL, do not use "'s or 's!
-  #      - WEBDRIVER_URL=http://browser-chrome:4444/wd/hub
-  #
-  #       WebDriver proxy settings webdriver_proxyType, webdriver_ftpProxy, webdriver_noProxy,
-  #                                webdriver_proxyAutoconfigUrl, webdriver_autodetect,
-  #                                webdriver_socksProxy, webdriver_socksUsername, webdriver_socksVersion, webdriver_socksPassword
-  #
-  #             https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.common.proxy
-  #
-  #       Alternative Playwright URL, do not use "'s or 's!
-  #      - PLAYWRIGHT_DRIVER_URL=ws://playwright-chrome:3000/?stealth=1&--disable-web-security=true
-  #
-  #       Playwright proxy settings playwright_proxy_server, playwright_proxy_bypass, playwright_proxy_username, playwright_proxy_password
-  #
-  #             https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-option-proxy
-  #
-  #        Plain requests - proxy support example.
-  #      - HTTP_PROXY=socks5h://10.10.1.10:1080
-  #      - HTTPS_PROXY=socks5h://10.10.1.10:1080
-  #
-  #        An exclude list (useful for notification URLs above) can be specified by with
-  #      - NO_PROXY="localhost,192.168.0.0/24"
-  #
-  #        Base URL of your changedetection.io install (Added to the notification alert)
-  #      - BASE_URL=https://mysite.com
-  #        Respect proxy_pass type settings, `proxy_set_header Host "localhost";` and `proxy_set_header X-Forwarded-Prefix /app;`
-  #        More here https://github.com/dgtlmoon/changedetection.io/wiki/Running-changedetection.io-behind-a-reverse-proxy-sub-directory
-  #      - USE_X_SETTINGS=1
-  #
-  #        Hides the `Referer` header so that monitored websites can't see the changedetection.io hostname.
-  #      - HIDE_REFERER=true
-  #        
-  #        Default number of parallel/concurrent fetchers
-  #      - FETCH_WORKERS=10
-
-      # Comment out ports: when using behind a reverse proxy , enable networks: etc.
-      ports:
-        - 5000:5000
-#      # Workaround to fix memory leak
-#      # See https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher#playwright-memory-leak
-#      deploy:
-#        resources:
-#          limits:
-#            memory: 1G
-#        restart_policy:
-#          condition: on-failure
-      restart: unless-stopped
-
-     # Used for fetching pages via WebDriver+Chrome where you need Javascript support.
-     # Now working on arm64 (needs testing on rPi - tested on Oracle ARM instance)
-     # replace image with seleniarm/standalone-chromium:4.0.0-20211213
-     
-     # If WEBDRIVER or PLAYWRIGHT are enabled, changedetection container depends on that
-     # and must wait before starting (substitute "browser-chrome" with "playwright-chrome" if last one is used)
+  changedetection:
+    image: ghcr.io/dgtlmoon/changedetection.io
+    container_name: changedetection
+    hostname: changedetection
+#    environment:
+#      # Default listening port, can also be changed with the -p option
+#      - PORT=5000
+#      # User id
+#      - PUID=1000
+#      # Group id
+#      - PGID=1000
+#      # Alternative WebDriver/selenium URL, do not use "'s or 's!
+#      # WebDriver proxy settings: webdriver_proxyType, webdriver_ftpProxy, webdriver_noProxy,
+#      #                           webdriver_proxyAutoconfigUrl, webdriver_autodetect, webdriver_socksProxy,
+#      #                           webdriver_socksUsername, webdriver_socksVersion, webdriver_socksPassword
+#      # https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.common.proxy
+#      - WEBDRIVER_URL=http://browser-chrome:4444/wd/hub
+#      # Alternative Playwright URL, do not use "'s or 's!
+#      # Playwright proxy settings: playwright_proxy_server, playwright_proxy_bypass, playwright_proxy_username,
+#      #                            playwright_proxy_password
+#      # https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-option-proxy
+#      - PLAYWRIGHT_DRIVER_URL=ws://playwright-chrome:3000/?stealth=1&--disable-web-security=true
+#      # Plain requests - proxy support example.
+#      - HTTP_PROXY=socks5h://10.10.1.10:1080
+#      - HTTPS_PROXY=socks5h://10.10.1.10:1080
+#      # An exclude list (useful for notification URLs above) can be specified by with
+#      - NO_PROXY="localhost,192.168.0.0/24"
+#
+#      # Base URL of your changedetection.io install (Added to the notification alert)
+#      - BASE_URL=https://mysite.com
+#      # Respect proxy_pass type settings, `proxy_set_header Host "localhost";` and `proxy_set_header X-Forwarded-Prefix /app;`
+#      # More here https://github.com/dgtlmoon/changedetection.io/wiki/Running-changedetection.io-behind-a-reverse-proxy-sub-directory
+#      - USE_X_SETTINGS=1
+#      # Hides the `Referer` header so that monitored websites can't see the changedetection.io hostname.
+#      - HIDE_REFERER=true
+#      # Default number of parallel/concurrent fetchers
+#      - FETCH_WORKERS=10
+    # Comment out ports: when using behind a reverse proxy , enable networks: etc.
+    ports:
+      - 5000:5000
+    volumes:
+      - changedetection-data:/datastore
+#      # Configurable proxy list support, see https://github.com/dgtlmoon/changedetection.io/wiki/Proxy-configuration#proxy-list-support
+#      - ./proxies.json:/datastore/proxies.json
+    # Workaround to fix memory leak
+    # See https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher#playwright-memory-leak
+#    deploy:
+#      resources:
+#        limits:
+#          memory: 1G
+#      restart_policy:
+#        condition: on-failure
+#    restart: unless-stopped
+    # Used for fetching pages via WebDriver+Chrome where you need Javascript support.
+    # Now working on arm64 (needs testing on rPi - tested on Oracle ARM instance)
+    # replace image with seleniarm/standalone-chromium:4.0.0-20211213
+    #
+    # If WEBDRIVER or PLAYWRIGHT are enabled, changedetection container depends on that
+    # and must wait before starting (substitute "browser-chrome" with "playwright-chrome" if last one is used)
 #    depends_on:
-#        browser-chrome:
-#            condition: service_started
+#      browser-chrome:
+#        condition: service_started
 
-#    browser-chrome:
-#        hostname: browser-chrome
-#        image: selenium/standalone-chrome-debug:3.141.59
-#        environment:
-#            - VNC_NO_PASSWORD=1
-#            - SCREEN_WIDTH=1920
-#            - SCREEN_HEIGHT=1080
-#            - SCREEN_DEPTH=24
-#        volumes:
-#            # Workaround to avoid the browser crashing inside a docker container
-#            # See https://github.com/SeleniumHQ/docker-selenium#quick-start
-#            - /dev/shm:/dev/shm
-#        restart: unless-stopped
+#  browser-chrome:
+#    hostname: browser-chrome
+#    image: selenium/standalone-chrome-debug:3.141.59
+#    environment:
+#      - VNC_NO_PASSWORD=1
+#      - SCREEN_WIDTH=1920
+#      - SCREEN_HEIGHT=1080
+#      - SCREEN_DEPTH=24
+#    volumes:
+#      # Workaround to avoid the browser crashing inside a docker container
+#      # See https://github.com/SeleniumHQ/docker-selenium#quick-start
+#      - /dev/shm:/dev/shm
+#    restart: unless-stopped
 
-     # Used for fetching pages via Playwright+Chrome where you need Javascript support.
+#  # Used for fetching pages via Playwright+Chrome where you need Javascript support.
+#  playwright-chrome:
+#    hostname: playwright-chrome
+#    image: browserless/chrome
+#    restart: unless-stopped
+#    environment:
+#      - SCREEN_WIDTH=1920
+#      - SCREEN_HEIGHT=1024
+#      - SCREEN_DEPTH=16
+#      - ENABLE_DEBUGGER=false
+#      - PREBOOT_CHROME=true
+#      - CONNECTION_TIMEOUT=300000
+#      - MAX_CONCURRENT_SESSIONS=10
+#      - CHROME_REFRESH_TIME=600000
+#      - DEFAULT_BLOCK_ADS=true
+#      - DEFAULT_STEALTH=true
+#      # Ignore HTTPS errors, like for self-signed certs
+#      - DEFAULT_IGNORE_HTTPS_ERRORS=true
 
-#    playwright-chrome:
-#        hostname: playwright-chrome
-#        image: browserless/chrome
-#        restart: unless-stopped
-#        environment:
-#            - SCREEN_WIDTH=1920
-#            - SCREEN_HEIGHT=1024
-#            - SCREEN_DEPTH=16
-#            - ENABLE_DEBUGGER=false
-#            - PREBOOT_CHROME=true
-#            - CONNECTION_TIMEOUT=300000
-#            - MAX_CONCURRENT_SESSIONS=10
-#            - CHROME_REFRESH_TIME=600000
-#            - DEFAULT_BLOCK_ADS=true
-#            - DEFAULT_STEALTH=true
-#
-#             Ignore HTTPS errors, like for self-signed certs
-#            - DEFAULT_IGNORE_HTTPS_ERRORS=true
-#
 volumes:
   changedetection-data:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,15 +45,7 @@ services:
       - changedetection-data:/datastore
 #      # Configurable proxy list support, see https://github.com/dgtlmoon/changedetection.io/wiki/Proxy-configuration#proxy-list-support
 #      - ./proxies.json:/datastore/proxies.json
-    # Workaround to fix memory leak
-    # See https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher#playwright-memory-leak
-#    deploy:
-#      resources:
-#        limits:
-#          memory: 1G
-#      restart_policy:
-#        condition: on-failure
-#    restart: unless-stopped
+    restart: unless-stopped
     # Used for fetching pages via WebDriver+Chrome where you need Javascript support.
     # Now working on arm64 (needs testing on rPi - tested on Oracle ARM instance)
     # replace image with seleniarm/standalone-chromium:4.0.0-20211213


### PR DESCRIPTION
Continuation from #1831

@dgtlmoon I introduced a workaround for the LXML parsing bug in a better way

It's simply a service that restarts the container each day at a certain hour