### PR TITLE
Added a one-click deploy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ docker compose pull && docker compose up -d
 
 See the wiki for more information https://github.com/dgtlmoon/changedetection.io/wiki
 
+### 3rd-Party Hosting Options
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=90)
+
 
 ## Filters
 


### PR DESCRIPTION
Added a third-party hosting section and a link to installer template at RepoCloud - allowing users access to their affordable cloud hosting and one-click deploy template. 

(This link also qualifies the changedetection team to earn 25% recurring lifetime affiliate commissions.)