### PR TITLE
fix: Inconsistent datatype for tags

### DIFF
--- a/changedetectionio/flask_app.py
+++ b/changedetectionio/flask_app.py
@@ -716,6 +716,8 @@ def changedetection_app(config=None, datastore_o=None):
                     for t in form.data.get('tags').split(','):
                         tag_uuids.append(datastore.add_tag(name=t))
                     extra_update_obj['tags'] = tag_uuids
+            else:
+                extra_update_obj['tags'] = [] #would otherwise be stored as "", unexpected datatype
 
             datastore.data['watching'][uuid].update(form.data)
             datastore.data['watching'][uuid].update(extra_update_obj)
@@ -1482,6 +1484,8 @@ def changedetection_app(config=None, datastore_o=None):
                     for uuid in uuids:
                         uuid = uuid.strip()
                         if datastore.data['watching'].get(uuid):
+                            if datastore.data['watching'][uuid]['tags'] == "": #old format
+                                datastore.data['watching'][uuid]['tags'] = []
                             datastore.data['watching'][uuid]['tags'].append(tag_uuid)
 
             flash("{} watches assigned tag".format(len(uuids)))


### PR DESCRIPTION
Core issue: Saving a job **on the edit page** when the job has **no tags** results in **tags = ""** in stored data. I.e. data stored as **string when list is expected** everywhere else. Causes error as in #1847 (on the front page, set checkbox on at least this job, click "Tag" button, enter any tag name, submit). This PR **fixes the core issue**.

But since in **existing setups**, if the core issue occurred there, there are now already jobs/watches with this unexpected datatype (tags = ""), so #1847 would still occur, so an **additional workaround** is added (check type instead of blindly assuming list). Since it is a simple validity check, no migration or whatsoever, this workaround will probably have to remain in the code for indefenite time, as there could always be still a job with this issue.

**No tests provided!** Only tested manually (core issue and additional workaround were properly tested independently).