### PR TITLE
Improve warning message when filters produce no content for change detection

### DIFF
--- a/changedetectionio/async_update_worker.py
+++ b/changedetectionio/async_update_worker.py
@@ -165,7 +165,7 @@ async def async_update_worker(worker_id, q, notification_q, app, datastore):
                     if not datastore.data['watching'].get(uuid):
                         continue
 
-                    err_text = "Warning, no filters were found, no change detection ran - Did the page change layout? update your Visual Filter if necessary."
+                    err_text = "Warning: no content found with configured filters; no change detection ran. Did the page change layout? update your Visual Filter if necessary."
                     datastore.update_watch(uuid=uuid, update_obj={'last_error': err_text})
 
                     # Filter wasnt found, but we should still update the visual selector so that they can have a chance to set it up again

--- a/changedetectionio/tests/test_filter_failure_notification.py
+++ b/changedetectionio/tests/test_filter_failure_notification.py
@@ -114,7 +114,7 @@ def run_filter_test(client, live_server, content_filter):
         client.get(url_for("ui.form_watch_checknow"), follow_redirects=True)
         wait_for_all_checks(client)
         res = client.get(url_for("watchlist.index"))
-        assert b'Warning, no filters were found' in res.data
+        assert b'Warning: no content found with configured filters' in res.data
         assert not os.path.isfile("test-datastore/notification.txt")
         time.sleep(1)
         

--- a/changedetectionio/tests/test_group.py
+++ b/changedetectionio/tests/test_group.py
@@ -91,7 +91,7 @@ def test_setup_group_tag(client, live_server, measure_memory_usage):
     wait_for_all_checks(client)
 
     res = client.get(url_for("watchlist.index"))
-    assert b'Warning, no filters were found' not in res.data
+    assert b'Warning: no content found with configured filters' not in res.data
 
     res = client.get(
         url_for("ui.ui_views.preview_page", uuid="first"),


### PR DESCRIPTION
I understood the current message to mean something was wrong with my _configuration_ because the detection did not have any filters.

This warning actually just indicates that the configured filters results no content for change detection to check, which may be perfectly normal (as in my use case).

This PR attempts to clarify the language of the warning:

- Old message: `Warning, no filters were found`
- New message: `Warning: no content found with configured filters`

Refs #3388