### PR TITLE
Don't restrict .box to 80% width

### DIFF
--- a/changedetectionio/static/styles/scss/styles.scss
+++ b/changedetectionio/static/styles/scss/styles.scss
@@ -185,7 +185,8 @@ code {
 }
 
 .box {
-  max-width: 80%;
+  max-width: 100%;
+  margin: 0 1em;
   flex-direction: column;
   display: flex;
   justify-content: center;
@@ -620,10 +621,6 @@ footer {
 
 @media only screen and (max-width: 760px),
 (min-device-width: 768px) and (max-device-width: 1024px) {
-  .box {
-    max-width: 95%
-  }
-
   .edit-form {
     padding: 0.5em;
     margin: 0;

--- a/changedetectionio/static/styles/styles.css
+++ b/changedetectionio/static/styles/styles.css
@@ -826,7 +826,8 @@ code {
   background: var(--color-text-watch-tag-list); }
 
 .box {
-  max-width: 80%;
+  max-width: 100%;
+  margin: 0 1em;
   flex-direction: column;
   display: flex;
   justify-content: center; }
@@ -1129,8 +1130,6 @@ footer {
       gap: 1em; }
 
 @media only screen and (max-width: 760px), (min-device-width: 768px) and (max-device-width: 1024px) {
-  .box {
-    max-width: 95%; }
   .edit-form {
     padding: 0.5em;
     margin: 0; }


### PR DESCRIPTION
Having `max-width: 80%` is very frustrating.

I can see my browser window has enough space for a wider table, and yet the table cells are squished while leaving empty whitespace at the sides.

This is specially noticeable when using a non-wide monitor and resizing the browser to half of the monitor width. (In my case, 2240x1400 / 2 = 1120x1400.)