### PR TITLE
Fix diff not starting from last viewed snapshot (#2744)

### DIFF
--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -255,6 +255,8 @@ class model(watch_base):
         keys = list(self.history.keys())
         if not keys:
             return None
+        if len(keys) == 1:
+            return keys[0]
 
         last_viewed = int(self.get('last_viewed'))
         sorted_keys = sorted(keys, key=lambda x: int(x))
@@ -264,15 +266,12 @@ class model(watch_base):
         if last_viewed >= int(sorted_keys[0]):
             return sorted_keys[1]
         
-        # When the 'last viewed' timestamp is less than or equal the oldest snapshot, return oldest
-        if last_viewed <= int(sorted_keys[-1]):
-            return sorted_keys[-1]
-
+        # When the 'last viewed' timestamp is between snapshots, return the older snapshot
         for newer, older in list(zip(sorted_keys[0:], sorted_keys[1:])):
             if last_viewed < int(newer) and last_viewed >= int(older):
                 return older
 
-        # Unreachable, return oldest
+        # When the 'last viewed' timestamp is less than the oldest snapshot, return oldest
         return sorted_keys[-1]
 
     def get_history_snapshot(self, timestamp):

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -247,12 +247,9 @@ class model(watch_base):
         bump = self.history
         return self.__newest_history_key
 
-    # Given an arbitrary timestamp, find the closest next key
-    # For example, last_viewed = 1000 so it should return the next 1001 timestamp
-    #
-    # used for the [diff] button so it can preset a smarter from_version
+    # Given an arbitrary timestamp, find the best history key for the [diff] button so it can preset a smarter from_version
     @property
-    def get_next_snapshot_key_to_last_viewed(self):
+    def get_from_version_based_on_last_viewed(self):
 
         """Unfortunately for now timestamp is stored as string key"""
         keys = list(self.history.keys())
@@ -260,24 +257,23 @@ class model(watch_base):
             return None
 
         last_viewed = int(self.get('last_viewed'))
-        prev_k = keys[0]
         sorted_keys = sorted(keys, key=lambda x: int(x))
         sorted_keys.reverse()
 
-        # When the 'last viewed' timestamp is greater than the newest snapshot, return second last
-        if last_viewed > int(sorted_keys[0]):
+        # When the 'last viewed' timestamp is greater than or equal the newest snapshot, return second newest
+        if last_viewed >= int(sorted_keys[0]):
             return sorted_keys[1]
+        
+        # When the 'last viewed' timestamp is less than or equal the oldest snapshot, return oldest
+        if last_viewed <= int(sorted_keys[-1]):
+            return sorted_keys[-1]
 
-        for k in sorted_keys:
-            if int(k) < last_viewed:
-                if prev_k == sorted_keys[0]:
-                    # Return the second last one so we dont recommend the same version compares itself
-                    return sorted_keys[1]
+        for newer, older in list(zip(sorted_keys[0:], sorted_keys[1:])):
+            if last_viewed < int(newer) and last_viewed >= int(older):
+                return older
 
-                return prev_k
-            prev_k = k
-
-        return keys[0]
+        # Unreachable, return oldest
+        return sorted_keys[-1]
 
     def get_history_snapshot(self, timestamp):
         import brotli

--- a/changedetectionio/templates/watch-overview.html
+++ b/changedetectionio/templates/watch-overview.html
@@ -191,7 +191,7 @@
                     {% if watch.history_n >= 2 %}
 
                         {%  if is_unviewed %}
-                           <a href="{{ url_for('diff_history_page', uuid=watch.uuid, from_version=watch.get_next_snapshot_key_to_last_viewed) }}" target="{{watch.uuid}}" class="pure-button pure-button-primary diff-link">History</a>
+                           <a href="{{ url_for('diff_history_page', uuid=watch.uuid, from_version=watch.get_from_version_based_on_last_viewed) }}" target="{{watch.uuid}}" class="pure-button pure-button-primary diff-link">History</a>
                         {% else %}
                            <a href="{{ url_for('diff_history_page', uuid=watch.uuid)}}" target="{{watch.uuid}}" class="pure-button pure-button-primary diff-link">History</a>
                         {% endif %}

--- a/changedetectionio/tests/unit/test_watch_model.py
+++ b/changedetectionio/tests/unit/test_watch_model.py
@@ -57,5 +57,9 @@ class TestDiffBuilder(unittest.TestCase):
         p = watch.get_from_version_based_on_last_viewed
         assert p == "100", "Correct with only one history snapshot"
 
+        watch['last_viewed'] = 200
+        p = watch.get_from_version_based_on_last_viewed
+        assert p == "100", "Correct with only one history snapshot"
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2744 so that `get_from_version_based_on_last_viewed` returns snapshot before last viewed date instead of after.