### PR TITLE
[Draft] Memory fixes for large playwright screenshots with the new full page screenshot mechanism

### DIFF
--- a/changedetectionio/content_fetchers/helpers.py
+++ b/changedetectionio/content_fetchers/helpers.py
@@ -19,7 +19,7 @@ def capture_stitched_together_full_page(page):
     from PIL import Image, ImageDraw, ImageFont
 
     MAX_TOTAL_HEIGHT = SCREENSHOT_SIZE_STITCH_THRESHOLD*4  # Maximum total height for the final image (When in stitch mode)
-    MAX_CHUNK_HEIGHT = 4000  # Height per screenshot chunk
+    MAX_CHUNK_HEIGHT = 2000  # Height per screenshot chunk
     WARNING_TEXT_HEIGHT = 20  # Height of the warning text overlay
 
     # Save the original viewport size
@@ -51,9 +51,11 @@ def capture_stitched_together_full_page(page):
                 with Image.open(buf) as img:
                     img.load()
                     stitched_image.paste(img, (0, offset))
+                    img.close()
 
             # Explicit cleanup
             del buf
+            gc.collect()
             # Prevents Playwright from accumulating graphics buffers for different viewport sizes.
             page.set_viewport_size(original_viewport)
 

--- a/changedetectionio/content_fetchers/helpers.py
+++ b/changedetectionio/content_fetchers/helpers.py
@@ -103,6 +103,7 @@ def capture_stitched_together_full_page(page):
         stitched_image.save(output, format="JPEG", quality=int(os.getenv("SCREENSHOT_QUALITY", 30)))
         screenshot = output.getvalue()
         output.close()
+        stitched_image.close()
 
     finally:
         # Restore the original viewport size

--- a/changedetectionio/content_fetchers/helpers.py
+++ b/changedetectionio/content_fetchers/helpers.py
@@ -15,6 +15,7 @@ def capture_stitched_together_full_page(page):
     import io
     import os
     import time
+    import gc
     from PIL import Image, ImageDraw, ImageFont
 
     MAX_TOTAL_HEIGHT = SCREENSHOT_SIZE_STITCH_THRESHOLD*4  # Maximum total height for the final image (When in stitch mode)
@@ -47,7 +48,9 @@ def capture_stitched_together_full_page(page):
 
             # Capture screenshot chunk
             screenshot_bytes = page.screenshot(type='jpeg', quality=int(os.getenv("SCREENSHOT_QUALITY", 30)))
-            images.append(Image.open(io.BytesIO(screenshot_bytes)))
+            img = Image.open(io.BytesIO(screenshot_bytes))
+            img.load()
+            images.append(img)
 
             total_captured_height += chunk_height
 
@@ -64,6 +67,8 @@ def capture_stitched_together_full_page(page):
             stitched_image.paste(img, (0, y_offset))
             y_offset += img.height
             img.close()
+            del img
+            gc.collect()
 
         logger.debug(f"Screenshot stitched together in {time.time()-now:.2f}s")
 

--- a/changedetectionio/content_fetchers/helpers.py
+++ b/changedetectionio/content_fetchers/helpers.py
@@ -63,6 +63,7 @@ def capture_stitched_together_full_page(page):
         for img in images:
             stitched_image.paste(img, (0, y_offset))
             y_offset += img.height
+            img.close()
 
         logger.debug(f"Screenshot stitched together in {time.time()-now:.2f}s")
 
@@ -96,6 +97,7 @@ def capture_stitched_together_full_page(page):
         output = io.BytesIO()
         stitched_image.save(output, format="JPEG", quality=int(os.getenv("SCREENSHOT_QUALITY", 30)))
         screenshot = output.getvalue()
+        output.close()
 
     finally:
         # Restore the original viewport size


### PR DESCRIPTION
More investigation from https://github.com/dgtlmoon/changedetection.io/discussions/3035

I have bisected a memory issue that started in this changeset https://github.com/dgtlmoon/changedetection.io/compare/0.49.3...0.49.4

I have no issues with 0.49.3, but with 0.49.4 my RAM usage spikes and keeps growing to >1GB in a few hours

I am able to reproduce this with a single watch (screenshot warning at the top says it is 77000px tall) that is using playwright and uses the new screenshot mechanism introduced in https://github.com/dgtlmoon/changedetection.io/pull/2999

If I adjust playwright.py to always do 

`self.screenshot = self.page.screenshot(type='jpeg', full_page=True, quality=int(os.getenv("SCREENSHOT_QUALITY", 30)))`

 and never do the new 

`self.screenshot = capture_stitched_together_full_page(self.page)`

the memory seems to stay stable and not exhibit any issues

I haven't been able to fully get this under control yet, but is it an option to potentially revert/disable capture_stitched_together_full_page for now and go back to the old way?