### PR TITLE
flask_app/fix: Redirect to referrer for some pages.

### DIFF
--- a/changedetectionio/flask_app.py
+++ b/changedetectionio/flask_app.py
@@ -707,7 +707,7 @@ def changedetection_app(config=None, datastore_o=None):
             if request.args.get("next") and request.args.get("next") == 'diff':
                 return redirect(url_for('diff_history_page', uuid=uuid))
 
-            return redirect(url_for('index'))
+            return redirect(request.referrer)
 
         else:
             if request.method == 'POST' and not form.validate():
@@ -1358,7 +1358,7 @@ def changedetection_app(config=None, datastore_o=None):
                     i += 1
 
         flash("{} watches queued for rechecking.".format(i))
-        return redirect(url_for('index', tag=tag))
+        return redirect(request.referrer)
 
     @app.route("/form/checkbox-operations", methods=['POST'])
     @login_optionally_required
@@ -1448,7 +1448,7 @@ def changedetection_app(config=None, datastore_o=None):
 
             flash("{} watches assigned tag".format(len(uuids)))
 
-        return redirect(url_for('index'))
+        return redirect(request.referrer)
 
     @app.route("/api/share-url", methods=['GET'])
     @login_optionally_required


### PR DESCRIPTION
For example, previously when a user had a lot of tasks to watch, every time the user clicked the recheck button, the app sent the user to the index. With this PR, the user can stay the same page.

This doesn't solve all the relative problems since I still stumble along the code.

I didn't figure out everything but this is a byproduct of the https://github.com/dgtlmoon/changedetection.io/pull/2135