### PR TITLE
eventlet 0.34.1 - fixes python 3.12 "AttributeError: module 'ssl' has no attribute 'wrap_socket'"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 # Used by Pyppeteer
 pyee
 
-eventlet==0.33.3 # related to dnspython fixes
+# eventlet 0.33.3 was related to dnspython fixes
+# 0.34.1 - fixes python 3.12 "AttributeError: module 'ssl' has no attribute 'wrap_socket'"
+eventlet==0.34.1
+
 feedgen~=0.9
 flask-compress
 # 0.6.3 included compatibility fix for werkzeug 3.x (2.x had deprecation of url handlers)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ jsonpath-ng~=1.5.3
 
 # Pinned: module 'eventlet.green.select' has no attribute 'epoll'
 # https://github.com/eventlet/eventlet/issues/805#issuecomment-1640463482
-dnspython==2.3.0 # related to eventlet fixes
+dnspython==2.6.1 # related to eventlet fixes
 
 # jq not available on Windows so must be installed manually
 


### PR DESCRIPTION
Maybe was related https://github.com/dgtlmoon/changedetection.io/issues/1314