### PR TITLE
Fix container shutdown

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -105,8 +105,47 @@ jobs:
           
           # and IPv6
           curl -s -g -6 "http://[::1]:5556"|grep -q checkbox-uuid
+          docker kill test-changedetectionio
+
+      - name: Test changedetection.io SIGTERM and SIGINT signal shutdown
+        run: |
           
+          echo SIGINT Shutdown request test
+          docker run --name sig-test -d test-changedetectionio
+          sleep 3
+          echo ">>> Sending SIGINT to sig-test container"
+          docker kill --signal=SIGINT sig-test
+          sleep 3
+          # invert the check (it should be not 0/not running)
+          docker ps
+          docker logs sig-test
+          docker inspect --format '{{json .State.Running}}' sig-test
+          if [ $? -eq 0 ]
+          then
+            exit 1
+          fi
+          
+          # @todo - scan the container log to see the right "graceful shutdown" text exists 
+          docker rm sig-test
+          
+          echo SIGTERM Shutdown request test
+          docker run --name sig-test -d test-changedetectionio
+          sleep 3
+          echo ">>> Sending SIGTERM to sig-test container"
+          docker kill --signal=SIGTERM sig-test
+          sleep 3
+          # invert the check (it should be not 0/not running)
+          docker ps
+          docker logs sig-test
+          docker inspect --format '{{json .State.Running}}' sig-test
+          if [ $? -eq 0 ]
+          then
+            exit 1
+          fi
+          
+          # @todo - scan the container log to see the right "graceful shutdown" text exists           
+          docker rm sig-test
 
 #export WEBDRIVER_URL=http://localhost:4444/wd/hub
 #pytest tests/fetchers/test_content.py
-#pytest tests/test_errorhandling.py
+#pytest tests/test_errorhandling.py          

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ COPY --from=builder /dependencies /usr/local
 ENV PYTHONPATH=/usr/local
 
 EXPOSE 5000
+
+# Send the SIGINT signal because SIGTERM gets ignored
 STOPSIGNAL SIGINT
 
 # The actual flask app

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=builder /dependencies /usr/local
 ENV PYTHONPATH=/usr/local
 
 EXPOSE 5000
+STOPSIGNAL SIGINT
 
 # The actual flask app
 COPY changedetectionio /app/changedetectionio


### PR DESCRIPTION
I have a longstanding issue that this container does not respond to the SIGTERM signal that Docker sends when trying to stop a container.

The result is that it always get killed after a timeout, which may lead to all kinds of problems like corrupted files, etc.

I noticed that although there is no handling for SIGTERM in the code, there is a handler for keyboard interrupts (CTRL+C).

So this pull-request changes the Dockerfile so that the container will receive a SIGINT (CTRL+C) instead of a SIGTERM. My hope is that this fixes the problem, but I did not test it.

The best solution would be to add a handler that prints a message and exits on SIGTERM. But I have zero knowledge about Python, so modifying the Dockerfile is the best I could do.

Fixes: https://github.com/dgtlmoon/changedetection.io/issues/1632