### PR TITLE
API - Support optional `processor` on Watch create to set the `restock_diff` or `text_json_diff` mode on watch create.

### DIFF
--- a/changedetectionio/api/api_schema.py
+++ b/changedetectionio/api/api_schema.py
@@ -96,7 +96,10 @@ def build_watch_json_schema(d):
                                                            "enum": ["html_requests", "html_webdriver"]
                                                            })
 
-
+    schema['properties']['processor'] = {"anyOf": [
+        {"type": "string", "enum": ["restock_diff", "text_json_diff"]},
+        {"type": "null"}
+    ]}
 
     # All headers must be key/value type dict
     schema['properties']['headers'] = {

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -228,6 +228,11 @@ components:
                 maxLength: 5000
             required: [operation, selector, optional_value]
           description: Browser automation steps
+        processor:
+          type: string
+          enum: [restock_diff, text_json_diff]
+          default: text_json_diff
+          description: Optional processor mode to use for change detection. Defaults to `text_json_diff` if not specified.
 
     Watch:
       allOf:
@@ -428,7 +433,7 @@ paths:
       operationId: createWatch
       tags: [Watch Management]
       summary: Create a new watch
-      description: Create a single web page change monitor (watch). Requires at least 'url' to be set.
+      description: Create a single web page change monitor (watch). Requires at least 'url' to be set, Optionally use `"processor"` field to set the `restock_diff` mode or `text_json_diff` (default)
       x-code-samples:
         - lang: 'curl'
           source: |
@@ -446,7 +451,7 @@ paths:
           source: |
             import requests
             import json
-            
+
             headers = {
                 'x-api-key': 'YOUR_API_KEY',
                 'Content-Type': 'application/json'
@@ -458,7 +463,7 @@ paths:
                     'hours': 1
                 }
             }
-            response = requests.post('http://localhost:5000/api/v1/watch', 
+            response = requests.post('http://localhost:5000/api/v1/watch',
                                    headers=headers, json=data)
             print(response.text)
       requestBody:


### PR DESCRIPTION
Closes #3367