### PR TITLE
Development: introduce Ruff as linter/formatter

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Lint with flake8
+      - name: Lint with Ruff
         run: |
-          pip3 install flake8
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install ruff
+          # Check for syntax errors and undefined names
+          ruff check . --select E9,F63,F7,F82
+          # Complete check with errors treated as warnings
+          ruff check . --exit-zero
 
   test-application-3-10:
     needs: lint-code
@@ -43,4 +43,3 @@ jobs:
     with:
       python-version: '3.13'
       skip-pypuppeteer: true
-      

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 .env
 .venv/
 venv/
+.python-version
 
 # IDEs
 .idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      # Lint (and apply safe fixes)
+      - id: ruff
+        args: [--fix]
+      # Fomrat
+      - id: ruff-format

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,48 @@
+# Assume Python 3.11
+target-version = "py311"
+
+# Formatting options
+line-length = 100
+indent-width = 4
+
+exclude = [
+    "__pycache__",
+    ".eggs",
+    ".git",
+    ".tox",
+    ".venv",
+    "*.egg-info",
+    "*.pyc",
+]
+
+[lint]
+# https://docs.astral.sh/ruff/rules/
+select = [
+    "B", # flake8-bugbear
+    "B9",
+    "C", 
+    "E", # pycodestyle
+    "F", # Pyflakes
+    "I", # isort
+    "N", # pep8-naming
+    "UP", # pyupgrade
+    "W", # pycodestyle
+]
+ignore = [
+    "B007", # unused-loop-control-variable
+    "B909", # loop-iterator-mutation
+    "E203", # whitespace-before-punctuation
+    "E266", # multiple-leading-hashes-for-block-comment
+    "E501", # redundant-backslash
+    "F403", # undefined-local-with-import-star
+    "N802", # invalid-function-name
+    "N806", # non-lowercase-variable-in-function
+    "N815", # mixed-case-variable-in-class-scope
+]
+
+[lint.mccabe]
+max-complexity = 12
+
+[format]
+indent-style = "space"
+quote-style = "preserve"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
-# Assume Python 3.11
-target-version = "py311"
+# Minimum supported version
+target-version = "py310"
 
 # Formatting options
 line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,3 +114,4 @@ pluggy ~= 1.5
 psutil==7.0.0
 
 ruff >= 0.11.2
+pre_commit >= 4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,3 +112,5 @@ pluggy ~= 1.5
 
 # Needed for testing, cross-platform for process and system monitoring
 psutil==7.0.0
+
+ruff >= 0.11.2


### PR DESCRIPTION
Hi. For a long time, I've had this repository in my bookmarks, but until recently I had never used it, even though I really liked the idea. Recently, I self-hosted it to track changes of some information on the web, and I found it very useful. In this regard, thanks to you and all the people behind the project!

I decided to contribute, as much as I can, to the project. However, I noticed that no tools are being used for code formatting and linting (black, flake8, ruff...). I believe it's important to have one that at least enforces code formatting, to avoid creating "noise" between PRs and to have a common style for everyone.

This PR introduces [Ruff](https://github.com/astral-sh/ruff), by Astral, among the dependencies, and its configuration (certainly opinionated by me, it's the one I've been using in all my projects for some time now).

It's easy to notice that a simple `ruff check` and a `ruff format` show many changes to the codebase, all naturally style-related, as well as highlighting violations of the style rules specified in the configuration.

Additionally, the PR adds a small ignore line for the configuration file that is created by `pyenv`, if it is used to use a specific Python version.

PS. If approved, I can take care of applying all the formatting and various fixes that Ruff recommends (both those that can be applied automatically and the "unsafe" ones that require manual application).