### PR TITLE
Cron like checking/scheduler Adding apscheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ pytest-flask ~=1.2
 # Anything 4.0 and up but not 5.0
 jsonschema ~= 4.0
 
-
+apscheduler
 loguru
 
 # For scraping all possible metadata relating to products so we can do better restock detection

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ pytest-flask ~=1.2
 # Anything 4.0 and up but not 5.0
 jsonschema ~= 4.0
 
-apscheduler
+apscheduler ~= 3.9
 loguru
 
 # For scraping all possible metadata relating to products so we can do better restock detection


### PR DESCRIPTION
solution for https://github.com/dgtlmoon/changedetection.io/pull/1092

- needs sqlite or similar (only should be enabled when this is setup?)
- needs to keep the item scheduled until it has ran (incase it gets scheduled but cdio restarted)

```
    async with AsyncScheduler(data_store) as scheduler:
        await scheduler.add_schedule(tick, IntervalTrigger(seconds=1), id="tick")
        await scheduler.run_until_stopped()
```

maybe interval trigger could be based on the current seconds/days/etc too

is in-memory-scheduler enough? pgsql/mysql etc not needed?

https://apscheduler.readthedocs.io/en/3.x/


> APScheduler has three built-in scheduling systems you can use:
> 
> - Cron-style scheduling (with optional start/end times)
> - Interval-based execution (runs jobs on even intervals, with optional start/end times)
> - One-off delayed execution (runs jobs once, on a set date/time)

use the interval based execution (what we have now) first