### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
      # If WEBDRIVER or PLAYWRIGHT are enabled, changedetection container depends on that
      # and must wait before starting (substitute "browser-chrome" with "playwright-chrome" if last one is used)
 #      depends_on:
-#          playwright-chrome:
+#          sockpuppetbrowser:
 #              condition: service_started
 
 


### PR DESCRIPTION
I guess after moving to sockpuppet the depends-on statement wasn't updated.


Orthogonal question: is sockpuppetbrowser a playwright replacement? (I could not fully get that in its README)