### PR TITLE
Visual Selector - Improving elements fetcher reliability

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -1208,8 +1208,7 @@ def changedetection_app(config=None, datastore_o=None):
             # These files should be in our subdirectory
             try:
                 # set nocache, set content-type
-                watch_dir = datastore_o.datastore_path + "/" + filename
-                response = make_response(send_from_directory(filename="elements.json", directory=watch_dir, path=watch_dir + "/elements.json"))
+                response = make_response(send_from_directory(os.path.join(datastore_o.datastore_path, filename), "elements.json"))
                 response.headers['Content-type'] = 'application/json'
                 response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
                 response.headers['Pragma'] = 'no-cache'

--- a/changedetectionio/tests/visualselector/test_fetch_data.py
+++ b/changedetectionio/tests/visualselector/test_fetch_data.py
@@ -57,6 +57,8 @@ def test_visual_selector_content_ready(client, live_server):
     # Attempt to fetch it via the web hook that the browser would use
     res = client.get(url_for('static_content', group='visual_selector_data', filename=uuid))
     json.loads(res.data)
+    assert res.mimetype == 'application/json'
+    assert res.status_code == 200
 
 
     # Some options should be enabled

--- a/changedetectionio/tests/visualselector/test_fetch_data.py
+++ b/changedetectionio/tests/visualselector/test_fetch_data.py
@@ -54,6 +54,11 @@ def test_visual_selector_content_ready(client, live_server):
     with open(os.path.join('test-datastore', uuid, 'elements.json'), 'r') as f:
         json.load(f)
 
+    # Attempt to fetch it via the web hook that the browser would use
+    res = client.get(url_for('static_content', group='visual_selector_data', filename=uuid))
+    json.loads(res.data)
+
+
     # Some options should be enabled
     # @todo - in the future, the visibility should be toggled by JS from the request type setting
     res = client.get(


### PR DESCRIPTION
It was very strange that sometimes this would find the file, and sometimes return 404

This also helps to run on different platforms (correct OS path join, instead of hard-coded forward slash)