### PR TITLE
fix browser step relative URL display on Firefox browser

### DIFF
--- a/changedetectionio/static/js/browser-steps.js
+++ b/changedetectionio/static/js/browser-steps.js
@@ -454,7 +454,7 @@ $(document).ready(function () {
         w = window.open(this.href, "_blank", "width=640,height=480");
         const t = $(event.currentTarget).data('type');
 
-        const url = window.origin + browser_steps_fetch_screenshot_image_url + `&step_n=${step_n}&type=${t}`;
+        const url = window.location.href.split('/').slice(0, self.length-2).join('/') +  browser_steps_fetch_screenshot_image_url + `&step_n=${step_n}&type=${t}`;
         w.document.body.innerHTML = `<!DOCTYPE html>
             <html lang="en">
                 <body>

--- a/changedetectionio/static/js/browser-steps.js
+++ b/changedetectionio/static/js/browser-steps.js
@@ -454,7 +454,7 @@ $(document).ready(function () {
         w = window.open(this.href, "_blank", "width=640,height=480");
         const t = $(event.currentTarget).data('type');
 
-        const url = browser_steps_fetch_screenshot_image_url + `&step_n=${step_n}&type=${t}`;
+        const url = window.origin + browser_steps_fetch_screenshot_image_url + `&step_n=${step_n}&type=${t}`;
         w.document.body.innerHTML = `<!DOCTYPE html>
             <html lang="en">
                 <body>


### PR DESCRIPTION
Fixes the issue where Firefox browsers will not display the browser step pictures on an about:blank popup because the relative URL path cannot be used. Adds base URL to the front of the URL path so it is compatible with both Firefox/Chrome browsers.