### PR TITLE
Fixing support for headers in custom post://, posts:// etc notifications

### DIFF
--- a/changedetectionio/notification.py
+++ b/changedetectionio/notification.py
@@ -90,7 +90,6 @@ def apprise_custom_api_call_wrapper(body, title, notify_type, *args, **kwargs):
             if not k.strip('+-') in results['qsd+'].keys():
                 params[URLBase.unquote(k)] = URLBase.unquote(v)
 
-
         # Determine Authentication
         auth = ''
         if results.get('user') and results.get('password'):
@@ -106,10 +105,10 @@ def apprise_custom_api_call_wrapper(body, title, notify_type, *args, **kwargs):
         pass
 
     r(results.get('url'),
-      headers=headers,
+      auth=auth,
       data=body,
-      params=params,
-      auth=auth
+      headers=headers,
+      params=params
       )
 
 

--- a/changedetectionio/notification.py
+++ b/changedetectionio/notification.py
@@ -83,9 +83,13 @@ def apprise_custom_api_call_wrapper(body, title, notify_type, *args, **kwargs):
         headers = {URLBase.unquote(x): URLBase.unquote(y)
                    for x, y in results['qsd+'].items()}
 
-        # Add our GET paramters in the event the user wants to pass these along
-        params = {URLBase.unquote(x): URLBase.unquote(y)
-                             for x, y in results['qsd-'].items()}
+        # https://github.com/caronc/apprise/wiki/Notify_Custom_JSON#get-parameter-manipulation
+        # In Apprise, it relies on prefixing each request arg with "-", because it uses say &method=update as a flag for apprise
+        # but here we are making straight requests, so we need todo convert this against apprise's logic
+        for k, v in results['qsd'].items():
+            if not k.strip('+-') in results['qsd+'].keys():
+                params[URLBase.unquote(k)] = URLBase.unquote(v)
+
 
         # Determine Authentication
         auth = ''

--- a/changedetectionio/templates/_common_fields.jinja
+++ b/changedetectionio/templates/_common_fields.jinja
@@ -16,7 +16,7 @@
                                 <li><code><a target=_new href="https://github.com/caronc/apprise/wiki/Notify_discord">discord://</a></code> (or <code>https://discord.com/api/webhooks...</code>)) only supports a maximum <strong>2,000 characters</strong> of notification text, including the title.</li>
                                 <li><code><a target=_new href="https://github.com/caronc/apprise/wiki/Notify_telegram">tgram://</a></code> bots can't send messages to other bots, so you should specify chat ID of non-bot user.</li>
                                 <li><code><a target=_new href="https://github.com/caronc/apprise/wiki/Notify_telegram">tgram://</a></code> only supports very limited HTML and can fail when extra tags are sent, <a href="https://core.telegram.org/bots/api#html-style">read more here</a> (or use plaintext/markdown format)</li>
-                                <li><code>gets://</code>, <code>posts://</code>, <code>puts://</code>, <code>deletes://</code> for direct API calls (or omit the "<code>s</code>" for non-SSL ie <code>get://</code>)</li>
+                                <li><code>gets://</code>, <code>posts://</code>, <code>puts://</code>, <code>deletes://</code> for direct API calls (or omit the "<code>s</code>" for non-SSL ie <code>get://</code>) <a href="https://github.com/dgtlmoon/changedetection.io/wiki/Notification-configuration-notes#postposts">more help here</a></li>
                                   <li>Accepts the <code>{{ '{{token}}' }}</code> placeholders listed below</li>
                               </ul>
                             </div>

--- a/changedetectionio/tests/conftest.py
+++ b/changedetectionio/tests/conftest.py
@@ -13,22 +13,14 @@ global app
 
 
 def cleanup(datastore_path):
+    import glob
     # Unlink test output files
-    files = [
-        'count.txt',
-        'endpoint-content.txt'
-        'headers.txt',
-        'headers-testtag.txt',
-        'notification.txt',
-        'secret.txt',
-        'url-watches.json',
-        'output.txt',
-    ]
-    for file in files:
-        try:
-            os.unlink("{}/{}".format(datastore_path, file))
-        except FileNotFoundError:
-            pass
+
+    for g in ["*.txt", "*.json", "*.pdf"]:
+        files = glob.glob(os.path.join(datastore_path, g))
+        for f in files:
+            if os.path.isfile(f):
+                os.unlink(f)
 
 @pytest.fixture(scope='session')
 def app(request):

--- a/changedetectionio/tests/conftest.py
+++ b/changedetectionio/tests/conftest.py
@@ -19,6 +19,9 @@ def cleanup(datastore_path):
     for g in ["*.txt", "*.json", "*.pdf"]:
         files = glob.glob(os.path.join(datastore_path, g))
         for f in files:
+            if 'proxies.json' in f:
+                # Usually mounted by docker container during test time
+                continue
             if os.path.isfile(f):
                 os.unlink(f)
 

--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -205,6 +205,9 @@ def live_server_setup(live_server):
         with open("test-datastore/notification-url.txt", "w") as f:
             f.write(request.url)
 
+        with open("test-datastore/notification-headers.txt", "w") as f:
+            f.write(str(request.headers))
+
         if request.content_type:
             with open("test-datastore/notification-content-type.txt", "w") as f:
                 f.write(request.content_type)


### PR DESCRIPTION
Should work the same as https://github.com/caronc/apprise/wiki/Notify_Custom_JSON#header-manipulation

Todo
- check tokens are removed from URL (like in NotifyJSON)
- user/password/etc/etc handled (like in NotifyJSON)