### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Used by Pyppeteer
 pyee
 
-eventlet==0.35.2 # related to dnspython fixes
+eventlet>=0.36.1 # fixes SSL error on Python 3.12
 feedgen~=0.9
 flask-compress
 # 0.6.3 included compatibility fix for werkzeug 3.x (2.x had deprecation of url handlers)


### PR DESCRIPTION
Updated the version of eventlet from 0.35.2 to any version greater than or equal to 0.36.1.

Running 0.35.2 causes an ssl error on launch, which causes changedetection.io to crash immediately when running Python 3.12.