### PR TITLE
Bugfix: Notification title being set to notification format, notifiction format not being respected

### DIFF
--- a/changedetectionio/flask_app.py
+++ b/changedetectionio/flask_app.py
@@ -1603,7 +1603,7 @@ def notification_runner():
                     n_object['notification_title'] = datastore.data['settings']['application'].get('notification_title')
 
                 if not n_object.get('notification_format') and datastore.data['settings']['application'].get('notification_format'):
-                    n_object['notification_title'] = datastore.data['settings']['application'].get('notification_format')
+                    n_object['notification_format'] = datastore.data['settings']['application'].get('notification_format')
 
                 sent_obj = notification.process_notification(n_object, datastore)
 


### PR DESCRIPTION
Fixes #2103 and related discussion #2109

The notification format was not being set, and thus all html notifications were being sent as plaintext. Instead, the notification title was being set to the notification format if specified.