### PR TITLE
Narrow paho-mqtt requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,9 +38,8 @@ dnspython==2.6.1 # related to eventlet fixes
 apprise==1.9.0
 
 # apprise mqtt https://github.com/dgtlmoon/changedetection.io/issues/315
-# and 2.0.0 https://github.com/dgtlmoon/changedetection.io/issues/2241 not yet compatible
-# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt>=1.6.1,<2.0.0
+# use any version other than 2.0.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
+paho-mqtt!=2.0.*
 
 # Requires extra wheel for rPi
 cryptography~=42.0.8


### PR DESCRIPTION
The paho-mqtt backwards compatibility problem was fixed with version 2.1.0, so we only need to avoid the 2.0.x series of releases. Upstream apprise is currently being tested with paho-mqtt 2.1.0 as part of my fix at https://github.com/caronc/apprise/pull/1238

This narrows the workaround for issue #2241