### PR TITLE
removing deprecated  docker version attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
     changedetection:
       image: ghcr.io/dgtlmoon/changedetection.io


### PR DESCRIPTION
Fixing warning in up to date docker environments:

´´´
WARN[0000] /root/changedetection.io/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion  ´´