### PR TITLE
chore: Skip elementpath 4.2 but support since 4.1.5.

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -125,12 +125,7 @@ def xpath_filter(xpath_filter, html_content, append_pretty_line_formatting=False
     tree = html.fromstring(bytes(html_content, encoding='utf-8'), parser=parser)
     html_block = ""
 
-    # https://github.com/sissaschool/elementpath/issues/71
-    r = elementpath.select(tree,
-            xpath_filter.strip(),
-            namespaces={'re': 'http://exslt.org/regular-expressions'},
-            fragment=False,
-            parser=XPath3Parser)
+    r = elementpath.select(tree, xpath_filter.strip(), namespaces={'re': 'http://exslt.org/regular-expressions'}, parser=XPath3Parser)
     #@note: //title/text() wont work where <title>CDATA..
 
     if type(r) != list:

--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -125,7 +125,12 @@ def xpath_filter(xpath_filter, html_content, append_pretty_line_formatting=False
     tree = html.fromstring(bytes(html_content, encoding='utf-8'), parser=parser)
     html_block = ""
 
-    r = elementpath.select(tree, xpath_filter.strip(), namespaces={'re': 'http://exslt.org/regular-expressions'}, parser=XPath3Parser)
+    # https://github.com/sissaschool/elementpath/issues/71
+    r = elementpath.select(tree,
+            xpath_filter.strip(),
+            namespaces={'re': 'http://exslt.org/regular-expressions'},
+            fragment=False,
+            parser=XPath3Parser)
     #@note: //title/text() wont work where <title>CDATA..
 
     if type(r) != list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ beautifulsoup4
 lxml
 
 # XPath 2.0-3.1 support - 4.2.0 broke something?
-elementpath==4.1.5
+elementpath!=4.2
 
 selenium~=4.14.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ beautifulsoup4
 lxml
 
 # XPath 2.0-3.1 support - 4.2.0 broke something?
-elementpath!=4.2
+elementpath!=4.2,>=4.1.5
 
 selenium~=4.14.0
 


### PR DESCRIPTION
This allows installing elementpath4.2.1 (bug fix) with skipping 4.2.
Test cases are merged into the elementpath repo. https://github.com/sissaschool/elementpath/commit/4aa9adb8c3a731d4968f2ac0e97aabd3cc0c10fa