### PR TITLE
Update Apprise to 1.9.1

### DIFF
--- a/changedetectionio/apprise_plugin/__init__.py
+++ b/changedetectionio/apprise_plugin/__init__.py
@@ -14,7 +14,7 @@ def apprise_custom_api_call_wrapper(body, title, notify_type, *args, **kwargs):
     import requests
     import json
     from urllib.parse import unquote_plus
-    from apprise.utils import parse_url as apprise_parse_url
+    from apprise.utils.parse import parse_url as apprise_parse_url
     from apprise import URLBase
 
     url = kwargs['meta'].get('url')

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ dnspython==2.6.1 # related to eventlet fixes
 # jq not available on Windows so must be installed manually
 
 # Notification library
-apprise==1.9.0
+apprise==1.9.1
 
 # apprise mqtt https://github.com/dgtlmoon/changedetection.io/issues/315
 # use any version other than 2.0.x due to https://github.com/eclipse/paho.mqtt.python/issues/814


### PR DESCRIPTION
Apprise [1.9.1](https://github.com/caronc/apprise/releases/tag/v1.9.1) includes some fixes for Matrix users particularly in that it allows one to use an access token for authentication instead of logging in for every request, thus avoiding login rate limits.