### PR TITLE
When scraping elements, check for null results

### DIFF
--- a/changedetectionio/content_fetchers/res/xpath_element_scraper.js
+++ b/changedetectionio/content_fetchers/res/xpath_element_scraper.js
@@ -214,7 +214,7 @@ if (include_filters.length) {
             console.log(e);
         }
 
-        if (results.length) {
+        if (results != null && results.length) {
 
             // Iterate over the results
             results.forEach(node => {


### PR DESCRIPTION
When using Playwright if the XPath entry is something Chrome does not understand (i.e., XPath 2.0), it will throw an error when filtering visual elements using that XPath. This will cause the "results" variable to be empty. The next check is "results.length" which result in a null pointer dereference.

This results in an error seen on the web interface for the item:

    Exception: TypeError: Cannot read properties of undefined (reading
    'length') at eval (eval at evaluate (:226:30), <anonymous>:217:21)
    at UtilityScript.evaluate (<anonymous>:233:19) at
    UtilityScript.<anonymous> (<anonymous>:1:44)

This is a very confusing message because it does not have a reference to the original code file. An improvement might be to allow error messages to be passed back to the web UI when scraping the visual elements.