### PR TITLE
Pass headers to browsersteps

### DIFF
--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -85,7 +85,8 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         browsersteps_start_session['browserstepper'] = browser_steps.browsersteps_live_ui(
             playwright_browser=browsersteps_start_session['browser'],
             proxy=proxy,
-            start_url=datastore.data['watching'][watch_uuid].get('url')
+            start_url=datastore.data['watching'][watch_uuid].get('url'),
+            headers=datastore.data['watching'][watch_uuid].get('headers')
         )
 
         # For test


### PR DESCRIPTION
Hi there, I was testing some headers changes for a couple sites and was using the browser steps to quicky verify. Turns out, browser steps was not getting the headers I was setting but actual change detection attempts were. Either way, this seemed like a pretty straight forward addition to pass any pre-defined headers to the browser steps function.

I couldn't find tests for this section to modify but did test in my setup with both headers and no headers defined.

Thanks for developing such a great tool, looking forward to exploring more of it!