### PR TITLE
text_json_diff/fix: Keep an order of filter and remove duplicated filters. (#2172 #2170 #2151 #1845)

### DIFF
--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -29,7 +29,7 @@ class PDFToHTMLToolNotFound(ValueError):
         ValueError.__init__(self, msg)
 
 def merge_filters(include_filters, include_filters_from_tags):
-    return list({*include_filters, *include_filters_from_tags})
+    return list(dict.fromkeys(include_filters + include_filters_from_tags))
 
 # Some common stuff here that can be moved to a base class
 # (set_proxy_from_list)

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -118,7 +118,7 @@ class perform_site_check(difference_detection_processor):
         include_filters_from_tags = self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='include_filters')
 
         # 1845 - remove duplicated filters in both group and watch include filter
-        include_filters_rule = list({*watch.get('include_filters', []), *include_filters_from_tags})
+        include_filters_rule = list(dict.fromkeys(watch.get('include_filters', []) + include_filters_from_tags))
 
         subtractive_selectors = [*self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='subtractive_selectors'),
                                  *watch.get("subtractive_selectors", []),

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -28,6 +28,8 @@ class PDFToHTMLToolNotFound(ValueError):
     def __init__(self, msg):
         ValueError.__init__(self, msg)
 
+def merge_filters(include_filters, include_filters_from_tags):
+    return list({*include_filters, *include_filters_from_tags})
 
 # Some common stuff here that can be moved to a base class
 # (set_proxy_from_list)
@@ -118,7 +120,7 @@ class perform_site_check(difference_detection_processor):
         include_filters_from_tags = self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='include_filters')
 
         # 1845 - remove duplicated filters in both group and watch include filter
-        include_filters_rule = list({*watch.get('include_filters', []), *include_filters_from_tags})
+        include_filters_rule = merge_filters(watch.get('include_filters', []), include_filters_from_tags)
 
         subtractive_selectors = [*self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='subtractive_selectors'),
                                  *watch.get("subtractive_selectors", []),

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -28,6 +28,8 @@ class PDFToHTMLToolNotFound(ValueError):
     def __init__(self, msg):
         ValueError.__init__(self, msg)
 
+def merge_filters(include_filters, include_filters_from_tags):
+    return list(dict.fromkeys(include_filters + include_filters_from_tags))
 
 # Some common stuff here that can be moved to a base class
 # (set_proxy_from_list)
@@ -118,7 +120,7 @@ class perform_site_check(difference_detection_processor):
         include_filters_from_tags = self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='include_filters')
 
         # 1845 - remove duplicated filters in both group and watch include filter
-        include_filters_rule = list(dict.fromkeys(watch.get('include_filters', []) + include_filters_from_tags))
+        include_filters_rule = merge_filters(watch.get('include_filters', []), include_filters_from_tags)
 
         subtractive_selectors = [*self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='subtractive_selectors'),
                                  *watch.get("subtractive_selectors", []),

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -118,7 +118,7 @@ class perform_site_check(difference_detection_processor):
         include_filters_from_tags = self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='include_filters')
 
         # 1845 - remove duplicated filters in both group and watch include filter
-        include_filters_rule = list(dict.fromkeys(watch.get('include_filters', []) + include_filters_from_tags))
+        include_filters_rule = list({*watch.get('include_filters', []), *include_filters_from_tags})
 
         subtractive_selectors = [*self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='subtractive_selectors'),
                                  *watch.get("subtractive_selectors", []),

--- a/changedetectionio/processors/text_json_diff.py
+++ b/changedetectionio/processors/text_json_diff.py
@@ -28,8 +28,6 @@ class PDFToHTMLToolNotFound(ValueError):
     def __init__(self, msg):
         ValueError.__init__(self, msg)
 
-def merge_filters(include_filters, include_filters_from_tags):
-    return list(dict.fromkeys(include_filters + include_filters_from_tags))
 
 # Some common stuff here that can be moved to a base class
 # (set_proxy_from_list)
@@ -120,7 +118,7 @@ class perform_site_check(difference_detection_processor):
         include_filters_from_tags = self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='include_filters')
 
         # 1845 - remove duplicated filters in both group and watch include filter
-        include_filters_rule = merge_filters(watch.get('include_filters', []), include_filters_from_tags)
+        include_filters_rule = list(dict.fromkeys(watch.get('include_filters', []) + include_filters_from_tags))
 
         subtractive_selectors = [*self.datastore.get_tag_overrides_for_watch(uuid=uuid, attr='subtractive_selectors'),
                                  *watch.get("subtractive_selectors", []),


### PR DESCRIPTION
`2024-02-09 07:16:57.405 | DEBUG    | changedetectionio.processors.text_json_diff:run_changedetection:119 - include_filters_from_tags=[]type(include_filters_from_tags)=<class 'list'>`

@dgtlmoon  Could you confirm `include_filters_from_tags` and `include_filters` are always a `list` type?


I borrowed an idea from https://stackoverflow.com/a/17016257/20307768

related PR : https://github.com/dgtlmoon/changedetection.io/pull/2151
closes https://github.com/dgtlmoon/changedetection.io/discussions/2170 #2172 