### PR TITLE
Allow silencing of web access logs

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -185,10 +185,12 @@ def main():
     if ssl_mode:
         # @todo finalise SSL config, but this should get you in the right direction if you need it.
         eventlet.wsgi.server(eventlet.wrap_ssl(eventlet.listen((host, port), s_type),
+                                               log=logger,
                                                certfile='cert.pem',
                                                keyfile='privkey.pem',
                                                server_side=True), app)
 
     else:
-        eventlet.wsgi.server(eventlet.listen((host, int(port)), s_type), app)
+        eventlet.wsgi.server(eventlet.listen((host, int(port)), s_type), app,
+                             log=logger)
 

--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -182,15 +182,19 @@ def main():
 
     s_type = socket.AF_INET6 if ipv6_enabled else socket.AF_INET
 
+    wsgi_enable_access_log = logger_level in { 'TRACE', 'DEBUG' }
+
     if ssl_mode:
         # @todo finalise SSL config, but this should get you in the right direction if you need it.
         eventlet.wsgi.server(eventlet.wrap_ssl(eventlet.listen((host, port), s_type),
                                                log=logger,
+                                               log_output=wsgi_enable_access_log,
                                                certfile='cert.pem',
                                                keyfile='privkey.pem',
                                                server_side=True), app)
 
     else:
         eventlet.wsgi.server(eventlet.listen((host, int(port)), s_type), app,
-                             log=logger)
+                             log=logger,
+                             log_output=wsgi_enable_access_log)
 

--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -182,7 +182,7 @@ def main():
 
     s_type = socket.AF_INET6 if ipv6_enabled else socket.AF_INET
 
-    wsgi_enable_access_log = logger_level in { 'TRACE', 'DEBUG' }
+    wsgi_enable_access_log = not strtobool(os.getenv('SILENT_WSGI', 'false'))
 
     if ssl_mode:
         # @todo finalise SSL config, but this should get you in the right direction if you need it.


### PR DESCRIPTION
Changedetection.io currently emits web access logs on stderr that don’t respect `LOGGER_LEVEL`:

```
  $ podman run --rm --publish '5000:5000' --env LOGGER_LEVEL='INFO' changedetection.io
  2024-03-22 20:40:40.116 | INFO     | changedetectionio.store:__init__:45 - Datastore path is '/datastore/url-watches.json'
  2024-03-22 20:40:40.116 | CRITICAL | changedetectionio.store:__init__:91 - No JSON DB found at /datastore/url-watches.json, creating JSON store at /datastore
  2024-03-22 20:40:40.117 | INFO     | changedetectionio.store:sync_to_json:420 - Saving JSON..
  2024-03-22 20:40:40.117 | INFO     | changedetectionio.store:sync_to_json:420 - Saving JSON..
  2024-03-22 20:40:40.119 | INFO     | changedetectionio.store:sync_to_json:420 - Saving JSON..
┃ (1) wsgi starting up on http://0.0.0.0:5000
  2024-03-22 20:40:41.150 | INFO     | changedetectionio.update_worker:run:248 - Processing watch UUID bc68db9c-cef9-43f8-ad4a-76689ed70484 Priority 1711140040 URL https://news.ycombinator.com/
  2024-03-22 20:40:41.151 | INFO     | changedetectionio.update_worker:run:248 - Processing watch UUID 7346370b-6d30-4c3f-8ddf-1d14de324931 Priority 1711140040 URL https://changedetection.io/CHANGELOG.txt
  2024-03-22 20:40:41.414 | INFO     | changedetectionio.update_worker:run:506 - Change triggered in UUID bc68db9c-cef9-43f8-ad4a-76689ed70484 due to first history saving (no notifications sent) - https://news.ycombinator.com/
  2024-03-22 20:40:42.918 | INFO     | changedetectionio.update_worker:run:506 - Change triggered in UUID 7346370b-6d30-4c3f-8ddf-1d14de324931 due to first history saving (no notifications sent) - https://changedetection.io/CHANGELOG.txt
┃ (1) accepted ('10.0.2.100', 34698)
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET / HTTP/1.1" 200 7812 0.063777
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/styles/pure-min.css HTTP/1.1" 200 4220 0.002249
┃ (1) accepted ('10.0.2.100', 34714)
┃ (1) accepted ('10.0.2.100', 34716)
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/styles/styles.css?v=0.45.16 HTTP/1.1" 200 8674 0.001966
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/js/jquery-3.6.0.min.js HTTP/1.1" 200 32361 0.004307
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/js/toggle-theme.js HTTP/1.1" 200 1117 0.001498
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/js/watch-overview.js HTTP/1.1" 200 1182 0.001342
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/spread.svg HTTP/1.1" 200 1158 0.001050
┃ (1) accepted ('10.0.2.100', 34726)
┃ (1) accepted ('10.0.2.100', 34728)
┃ (1) accepted ('10.0.2.100', 34746)
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/bell-off.svg HTTP/1.1" 200 1634 0.001030
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/Google-Chrome-icon.png HTTP/1.1" 200 14886 0.000925
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/spread-white.svg HTTP/1.1" 200 1268 0.000839
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/pause.svg HTTP/1.1" 200 3297 0.000817
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/Generic_Feed-icon.svg HTTP/1.1" 200 989 0.001147
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/images/gradient-border.png HTTP/1.1" 200 22393 0.001131
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/js/jquery-3.6.0.min.js HTTP/1.1" 200 32361 0.002757
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/favicons/apple-touch-icon.png HTTP/1.1" 200 32336 0.001297
┃ 10.0.2.100 - - [22/Mar/2024 20:40:47] "GET /static/favicons/favicon-32x32.png HTTP/1.1" 200 14318 0.000767
```

My goal is to have some mechanism by which to silence the web access logs. Here I’ve offered one solution, but perhaps someone else can suggest a better one.