### PR TITLE
requirements/chore: Enable jq package installation for darwin(m…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,8 @@ jinja2-time
 
 # https://peps.python.org/pep-0508/#environment-markers
 # https://github.com/dgtlmoon/changedetection.io/pull/1009
-jq~=1.3 ;python_version >= "3.8" and sys_platform == "linux"
+jq~=1.3; python_version >= "3.8" and sys_platform == "linux"
+jq~=1.3; python_version >= "3.8" and sys_platform == "darwin"
 
 # Any current modern version, required so far for screenshot PNG->JPEG conversion but will be used more in the future
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,8 +63,8 @@ jinja2-time
 
 # https://peps.python.org/pep-0508/#environment-markers
 # https://github.com/dgtlmoon/changedetection.io/pull/1009
-jq~=1.3; python_version >= "3.8" and sys_platform == "linux"
 jq~=1.3; python_version >= "3.8" and sys_platform == "darwin"
+jq~=1.3; python_version >= "3.8" and sys_platform == "linux"
 
 # Any current modern version, required so far for screenshot PNG->JPEG conversion but will be used more in the future
 pillow


### PR DESCRIPTION
…acOS)

https://github.com/mwilliamson/jq.py#installation
> Wheels are built for various Python versions and architectures on Linux and Mac OS X. On these platforms, you should be able to install jq with a normal pip install