### PR TITLE
update_worker/feat: Detailed loguru log.

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -107,9 +107,9 @@ def main():
     try:
         log_level_for_stdout = { 'DEBUG', 'SUCCESS' }
         logger.configure(handlers=[
-            {"sink": sys.stdout, "level": logger_level,
+            {"sink": sys.stdout, "level": logger_level, "backtrace": True, "diagnose" :True,
              "filter" : lambda record: record['level'].name in log_level_for_stdout},
-            {"sink": sys.stderr, "level": logger_level,
+            {"sink": sys.stderr, "level": logger_level, "backtrace": True, "diagnose" :True,
              "filter": lambda record: record['level'].name not in log_level_for_stdout},
             ])
     # Catch negative number or wrong log level name

--- a/changedetectionio/update_worker.py
+++ b/changedetectionio/update_worker.py
@@ -460,7 +460,7 @@ class update_worker(threading.Thread):
                         self.datastore.update_watch(uuid=uuid, update_obj={'last_error': f"Unable to extract restock data for this page unfortunately. (Got code {e.status_code} from server)"})
                         process_changedetection_results = False
                     except Exception as e:
-                        logger.error(f"Exception reached processing watch UUID: {uuid}")
+                        logger.exception(f"Exception reached processing watch UUID: {uuid}")
                         logger.error(str(e))
                         self.datastore.update_watch(uuid=uuid, update_obj={'last_error': str(e)})
                         # Other serious error


### PR DESCRIPTION
this is not PR. I'm sorry for this messing board. I didn't configure it correctly for users. I haven't profiled yet. maybe trace should become a different configuration. I hope this helps you. Thank you!
EDIT: For every test I did, I used `xpath://*/text()` and no browser steps with a new container.
![Screenshot 2024-02-13 at 23 32 28](https://github.com/dgtlmoon/changedetection.io/assets/61624808/813843e6-754a-4542-b43e-69e4f97b265e)
![Screenshot 2024-02-13 at 23 33 32](https://github.com/dgtlmoon/changedetection.io/assets/61624808/86671a59-4f4f-4d0f-b03f-898d9852afdf)

![Screenshot 2024-02-13 at 23 34 46](https://github.com/dgtlmoon/changedetection.io/assets/61624808/4a4de521-e514-43a9-b601-18e2000b3512)
[two_kinds_of_logs.txt](https://github.com/dgtlmoon/changedetection.io/files/14268319/two_kinds_of_logs.txt)

