### PR TITLE
Small fix for when last fetched was zero bytes

### DIFF
--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -575,7 +575,7 @@ class model(watch_base):
         import brotli
         filepath = os.path.join(self.watch_data_dir, 'last-fetched.br')
 
-        if not os.path.isfile(filepath):
+        if not os.path.isfile(filepath) or os.path.getsize(filepath) == 0:
             # If a previous attempt doesnt yet exist, just snarf the previous snapshot instead
             dates = list(self.history.keys())
             if len(dates):


### PR DESCRIPTION
Set to

x **Added lines**
x **Replaced/changed lines**
not **Removed lines**

somehow last-fetched.br was getting created with zero bytes