### PR TITLE
Ensure a default Locale is set for more reliable text decoding (en_US.UTF-8 by default)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ COPY changedetection.py /app/changedetection.py
 ARG LOGGER_LEVEL=''
 ENV LOGGER_LEVEL="$LOGGER_LEVEL"
 
+# Default
+ENV LC_ALL=en_US.UTF-8
+
 WORKDIR /app
 CMD ["python", "./changedetection.py", "-d", "/datastore"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
   #        A valid timezone name to run as (for scheduling watch checking) see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   #      - TZ=America/Los_Angeles
   #
+  #        Text processing locale, en_US.UTF-8 used by default unless defined as something else here, UTF-8 should cover 99.99% of cases.
+  #      - LC_ALL=en_US.UTF-8
+  #
   #        Maximum height of screenshots, default is 16000 px, screenshots will be clipped to this if exceeded.
   #        RAM usage will be higher if you increase this.
   #      - SCREENSHOT_MAX_HEIGHT=16000


### PR DESCRIPTION
Related to https://github.com/dgtlmoon/changedetection.io/discussions/2514#discussioncomment-13900534