### PR TITLE
Open github link on new tab

### DIFF
--- a/changedetectionio/templates/menu.html
+++ b/changedetectionio/templates/menu.html
@@ -52,7 +52,7 @@
         </button>
         <a class="github-link" href="https://github.com/dgtlmoon/changedetection.io"
            target="_blank" 
-           >
+          rel="noopener" >
             {% include "svgs/github.svg" %}
         </a>
     </li>


### PR DESCRIPTION
To open the github project we don't need to lost the current page on the changedetection.io.