### PR TITLE
2408 user agent headers

### DIFF
--- a/changedetectionio/processors/__init__.py
+++ b/changedetectionio/processors/__init__.py
@@ -1,12 +1,11 @@
 from abc import abstractmethod
-import os
-import hashlib
-import re
-from copy import deepcopy
 from changedetectionio.strtobool import strtobool
+from copy import deepcopy
 from loguru import logger
-
 from requests.structures import CaseInsensitiveDict
+import hashlib
+import os
+import re
 
 class difference_detection_processor():
 

--- a/changedetectionio/processors/__init__.py
+++ b/changedetectionio/processors/__init__.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from changedetectionio.strtobool import strtobool
 from loguru import logger
 
+from requests.structures import CaseInsensitiveDict
+
 class difference_detection_processor():
 
     browser_steps = None
@@ -93,13 +95,15 @@ class difference_detection_processor():
             self.fetcher.browser_steps_screenshot_path = os.path.join(self.datastore.datastore_path, self.watch.get('uuid'))
 
         # Tweak the base config with the per-watch ones
-        request_headers = self.watch.get('headers', [])
-        request_headers.update(self.datastore.get_all_base_headers())
-        request_headers.update(self.datastore.get_all_headers_in_textfile_for_watch(uuid=self.watch.get('uuid')))
+        request_headers = CaseInsensitiveDict()
 
         ua = self.datastore.data['settings']['requests'].get('default_ua')
         if ua and ua.get(prefer_fetch_backend):
             request_headers.update({'User-Agent': ua.get(prefer_fetch_backend)})
+
+        request_headers.update(self.watch.get('headers', {}))
+        request_headers.update(self.datastore.get_all_base_headers())
+        request_headers.update(self.datastore.get_all_headers_in_textfile_for_watch(uuid=self.watch.get('uuid')))
 
         # https://github.com/psf/requests/issues/4525
         # Requests doesnt yet support brotli encoding, so don't put 'br' here, be totally sure that the user cannot

--- a/changedetectionio/processors/__init__.py
+++ b/changedetectionio/processors/__init__.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from changedetectionio.strtobool import strtobool
 from copy import deepcopy
 from loguru import logger
-from requests.structures import CaseInsensitiveDict
 import hashlib
 import os
 import re
@@ -22,7 +21,7 @@ class difference_detection_processor():
         self.watch = deepcopy(self.datastore.data['watching'].get(watch_uuid))
 
     def call_browser(self):
-
+        from requests.structures import CaseInsensitiveDict
         # Protect against file:// access
         if re.search(r'^file://', self.watch.get('url', '').strip(), re.IGNORECASE):
             if not strtobool(os.getenv('ALLOW_FILE_URI', 'false')):


### PR DESCRIPTION
Closes #2408 

- Correctly let the watch override the global settings (not the other way)
- Use a case-insensitive dict for merging headers (`user-agent` should override `User-Agent` etc)