### PR TITLE
Implement visual selector override of price data Re #3505

### DIFF
--- a/changedetectionio/blueprint/ui/templates/edit.html
+++ b/changedetectionio/blueprint/ui/templates/edit.html
@@ -29,7 +29,7 @@
     const default_system_fetch_backend="{{ settings_application['fetch_backend'] }}";
 </script>
 <script src="{{url_for('static_content', group='js', filename='plugins.js')}}" defer></script>
-<script src="{{url_for('static_content', group='js', filename='watch-settings.js')}}" defer></script>
+<script src="{{url_for('static_content', group='js', filename=watch['processor']+".js")}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='notifications.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='visual-selector.js')}}" defer></script>
 {% if playwright_enabled %}
@@ -50,8 +50,10 @@
             {% endif %}
             <li class="tab"><a id="browsersteps-tab" href="#browser-steps">Browser Steps</a></li>
         <!-- should goto extra forms? -->
-            {% if watch['processor'] == 'text_json_diff' %}
+            {% if watch['processor'] == 'text_json_diff' or watch['processor'] == 'restock_diff' %}
             <li class="tab"><a id="visualselector-tab" href="#visualselector">Visual Filter Selector</a></li>
+            {% endif %}
+            {% if watch['processor'] == 'text_json_diff' %}
             <li class="tab" id="filters-and-triggers-tab"><a href="#filters-and-triggers">Filters &amp; Triggers</a></li>
             <li class="tab" id="conditions-tab"><a href="#conditions">Conditions</a></li>
             {% endif %}
@@ -377,7 +379,7 @@ Math: {{ 1 + 1 }}") }}
             {{ extra_form_content|safe }}
             </div>
         {% endif %}
-            {% if watch['processor'] == 'text_json_diff' %}
+            {% if watch['processor'] == 'text_json_diff' or watch['processor'] == 'restock_diff' %}
             <div class="tab-pane-inner visual-selector-ui" id="visualselector">
                 <img class="beta-logo" src="{{url_for('static_content', group='images', filename='beta-logo.png')}}" alt="New beta functionality">
 

--- a/changedetectionio/model/__init__.py
+++ b/changedetectionio/model/__init__.py
@@ -55,6 +55,7 @@ class watch_base(dict):
             'previous_md5_before_filters': False,  # Used for skipping changedetection entirely
             'processor': 'text_json_diff',  # could be restock_diff or others from .processors
             'price_change_threshold_percent': None,
+            'price_change_custom_include_filters': None, # Like 'include_filter' but for price changes only
             'proxy': None,  # Preferred proxy connection
             'remote_server_reply': None,  # From 'server' reply header
             'sort_text_alphabetically': False,

--- a/changedetectionio/processors/restock_diff/__init__.py
+++ b/changedetectionio/processors/restock_diff/__init__.py
@@ -6,8 +6,76 @@ import re
 
 class Restock(dict):
 
-    def parse_currency(self, raw_value: str) -> Union[float, None]:
-        # Clean and standardize the value (ie 1,400.00 should be 1400.00), even better would be store the whole thing as an integer.
+    def _normalize_currency_code(self, currency: str) -> str:
+        """
+        Normalize currency symbol or code to ISO 4217 code for consistency.
+        Uses iso4217parse for accurate conversion.
+        """
+        if not currency:
+            return currency
+
+        # If already a 3-letter code, likely already normalized
+        if len(currency) == 3 and currency.isupper():
+            return currency
+
+        try:
+            import iso4217parse
+
+            # Parse the currency - returns list of possible matches
+            currencies = iso4217parse.parse(currency)
+
+            if currencies:
+                # For ambiguous symbols, prefer common currencies
+                if currency == '$':
+                    # Prefer USD for $ symbol
+                    usd = [c for c in currencies if c.alpha3 == 'USD']
+                    if usd:
+                        return 'USD'
+                elif currency == '£':
+                    # Prefer GBP for £ symbol
+                    gbp = [c for c in currencies if c.alpha3 == 'GBP']
+                    if gbp:
+                        return 'GBP'
+                elif currency == '¥':
+                    # Prefer JPY for ¥ symbol
+                    jpy = [c for c in currencies if c.alpha3 == 'JPY']
+                    if jpy:
+                        return 'JPY'
+
+                # Return first match for unambiguous symbols
+                return currencies[0].alpha3
+        except Exception:
+            pass
+
+        # Fallback: return as-is if can't normalize
+        return currency
+
+    def parse_currency(self, raw_value: str) -> Union[dict, None]:
+        """
+        Parse price and currency from text, handling messy formats with extra text.
+        Returns dict with 'price' and 'currency' keys (ISO 4217 code), or None if parsing fails.
+        """
+        try:
+            from price_parser import Price
+            # price-parser handles:
+            # - Extra text before/after ("Beginning at", "tax incl.")
+            # - Various number formats (1 099,00 or 1,099.00)
+            # - Currency symbols and codes
+            price_obj = Price.fromstring(raw_value)
+
+            if price_obj.amount is not None:
+                result = {'price': float(price_obj.amount)}
+                if price_obj.currency:
+                    # Normalize currency symbol to ISO 4217 code for consistency with metadata
+                    normalized_currency = self._normalize_currency_code(price_obj.currency)
+                    result['currency'] = normalized_currency
+                return result
+
+        except Exception as e:
+            from loguru import logger
+            logger.trace(f"price-parser failed on '{raw_value}': {e}, falling back to manual parsing")
+
+        # Fallback to existing manual parsing logic
         standardized_value = raw_value
 
         if ',' in standardized_value and '.' in standardized_value:
@@ -24,7 +92,7 @@ class Restock(dict):
 
         if standardized_value:
             # Convert to float
-            return float(parse_decimal(standardized_value, locale='en'))
+            return {'price': float(parse_decimal(standardized_value, locale='en'))}
 
         return None
 
@@ -51,7 +119,15 @@ class Restock(dict):
         # Custom logic to handle setting price and original_price
         if key == 'price' or key == 'original_price':
             if isinstance(value, str):
-                value = self.parse_currency(raw_value=value)
+                parsed = self.parse_currency(raw_value=value)
+                if parsed:
+                    # Set the price value
+                    value = parsed.get('price')
+                    # Also set currency if found and not already set
+                    if parsed.get('currency') and not self.get('currency'):
+                        super().__setitem__('currency', parsed.get('currency'))
+                else:
+                    value = None
 
         super().__setitem__(key, value)
 

--- a/changedetectionio/processors/restock_diff/forms.py
+++ b/changedetectionio/processors/restock_diff/forms.py
@@ -27,7 +27,7 @@ class RestockSettingsForm(Form):
         validators.NumberRange(min=0, max=100, message="Should be between 0 and 100"),
     ], render_kw={"placeholder": "0%", "size": "5"})
 
-    price_change_custom_include_filters = StringListField('Override automatic price detection with these selectors', [ValidateCSSJSONXPATHInput()], default='')
+    price_change_custom_include_filters = StringListField('Override automatic price detection with this selector', [ValidateCSSJSONXPATHInput()], default='')
 
     follow_price_changes = BooleanField('Follow price changes', default=True)
 
@@ -78,13 +78,8 @@ class processor_settings_form(processor_text_json_diff_form):
                     <span class="pure-form-message-inline">For example, If the product is $1,000 USD originally, <strong>2%</strong> would mean it has to change more than $20 since the first check.</span><br>
                 </fieldset>
                 <fieldset class="pure-group price-change-minmax">
-                        {% set field = render_field(form.restock_settings.price_change_custom_include_filters,
-                            rows=5,
-                            placeholder="#example
-xpath://body/div/span[contains(@class, 'example-class')]",
-                            class="m-d")
-                        %}
-                        {{ field }}
+                        {{ render_field(form.restock_settings.price_change_custom_include_filters) }}
+                        <span class="pure-form-message-inline">Override the automatic price metadata reader with this custom select from the <a href="#visualselector">Visual Selector</a>, in the case that the automatic detection was incorrect.</span><br>
                 </fieldset>                                  
             </div>
         </fieldset>

--- a/changedetectionio/processors/restock_diff/forms.py
+++ b/changedetectionio/processors/restock_diff/forms.py
@@ -1,7 +1,7 @@
 from wtforms import (
     BooleanField,
     validators,
-    FloatField
+    FloatField, StringField
 )
 from wtforms.fields.choices import RadioField
 from wtforms.fields.form import FormField
@@ -27,7 +27,7 @@ class RestockSettingsForm(Form):
         validators.NumberRange(min=0, max=100, message="Should be between 0 and 100"),
     ], render_kw={"placeholder": "0%", "size": "5"})
 
-    price_change_custom_include_filters = StringListField('Override automatic price detection with this selector', [ValidateCSSJSONXPATHInput()], default='')
+    price_change_custom_include_filters = StringField('Override automatic price detection with this selector', [ValidateCSSJSONXPATHInput()], default='', render_kw={"style": "width: 100%;"})
 
     follow_price_changes = BooleanField('Follow price changes', default=True)
 

--- a/changedetectionio/processors/restock_diff/forms.py
+++ b/changedetectionio/processors/restock_diff/forms.py
@@ -7,7 +7,7 @@ from wtforms.fields.choices import RadioField
 from wtforms.fields.form import FormField
 from wtforms.form import Form
 
-from changedetectionio.forms import processor_text_json_diff_form
+from changedetectionio.forms import processor_text_json_diff_form, ValidateCSSJSONXPATHInput, StringListField
 
 
 class RestockSettingsForm(Form):
@@ -26,6 +26,8 @@ class RestockSettingsForm(Form):
         validators.Optional(),
         validators.NumberRange(min=0, max=100, message="Should be between 0 and 100"),
     ], render_kw={"placeholder": "0%", "size": "5"})
+
+    price_change_custom_include_filters = StringListField('Override automatic price detection with these selectors', [ValidateCSSJSONXPATHInput()], default='')
 
     follow_price_changes = BooleanField('Follow price changes', default=True)
 
@@ -74,7 +76,16 @@ class processor_settings_form(processor_text_json_diff_form):
                     {{ render_field(form.restock_settings.price_change_threshold_percent) }}
                     <span class="pure-form-message-inline">Price must change more than this % to trigger a change since the first check.</span><br>
                     <span class="pure-form-message-inline">For example, If the product is $1,000 USD originally, <strong>2%</strong> would mean it has to change more than $20 since the first check.</span><br>
-                </fieldset>                
+                </fieldset>
+                <fieldset class="pure-group price-change-minmax">
+                        {% set field = render_field(form.restock_settings.price_change_custom_include_filters,
+                            rows=5,
+                            placeholder="#example
+xpath://body/div/span[contains(@class, 'example-class')]",
+                            class="m-d")
+                        %}
+                        {{ field }}
+                </fieldset>                                  
             </div>
         </fieldset>
         """

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -125,6 +125,79 @@ def get_itemprop_availability(html_content) -> Restock:
     return value
 
 
+def get_price_data_availability(html_content, price_change_custom_include_filters) -> Restock:
+    """
+    Extract price using custom CSS/XPath selectors.
+    Reuses apply_include_filters logic from text_json_diff processor.
+
+    Args:
+        html_content: The HTML content to parse
+        price_change_custom_include_filters: List of CSS/XPath selectors to extract price
+
+    Returns:
+        Restock dict with 'price' key if found
+    """
+    from changedetectionio import html_tools
+    from changedetectionio.processors.magic import guess_stream_type
+
+    value = Restock()
+
+    if not price_change_custom_include_filters:
+        return value
+
+    # Get content type
+    stream_content_type = guess_stream_type(http_content_header='text/html', content=html_content)
+
+    # Apply filters to extract price element
+    filtered_content = ""
+
+    for filter_rule in price_change_custom_include_filters:
+        # XPath filters
+        if filter_rule[0] == '/' or filter_rule.startswith('xpath:'):
+            filtered_content += html_tools.xpath_filter(
+                xpath_filter=filter_rule.replace('xpath:', ''),
+                html_content=html_content,
+                append_pretty_line_formatting=False,
+                is_rss=stream_content_type.is_rss
+            )
+
+        # XPath1 filters (first match only)
+        elif filter_rule.startswith('xpath1:'):
+            filtered_content += html_tools.xpath1_filter(
+                xpath_filter=filter_rule.replace('xpath1:', ''),
+                html_content=html_content,
+                append_pretty_line_formatting=False,
+                is_rss=stream_content_type.is_rss
+            )
+
+        # CSS selectors, default fallback
+        else:
+            filtered_content += html_tools.include_filters(
+                include_filters=filter_rule,
+                html_content=html_content,
+                append_pretty_line_formatting=False
+            )
+
+    if filtered_content.strip():
+        # Convert HTML to text
+        price_text = html_tools.html_to_text(
+            html_content=filtered_content,
+            render_anchor_tag_content=False,
+            is_rss=False
+        ).strip()
+
+        # Parse the price from text
+        try:
+            parsed_price = value.parse_currency(price_text)
+            if parsed_price is not None:
+                value['price'] = parsed_price
+                logger.debug(f"Extracted price from custom selector: {parsed_price} (from text: '{price_text}')")
+        except Exception as e:
+            logger.warning(f"Failed to parse price from '{price_text}': {e}")
+
+    return value
+
+
 def is_between(number, lower=None, upper=None):
     """
     Check if a number is between two values.
@@ -185,18 +258,23 @@ class perform_site_check(difference_detection_processor):
                 logger.info(f"Watch {watch.get('uuid')} - Tag '{tag.get('title')}' selected for restock settings override")
                 break
 
-
+    #if not has custom selector..
         itemprop_availability = {}
-        try:
-            itemprop_availability = get_itemprop_availability(self.fetcher.content)
-        except MoreThanOnePriceFound as e:
-            # Add the real data
-            raise ProcessorException(message="Cannot run, more than one price detected, this plugin is only for product pages with ONE product, try the content-change detection mode.",
-                                     url=watch.get('url'),
-                                     status_code=self.fetcher.get_last_status_code(),
-                                     screenshot=self.fetcher.screenshot,
-                                     xpath_data=self.fetcher.xpath_data
-                                     )
+        if restock_settings.get('price_change_custom_include_filters'):
+            itemprop_availability = get_price_data_availability(html_content=self.fetcher.content,
+                                                                price_change_custom_include_filters=restock_settings.get('price_change_custom_include_filters')
+                                                                )
+        else:
+            try:
+                itemprop_availability = get_itemprop_availability(self.fetcher.content)
+            except MoreThanOnePriceFound as e:
+                # Add the real data
+                raise ProcessorException(message="Cannot run, more than one price detected, this plugin is only for product pages with ONE product, try the content-change detection mode.",
+                                         url=watch.get('url'),
+                                         status_code=self.fetcher.get_last_status_code(),
+                                         screenshot=self.fetcher.screenshot,
+                                         xpath_data=self.fetcher.xpath_data
+                                         )
 
         # Something valid in get_itemprop_availability() by scraping metadata ?
         if itemprop_availability.get('price') or itemprop_availability.get('availability'):

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -125,7 +125,7 @@ def get_itemprop_availability(html_content) -> Restock:
     return value
 
 
-def get_price_data_availability(html_content, price_change_custom_include_filters) -> Restock:
+def get_price_data_availability_from_filters(html_content, price_change_custom_include_filters) -> Restock:
     """
     Extract price using custom CSS/XPath selectors.
     Reuses apply_include_filters logic from text_json_diff processor.
@@ -192,7 +192,7 @@ def get_price_data_availability(html_content, price_change_custom_include_filter
 
         # Parse the price from text
         try:
-            parsed_result = value.parse_currency(price_text)
+            parsed_result = value.parse_currency(price_text, normalize_dollar=True)
             if parsed_result:
                 value['price'] = parsed_result.get('price')
                 if parsed_result.get('currency'):
@@ -267,7 +267,7 @@ class perform_site_check(difference_detection_processor):
     #if not has custom selector..
         itemprop_availability = {}
         if restock_settings.get('price_change_custom_include_filters'):
-            itemprop_availability = get_price_data_availability(html_content=self.fetcher.content,
+            itemprop_availability = get_price_data_availability_from_filters(html_content=self.fetcher.content,
                                                                 price_change_custom_include_filters=restock_settings.get('price_change_custom_include_filters')
                                                                 )
         else:

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -180,18 +180,24 @@ def get_price_data_availability(html_content, price_change_custom_include_filter
 
     if filtered_content.strip():
         # Convert HTML to text
-        price_text = html_tools.html_to_text(
-            html_content=filtered_content,
-            render_anchor_tag_content=False,
-            is_rss=False
-        ).strip()
+        import re
+        price_text = re.sub(
+            r'[\r\n\t]+', ' ',
+            html_tools.html_to_text(
+                html_content=filtered_content,
+                render_anchor_tag_content=False,
+                is_rss=False
+            ).strip()
+        )
 
         # Parse the price from text
         try:
-            parsed_price = value.parse_currency(price_text)
-            if parsed_price is not None:
-                value['price'] = parsed_price
-                logger.debug(f"Extracted price from custom selector: {parsed_price} (from text: '{price_text}')")
+            parsed_result = value.parse_currency(price_text)
+            if parsed_result:
+                value['price'] = parsed_result.get('price')
+                if parsed_result.get('currency'):
+                    value['currency'] = parsed_result.get('currency')
+                logger.debug(f"Extracted price from custom selector: {parsed_result.get('price')} {parsed_result.get('currency', '')} (from text: '{price_text}')")
         except Exception as e:
             logger.warning(f"Failed to parse price from '{price_text}': {e}")
 

--- a/changedetectionio/static/js/restock_diff.js
+++ b/changedetectionio/static/js/restock_diff.js
@@ -9,12 +9,34 @@ $(document).ready(function () {
             $includeFiltersElem: $('#restock_settings-price_change_custom_include_filters')
         });
     }
+
+    // Function to check and bootstrap visual selector based on hash
+    function checkAndBootstrapVisualSelector() {
+        if (visualSelectorAPI) {
+            if (window.location.hash && window.location.hash.includes('visualselector')) {
+                $('img#selector-background').off('load');
+                visualSelectorAPI.bootstrap();
+            } else {
+                // Shutdown when navigating away from visualselector
+                visualSelectorAPI.shutdown();
+            }
+        }
+    }
+
     // Bootstrap the visual selector when the tab is clicked
     $('#visualselector-tab').click(function () {
         if (visualSelectorAPI) {
             $('img#selector-background').off('load');
             visualSelectorAPI.bootstrap();
         }
+    });
+
+    // Check on page load if hash contains 'visualselector'
+    checkAndBootstrapVisualSelector();
+
+    // Listen for hash changes (when anchor changes)
+    $(window).on('hashchange', function() {
+        checkAndBootstrapVisualSelector();
     });
 });
 

--- a/changedetectionio/static/js/restock_diff.js
+++ b/changedetectionio/static/js/restock_diff.js
@@ -1,0 +1,20 @@
+$(document).ready(function () {
+    // Initialize Visual Selector plugin
+    let visualSelectorAPI = null;
+    if ($('#selector-wrapper').length > 0) {
+        visualSelectorAPI = $('#selector-wrapper').visualSelector({
+            screenshotUrl: screenshot_url,
+            visualSelectorDataUrl: watch_visual_selector_data_url,
+            singleSelectorOnly: true,
+            $includeFiltersElem: $('#restock_settings-price_change_custom_include_filters')
+        });
+    }
+    // Bootstrap the visual selector when the tab is clicked
+    $('#visualselector-tab').click(function () {
+        if (visualSelectorAPI) {
+            $('img#selector-background').off('load');
+            visualSelectorAPI.bootstrap();
+        }
+    });
+});
+

--- a/changedetectionio/static/js/text_json_diff.js
+++ b/changedetectionio/static/js/text_json_diff.js
@@ -54,12 +54,33 @@ $(document).ready(function () {
             visualSelectorDataUrl: watch_visual_selector_data_url
         });
 
+        // Function to check and bootstrap visual selector based on hash
+        function checkAndBootstrapVisualSelector() {
+            if (visualSelectorAPI) {
+                if (window.location.hash && window.location.hash.includes('visualselector')) {
+                    $('img#selector-background').off('load');
+                    visualSelectorAPI.bootstrap();
+                } else {
+                    // Shutdown when navigating away from visualselector
+                    visualSelectorAPI.shutdown();
+                }
+            }
+        }
+
         // Bootstrap the visual selector when the tab is clicked
         $('#visualselector-tab').click(function() {
             if (visualSelectorAPI) {
                 $('img#selector-background').off('load');
                 visualSelectorAPI.bootstrap();
             }
+        });
+
+        // Check on page load if hash contains 'visualselector'
+        checkAndBootstrapVisualSelector();
+
+        // Listen for hash changes (when anchor changes)
+        $(window).on('hashchange', function() {
+            checkAndBootstrapVisualSelector();
         });
     }
 

--- a/changedetectionio/static/js/text_json_diff.js
+++ b/changedetectionio/static/js/text_json_diff.js
@@ -46,6 +46,23 @@ function request_textpreview_update() {
 
 $(document).ready(function () {
 
+    // Initialize Visual Selector plugin
+    let visualSelectorAPI = null;
+    if ($('#selector-wrapper').length > 0) {
+        visualSelectorAPI = $('#selector-wrapper').visualSelector({
+            screenshotUrl: screenshot_url,
+            visualSelectorDataUrl: watch_visual_selector_data_url
+        });
+
+        // Bootstrap the visual selector when the tab is clicked
+        $('#visualselector-tab').click(function() {
+            if (visualSelectorAPI) {
+                $('img#selector-background').off('load');
+                visualSelectorAPI.bootstrap();
+            }
+        });
+    }
+
     $('#notification-setting-reset-to-default').click(function (e) {
         $('#notification_title').val('');
         $('#notification_body').val('');

--- a/changedetectionio/static/js/visual-selector.js
+++ b/changedetectionio/static/js/visual-selector.js
@@ -311,21 +311,26 @@
         // Initialize event handlers
         initializeEventHandlers();
 
-        // Check if we should auto-bootstrap based on URL hash
-        if (window.location.hash && window.location.hash === '#visualselector') {
-            // Auto-bootstrap if on the visualselector tab
-            setTimeout(() => bootstrapVisualSelector(), 100);
-        } else {
-            // Clear the background image if not on the visualselector tab
-            $selectorBackgroundElem.attr('src', '');
-        }
-
         // Return public API
         return {
             bootstrap: function() {
                 currentSelections = [];
                 runInClearMode = false;
                 bootstrapVisualSelector();
+            },
+            shutdown: function() {
+                // Clear the background image and canvas when navigating away
+                $selectorBackgroundElem.attr('src', '');
+                if (c && ctx) {
+                    ctx.clearRect(0, 0, c.width, c.height);
+                }
+                if (c && xctx) {
+                    xctx.clearRect(0, 0, c.width, c.height);
+                }
+                // Unbind mouse events on canvas
+                $selectorCanvasElem.off('mousemove mousedown mouseleave');
+                // Unbind background image events
+                $selectorBackgroundElem.off('load error');
             },
             clear: function() {
                 clearReset();

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,6 +105,8 @@ extruct
 
 # For cleaning up unknown currency formats
 babel
+# For normalizing currency symbols to ISO 4217 codes
+iso4217parse
 
 levenshtein
 


### PR DESCRIPTION
Closes #3505
Related to
- https://github.com/dgtlmoon/changedetection.io/issues/2634



This adds a new filter field shown only in restock mode `price_change_custom_include_filters`, which is separate to the `include_filters` of the content change filter mode

**todo**

- [ ] fix: instock/soldout indicator does not update in realtime.js
- [X] fix: textarea for selector should be a single line input
- [ ] implement: instock/soldout indicator should have a third state `cant decide` or similar for restock detection
- [ ] implement: text above visual-selector needs a message "you are overriding the automatic detection"
- [ ] implement: any error messages from restock detector should give you an easy link to the visual selector option (too many prices, etc)
- [ ] implement: needs automated test of `price_change_custom_include_filters` selector for the price data
- [ ] add test for wild strings like `'Beginning at   1 099,00 €   tax incl.   tax incl.'` that they correct convert price and currency (`EUR` shown)
- [ ] out of stock detector should still run on the page
- [x] should still throw 'filter not found' trigger to alert you that the filter doesnt found anymore

**this is going to break/not work when this case happens.. because either new 'discount' element is going to go missing once the price returns..** so its not a great solution i think

<img width="1094" height="203" alt="image" src="https://github.com/user-attachments/assets/06a4b086-267e-40ee-8844-4ee268c6361a" />




## Anyway, here's how it looks



<img width="1062" height="195" alt="image" src="https://github.com/user-attachments/assets/6de046c0-a6dc-4ef4-9c78-06f2e8d83a3c" />


<img width="931" height="645" alt="image" src="https://github.com/user-attachments/assets/8a5d6a84-f0b1-42b4-b788-7504d0efc4f2" />


<img width="1072" height="663" alt="image" src="https://github.com/user-attachments/assets/7608b24b-778e-4479-baa7-09f6d9231016" />
