### PR TITLE
Added OPTIONS HTTP method

### DIFF
--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -43,6 +43,7 @@ valid_method = {
     'PUT',
     'PATCH',
     'DELETE',
+    'OPTIONS',
 }
 
 default_method = 'GET'


### PR DESCRIPTION
Hello,

This is a simple PR to add OPTIONS to the valid method list for configuring watches. It was needed because OPTIONS is a HTTP method that some endpoints accept in order to query API information. As such, it's useful for tracking changes. 