### PR TITLE
Make chrome browser headless when checking the site with selenium

### DIFF
--- a/changedetectionio/content_fetchers/webdriver_selenium.py
+++ b/changedetectionio/content_fetchers/webdriver_selenium.py
@@ -65,6 +65,7 @@ class fetcher(Fetcher):
         # request_body, request_method unused for now, until some magic in the future happens.
 
         options = ChromeOptions()
+        options.add_argument("--headless")
         if self.proxy:
             options.proxy = self.proxy
 


### PR DESCRIPTION
This is a one line change, which i tested on my win10 machine. It uses chromes own headless version, and shouldn't cause any issues.