### PR TITLE
Remove unused PUID and PGID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
   #    environment:
   #        Default listening port, can also be changed with the -p option
   #      - PORT=5000
-
-  #      - PUID=1000
-  #      - PGID=1000
   #
   #        Log levels are in descending order. (TRACE is the most detailed one)
   #        Log output levels: TRACE, DEBUG(default), INFO, SUCCESS, WARNING, ERROR, CRITICAL


### PR DESCRIPTION
Remove PUID and PGID because those configuration values are not used anywhere.

A user would expect this is working like in the linuxserver container images: https://docs.linuxserver.io/general/understanding-puid-and-pgid/