### PR TITLE
elementpath~=4.1 fixes build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,8 @@ beautifulsoup4
 # XPath filtering, lxml is required by bs4 anyway, but put it here to be safe.
 lxml
 
-# XPath 2.0-3.1 support - 4.2.0 broke something
-elementpath~=4.1
+# XPath 2.0-3.1 support - 4.2.0 broke something?
+elementpath==4.1.5
 
 selenium~=4.14.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,8 @@ beautifulsoup4
 # XPath filtering, lxml is required by bs4 anyway, but put it here to be safe.
 lxml
 
-# XPath 2.0-3.1 support
-elementpath
+# XPath 2.0-3.1 support - 4.2.0 broke something
+elementpath~=4.1
 
 selenium~=4.14.0
 


### PR DESCRIPTION
`tests/test_xpath_selector.py` was failing due to a change in elementpath in 4.2.0