### PR TITLE
Preserve whitespace's in HTML style notifications

### DIFF
--- a/changedetectionio/notification/handler.py
+++ b/changedetectionio/notification/handler.py
@@ -257,7 +257,6 @@ def process_notification(n_object: NotificationContextData, datastore):
             if n_object.get('markup_text_links_to_html_links'):
                 n_body = markup_text_links_to_html(body=n_body)
 
-
             n_title = jinja_render(template_str=n_object.get('notification_title', ''), **notification_parameters)
 
             url = url.strip()
@@ -278,6 +277,11 @@ def process_notification(n_object: NotificationContextData, datastore):
                 if 'html' in requested_output_format:
                     from markupsafe import escape
                     n_body = str(escape(n_body))
+
+            if 'html' in requested_output_format:
+                # Since the n_body is always some kind of text from the 'diff' engine, attempt to preserve whitespaces that get sent to the HTML output
+                # But only where its more than 1 consecutive whitespace, otherwise "and this" becomes "and&nbsp;this" etc which is too much.
+                n_body = n_body.replace('  ', '&nbsp;&nbsp;')
 
             (url, n_body, n_title) = apply_service_tweaks(url=url, n_body=n_body, n_title=n_title, requested_output_format=requested_output_format_original)
 

--- a/changedetectionio/tests/smtp/test_notification_smtp.py
+++ b/changedetectionio/tests/smtp/test_notification_smtp.py
@@ -477,7 +477,7 @@ def test_check_plaintext_document_html_notifications(client, live_server, measur
     """When following a plaintext document, notification in Plain Text format is sent correctly"""
 
     with open("test-datastore/endpoint-content.txt", "w") as f:
-        f.write("Some nice plain text\nwhich we add some extra data\nover here\n")
+        f.write("    Some nice plain text\nwhich we add some extra data\nover here\n")
 
     notification_url = f'mailto://changedetection@{smtp_test_server}:11025/?to=fff@home.com'
     notification_body = f"""{default_notification_body}"""
@@ -504,7 +504,7 @@ def test_check_plaintext_document_html_notifications(client, live_server, measur
 
     # Change the content
     with open("test-datastore/endpoint-content.txt", "w") as f:
-        f.write("Some nice plain text\nwhich we add some extra data\nAnd let's talk about <title> tags\nover here\n")
+        f.write("    Some nice plain text\nwhich we add some extra data\nAnd let's talk about <title> tags\nover here\n")
 
 
     time.sleep(2)
@@ -543,6 +543,10 @@ def test_check_plaintext_document_html_notifications(client, live_server, measur
     assert 'background-color' not in html_content
     assert '<br>\r\n(added) And let&#39;s talk about &lt;title&gt; tags<br>' in html_content
     assert '&lt;br' not in html_content
+
+    # And now for the whitespace retention
+    assert '&nbsp;&nbsp;&nbsp;&nbsp;Some nice plain text' in html_content
+    assert '(added) And let' in html_content # just to show a single whitespace didnt get touched
 
     delete_all_watches(client)
 
@@ -669,6 +673,7 @@ def test_check_html_document_plaintext_notification(client, live_server, measure
     assert '(into) sxome stuff\r\n' in body
     assert '(added) lets slip this in\r\n' in body
     assert '(added) and this in\r\n' in body
+    assert '&nbsp;' not in body
 
 
     delete_all_watches(client)


### PR DESCRIPTION
Makes sure the whitespaces are still present, so you can still understand the formatting

<img width="250" height="560" alt="image" src="https://github.com/user-attachments/assets/3cb6384c-7b26-4f8b-aa1a-6d36fc15aec8" />
