### PR TITLE
Notifications - Word difference on HTML style notifications should be configurable, add tests. Re #3740

### DIFF
--- a/changedetectionio/blueprint/settings/templates/settings.html
+++ b/changedetectionio/blueprint/settings/templates/settings.html
@@ -87,6 +87,10 @@
                 <fieldset>
                     {{ render_common_settings_form(form.application.form, emailprefix, settings_application, extra_notification_token_placeholder_info) }}
                 </fieldset>
+                 <fieldset class="pure-group">
+                    {{ render_checkbox_field(form.application.form.notification_html_word_diff_enabled) }}
+                    <span class="pure-form-message-inline">HTML notifications - Use "word by word" difference where possible.</span>
+                </fieldset>
                 <div class="pure-control-group" id="notification-base-url">
                     {{ render_field(form.application.form.base_url, class="m-d") }}
                     <span class="pure-form-message-inline">

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -991,6 +991,7 @@ class globalSettingsApplicationForm(commonSettingsForm):
                            render_kw={"placeholder": os.getenv('BASE_URL', 'Not set')}
                            )
     empty_pages_are_a_change =  BooleanField(_l('Treat empty pages as a change?'), default=False)
+    notification_html_word_diff_enabled = BooleanField(_l('Notification HTML as word-by-word difference'), default=True, validators=[validators.Optional()])
     fetch_backend = RadioField(_l('Fetch Method'), default="html_requests", choices=content_fetchers.available_fetchers(), validators=[ValidateContentFetcherIsReady()])
     global_ignore_text = StringListField(_l('Ignore Text'), [ValidateListRegex()])
     global_subtractive_selectors = StringListField(_l('Remove elements'), [ValidateCSSJSONXPATHInput(allow_json=False)])

--- a/changedetectionio/model/App.py
+++ b/changedetectionio/model/App.py
@@ -49,6 +49,7 @@ class model(dict):
                     'ssim_threshold': '0.96',  # Default SSIM threshold for screenshot comparison
                     'notification_body': default_notification_body,
                     'notification_format': default_notification_format,
+                    'notification_html_word_diff': True,
                     'notification_title': default_notification_title,
                     'notification_urls': [], # Apprise URL list
                     'pager_size': 50,

--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -250,6 +250,7 @@ class NotificationService:
         if n_object.get('notification_format') == USE_SYSTEM_DEFAULT_NOTIFICATION_FORMAT_FOR_WATCH:
             n_object['notification_format'] = self.datastore.data['settings']['application'].get('notification_format')
 
+        n_object['notification_html_word_diff_enabled'] = self.datastore.data['settings']['application'].get('notification_html_word_diff_enabled', True)
 
         triggered_text = ''
         if len(trigger_text):

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -1,5 +1,5 @@
 
-{% from '_helpers.html' import render_field %}
+{% from '_helpers.html' import render_field, render_checkbox_field %}
 
 {% macro show_token_placeholders(extra_notification_token_placeholder_info, suffix="") %}
 
@@ -8,9 +8,7 @@
             <span class="pure-form-message-inline">
         Body for all notifications &dash; You can use <a target="newwindow" href="https://jinja.palletsprojects.com/en/3.0.x/templates/">Jinja2</a> templating in the notification title, body and URL, and tokens from below.
     </span><br>
-        <div data-target="#notification-tokens-info{{ suffix }}" class="toggle-show pure-button button-tag button-xsmall">Show
-            token/placeholders
-        </div>
+        <div data-target="#notification-tokens-info{{ suffix }}" class="toggle-show pure-button button-tag button-xsmall">Show extra help and tokens</div>
     </div>
     <div class="pure-controls" style="display: none;" id="notification-tokens-info{{ suffix }}">
         <table class="pure-table" id="token-table">
@@ -105,11 +103,30 @@
                 {% endif %}
             </tbody>
         </table>
-
-        <span class="pure-form-message-inline">
+        <br>
+        <div class="pure-form-message-inline">
         Warning: Contents of <code>{{ '{{diff}}' }}</code>, <code>{{ '{{diff_removed}}' }}</code>, and <code>{{ '{{diff_added}}' }}</code> depend on how the difference algorithm perceives the change. <br>
-        For example, an addition or removal could be perceived as a change in some cases. <a target="newwindow" href="https://github.com/dgtlmoon/changedetection.io/wiki/Using-the-%7B%7Bdiff%7D%7D,-%7B%7Bdiff_added%7D%7D,-and-%7B%7Bdiff_removed%7D%7D-notification-tokens">More Here</a> <br>
-        </span>
+        For example, an addition or removal could be perceived as a change in some cases. <a target="newwindow"  href="https://github.com/dgtlmoon/changedetection.io/wiki/Using-the-%7B%7Bdiff%7D%7D,-%7B%7Bdiff_added%7D%7D,-and-%7B%7Bdiff_removed%7D%7D-notification-tokens">More Here</a> <br>
+        </div>
+    <br><br>
+        <div class="pure-form-message-inline">
+            <ul>
+                <li><span class="pure-form-message-inline">
+                For JSON payloads, use <strong>|tojson</strong> without quotes for automatic escaping, for example - <code>{ "name": {{ '{{ watch_title|tojson }}' }} }</code>
+            </span></li>
+                <li><span class="pure-form-message-inline">
+                URL encoding, use <strong>|urlencode</strong>, for example - <code>gets://hook-website.com/test.php?title={{ '{{ watch_title|urlencode }}' }}</code>
+            </span></li>
+                <li><span class="pure-form-message-inline">
+                Regular-expression replace, use <strong>|regex_replace</strong>, for example -   <code>{{ "{{ \"hello world 123\" | regex_replace('[0-9]+', 'no-more-numbers') }}" }}</code>
+            </span></li>
+                <li><span class="pure-form-message-inline">
+                For a complete reference of all Jinja2 built-in filters, users can refer to the <a
+                        href="https://jinja.palletsprojects.com/en/3.1.x/templates/#builtin-filters">https://jinja.palletsprojects.com/en/3.1.x/templates/#builtin-filters</a>
+            </span></li>
+            </ul>
+            <br>
+        </div>
     </div>
 {%  endmacro %}
 
@@ -151,28 +168,11 @@
                                 {{ render_field(form.notification_title, class="m-d notification-title", placeholder=settings_application['notification_title']) }}
                                 <span class="pure-form-message-inline">Title for all notifications</span>
                             </div>
-                            <div class="pure-control-group">
+                            <div>
                                 {{ render_field(form.notification_body , rows=5, class="notification-body", placeholder=settings_application['notification_body']) }}
                                 {{ show_token_placeholders(extra_notification_token_placeholder_info=extra_notification_token_placeholder_info) }}
-                                <div class="pure-form-message-inline">
-                                    <ul>
-                                    <li><span class="pure-form-message-inline">
-                                        For JSON payloads, use <strong>|tojson</strong> without quotes for automatic escaping, for example - <code>{ "name": {{ '{{ watch_title|tojson }}' }} }</code>
-                                    </span></li>
-                                    <li><span class="pure-form-message-inline">
-                                        URL encoding, use <strong>|urlencode</strong>, for example - <code>gets://hook-website.com/test.php?title={{ '{{ watch_title|urlencode }}' }}</code>
-                                    </span></li>
-                                    <li><span class="pure-form-message-inline">
-                                        Regular-expression replace, use <strong>|regex_replace</strong>, for example -   <code>{{ "{{ \"hello world 123\" | regex_replace('[0-9]+', 'no-more-numbers') }}" }}</code>
-                                    </span></li>
-                                    <li><span class="pure-form-message-inline">
-                                        For a complete reference of all Jinja2 built-in filters, users can refer to the <a href="https://jinja.palletsprojects.com/en/3.1.x/templates/#builtin-filters">https://jinja.palletsprojects.com/en/3.1.x/templates/#builtin-filters</a>
-                                    </span></li>
-                                    </ul>
-                                    <br>
-                                </div>
                             </div>
-                            <div class="">
+                            <div>
                                 {{ render_field(form.notification_format , class="notification-format") }}
                                 <span class="pure-form-message-inline">Format for all notifications</span>
                             </div>

--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -7,7 +7,7 @@ import logging
 import time
 import os
 
-def set_original_response(datastore_path, extra_title=''):
+def set_original_response(datastore_path, extra_title='', extras=''):
     test_return_data = f"""<html>
     <head><title>head title{extra_title}</title></head>
     <body>
@@ -15,6 +15,9 @@ def set_original_response(datastore_path, extra_title=''):
      <p>Which is across multiple lines</p>
      <br>
      So let's see what happens.  <br>
+     with more text that helps word-diff if needed<br>
+     and more text that helps word-diff if needed<br>
+     and even more text {extras}that helps word-diff if needed<br>     
      <span class="foobar-detection" style='display:none'></span>
      </body>
      </html>
@@ -24,14 +27,17 @@ def set_original_response(datastore_path, extra_title=''):
         f.write(test_return_data)
     return None
 
-def set_modified_response(datastore_path):
-    test_return_data = """<html>
+def set_modified_response(datastore_path, extras=''):
+    test_return_data =f"""<html>
     <head><title>modified head title</title></head>
     <body>
      Some initial text<br>
      <p>which has this one new line</p>
      <br>
      So let's see what happens.  <br>
+     with more text that helps word-diff if needed<br>
+     and more text that helps word-diff if needed<br>
+     and even more text {extras}that helps word-diff if needed<br>     
      </body>
      </html>
     """
@@ -92,8 +98,8 @@ def wait_for_notification_endpoint_output(datastore_path):
     #@todo - could check the apprise object directly instead of looking for this file
     from os.path import isfile
     notification_file = os.path.join(datastore_path, "notification.txt")
-    for i in range(1, 20):
-        time.sleep(1)
+    for i in range(1, 100):
+        time.sleep(0.3)
         if isfile(notification_file):
             return True
 


### PR DESCRIPTION
Maybe a different token is better `{{ diff:word }}` and then the UI option isnt needed