### PR TITLE
DEFAULT_BLOCK_ADS=false / Fix Issue #1536 / Update docker-compose.yml 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
 #            - CONNECTION_TIMEOUT=300000
 #            - MAX_CONCURRENT_SESSIONS=10
 #            - CHROME_REFRESH_TIME=600000
-#            - DEFAULT_BLOCK_ADS=true
+#            - DEFAULT_BLOCK_ADS=false
 #            - DEFAULT_STEALTH=true
 #
 #             Ignore HTTPS errors, like for self-signed certs


### PR DESCRIPTION
The Env Variable "DEFAULT_BLOCK_ADS=true" seems to cause "Timeout 30000ms exceeded taking page screenshot" errors with playwright fetches on more complex sites. 
Issue is described here: https://github.com/dgtlmoon/changedetection.io/issues/1536 
As suggested in https://github.com/dgtlmoon/changedetection.io/issues/1536#issuecomment-1624918142 Setting the variable to "DEFAULT_BLOCK_ADS=false" fixes this Issue.