### PR TITLE
Add delete all functionality for groups, tags, and watches

### DIFF
--- a/changedetectionio/blueprint/tags/templates/groups-overview.html
+++ b/changedetectionio/blueprint/tags/templates/groups-overview.html
@@ -57,6 +57,9 @@
             {% endfor %}
             </tbody>
         </table>
+        <div style="margin-top: 20px;">
+            <a href="{{ url_for('tags.delete_all') }}" class="pure-button" onclick="return confirm('Are you sure you want to delete ALL groups/tags? This action cannot be undone.')" style="background: #dd4242; color: white;">Delete all groups</a>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/changedetectionio/blueprint/ui/__init__.py
+++ b/changedetectionio/blueprint/ui/__init__.py
@@ -191,6 +191,13 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, worker_handle
 
         return redirect(url_for('watchlist.index'))
 
+    @ui_blueprint.route("/delete_all_watches", methods=['GET'])
+    @login_optionally_required
+    def form_delete_all_watches():
+        datastore.delete('all')
+        flash('All watches deleted.')
+        return redirect(url_for('watchlist.index'))
+
     @ui_blueprint.route("/clone", methods=['GET'])
     @login_optionally_required
     def form_clone():

--- a/changedetectionio/blueprint/watchlist/templates/watch-overview.html
+++ b/changedetectionio/blueprint/watchlist/templates/watch-overview.html
@@ -250,6 +250,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 all {% if active_tag_uuid %}  in '{{active_tag.title}}'{%endif%}</a>
             </li>
             <li>
+                <a href="{{ url_for('ui.form_delete_all_watches') }}" class="pure-button button-tag" id="delete-all-watches" onclick="return confirm('Are you sure you want to delete ALL watches? This action cannot be undone.')" style="background: #dd4242; color: white;">Delete all watches</a>
+            </li>
+            <li>
                 <a href="{{ url_for('rss.feed', tag=active_tag_uuid, token=app_rss_token)}}"><img alt="RSS Feed" id="feed-icon" src="{{url_for('static_content', group='images', filename='generic_feed-icon.svg')}}" height="15"></a>
             </li>
         </ul>


### PR DESCRIPTION
A new /delete_all_watches route was added to changedetectionio/blueprint/ui/__init__.py to delete all watches via datastore.delete('all'). A "Delete all watches" button was added to changedetectionio/blueprint/watchlist/templates/watch-overview.html, linking to this route with a confirmation dialog. Additionally, a "Delete all Groups" button was added to changedetectionio/blueprint/tags/templates/groups-overview.html, utilizing the existing tags.delete_all route and including a similar safety confirmation.