### PR TITLE
Specify UTF-8 encoding for xpath_element_js

### DIFF
--- a/changedetectionio/blueprint/browser_steps/browser_steps.py
+++ b/changedetectionio/blueprint/browser_steps/browser_steps.py
@@ -439,7 +439,7 @@ class browsersteps_live_ui(steppable_browser_interface):
             logger.warning("Attempted to get current state after cleanup")
             return (None, None)
 
-        xpath_element_js = importlib.resources.files("changedetectionio.content_fetchers.res").joinpath('xpath_element_scraper.js').read_text()
+        xpath_element_js = importlib.resources.files("changedetectionio.content_fetchers.res").joinpath('xpath_element_scraper.js').read_text(encoding="utf-8")
 
         now = time.time()
         await self.page.wait_for_timeout(1 * 1000)


### PR DESCRIPTION
I've been running the app under Python to test something, and I came across an error message stating `Error fetching screenshot and element data - 'charmap' codec can't decode byte 0x8d ...` when looking at the browser steps preview.

Tracked it down to a single line. I'm assuming `read_text` defaults to some other encoding (maybe `CP-1252`) on Windows, so I just explicitly set the encoding to `utf-8` and it started working.

Side note: Also getting a 404 error when trying to check the latest screenshot for a watch, but `last-screenshot.png` actually exists under the respective watch folder. Have a feeling it's also related to Python-specifics on Windows, not sure tho.