### PR TITLE
Add 'nicht mehr lieferbar' to stock status checks

### DIFF
--- a/changedetectionio/content_fetchers/res/stock-not-in-stock.js
+++ b/changedetectionio/content_fetchers/res/stock-not-in-stock.js
@@ -47,6 +47,7 @@ async () => {
             'nicht lieferbar',
             'nicht verfügbar',
             'nicht vorrätig',
+            'nicht mehr lieferbar',
             'nicht zur verfügung',
             'nie znaleziono produktów',
             'niet beschikbaar',


### PR DESCRIPTION
mindfactory.de uses this string for not in stock.

Example: https://www.mindfactory.de/product_info.php/16TB-Seagate-Factory-Recertified-Exos-X-X16-ST16000NM001G-7-200U-min-25_1602638.html