### PR TITLE
Encode notification body with utf-8 so that can send posts://

### DIFF
--- a/changedetectionio/notification.py
+++ b/changedetectionio/notification.py
@@ -105,6 +105,9 @@ def apprise_custom_api_call_wrapper(body, title, notify_type, *args, **kwargs):
     except ValueError as e:
         pass
 
+    if isinstance(body, str):
+        body = body.encode('utf-8')
+        
     r(results.get('url'),
       auth=auth,
       data=body,


### PR DESCRIPTION
Currently if you simply set the notification url to send out a posts:// url, you will get this error:

![image](https://github.com/user-attachments/assets/6a34c634-1dd9-499e-8bed-54b49c5a30a9)
```bash
2024-07-26 19:36:39,587 - DEBUG - Loaded Custom - posts URL: posts://
2024-07-26 19:36:39,841 - WARNING - An exception occured sending a Custom - posts notification.
2024-07-26 19:36:39,841 - DEBUG - <class 'apprise.decorators.base.CustomNotifyPlugin.instantiate_plugin.<locals>.CustomNotifyPluginWrapper'> Exception: 'latin-1' codec can't encode character '\u2013' in position 1022: Body ('–') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

With encoding the body to `utf-8`, you can make sure the post request can be successfully sent

Already tested myself in the local dev environment, it is working.