### PR TITLE
Fix regression introduced by wrong indentation in previous commit

### DIFF
--- a/changedetectionio/store.py
+++ b/changedetectionio/store.py
@@ -413,7 +413,7 @@ class ChangeDetectionStore:
                 with open(self.json_store_path+".tmp", 'w') as json_file:
                     # Use compact JSON in production for better performance
                     json.dump(data, json_file, indent=2)
-                    os.replace(self.json_store_path+".tmp", self.json_store_path)
+                os.replace(self.json_store_path+".tmp", self.json_store_path)
             except Exception as e:
                 logger.error(f"Error writing JSON!! (Main JSON file save was skipped) : {str(e)}")
 


### PR DESCRIPTION
Fixes #3260 #3259

(Found via good ol' `git bisect` for those who care. once you know the previous commit was the offender, the issue is pretty easy to spot)