### PR TITLE
Fix HIDE_REFERER env option

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -160,11 +160,10 @@ def main():
                     )
 
     # Monitored websites will not receive a Referer header when a user clicks on an outgoing link.
-    # @Note: Incompatible with password login (and maybe other features) for now, submit a PR!
     @app.after_request
     def hide_referrer(response):
         if strtobool(os.getenv("HIDE_REFERER", 'false')):
-            response.headers["Referrer-Policy"] = "no-referrer"
+            response.headers["Referrer-Policy"] = "same-origin"
 
         return response
 


### PR DESCRIPTION
Solution for #1491 and #2257

Instead of using the `no-referrer` policy which blocks both same-origin and cross-origin referrers and breaks POST requests (login, saving settings, etc) inside the app, use the `same-origin` policy which allows the referrer inside the app while still blocking it outside the app.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#same-origin
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#same-origin_2