### PR TITLE
Revert "Add piwheels support for ARMv6 and ARMv7 machines"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,6 @@ WORKDIR /install
 
 COPY requirements.txt /requirements.txt
 
-# Instructing pip to fetch wheels from piwheels.org" on ARMv6 and ARMv7 machines
-RUN if [ "$(dpkg --print-architecture)" = "armhf" ] || [ "$(dpkg --print-architecture)" = "armel" ]; then \
-      printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf; \
-    fi;
-
 RUN pip install --target=/dependencies -r /requirements.txt
 
 # Playwright is an alternative to Selenium


### PR DESCRIPTION
Reverts to building packages as a part of GitHub actions.
I realized piwheels provides incompatible packages to the `python:3.11-slim-bookworm` Docker container used by changedetection, and this broke Docker releases on ARM devices.
I apologize for any inconvenience caused.