### PR TITLE
Handle "Execution context was destroyed" 

### DIFF
--- a/changedetectionio/content_fetchers/base.py
+++ b/changedetectionio/content_fetchers/base.py
@@ -156,7 +156,7 @@ class Fetcher():
                 except (Error, TimeoutError) as e:
                     # If the page has navigated (common with logins) then the context is destroyed
                     if "Execution context was destroyed" in str(e):
-                        logger.debug("Execution context was destroyed, most likely because of navigation")
+                        logger.debug("Execution context was destroyed, most likely because of navigation, continuing...")
                         continue
                     logger.debug(str(e))
                     # Stop processing here

--- a/changedetectionio/content_fetchers/base.py
+++ b/changedetectionio/content_fetchers/base.py
@@ -154,6 +154,10 @@ class Fetcher():
                     self.screenshot_step(step_n)
                     self.save_step_html(step_n)
                 except (Error, TimeoutError) as e:
+                    # If the page has navigated (common with logins) then the context is destroyed
+                    if "Execution context was destroyed" in str(e):
+                        logger.debug("Execution context was destroyed, most likely because of navigation")
+                        continue
                     logger.debug(str(e))
                     # Stop processing here
                     raise BrowserStepsStepException(step_n=step_n, original_e=e)


### PR DESCRIPTION
One of my watches (with browser steps) stopped working due to navigation errors. Ignoring the error and continuing resolves the issue and didn't break anything in my testing.
Not a new feature, just improved error handling. 