### PR TITLE
Documentation - Replace depreciated selenium/standalone-chrome-debug …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
 
 #    browser-chrome:
 #        hostname: browser-chrome
-#        image: selenium/standalone-chrome-debug:3.141.59
+#        image: selenium/standalone-chrome:latest
 #        environment:
 #            - VNC_NO_PASSWORD=1
 #            - SCREEN_WIDTH=1920


### PR DESCRIPTION
…with standalone-chrome

selenium/standalone-chrome-debug has been depreciated for 2 years, the non "-debug" version is frequently updated and appears to be compatible with my testing