### PR TITLE
Format JSON if jq: filter used on embedded JSON

### DIFF
--- a/changedetectionio/blueprint/ui/templates/edit.html
+++ b/changedetectionio/blueprint/ui/templates/edit.html
@@ -336,6 +336,10 @@ Math: {{ 1 + 1 }}") }}
                     <span class="pure-form-message-inline">{{ _('Remove duplicate lines of text') }}</span>
                 </fieldset>
                 <fieldset class="pure-control-group">
+                    {{ render_checkbox_field(form.sort_keys_alphabetically) }}
+                    <span class="pure-form-message-inline">{{ _('Helps reduce changes detected caused by inconsistent JSON formatting') }}</span>
+                </fieldset>
+                <fieldset class="pure-control-group">
                     {{ render_checkbox_field(form.sort_text_alphabetically) }}
                     <span class="pure-form-message-inline">{{ _('Helps reduce changes detected caused by sites shuffling lines around, combine with') }} <i>{{ _('check unique lines') }}</i> {{ _('below.') }}</span>
                 </fieldset>

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -811,6 +811,7 @@ class processor_text_json_diff_form(commonSettingsForm):
     ignore_status_codes = BooleanField(_l('Ignore status codes (process non-2xx status codes as normal)'), default=False)
     check_unique_lines = BooleanField(_l('Only trigger when unique lines appear in all history'), default=False)
     remove_duplicate_lines = BooleanField(_l('Remove duplicate lines of text'), default=False)
+    sort_keys_alphabetically =  BooleanField(_l('Sort JSON keys alphabetically'), default=False)
     sort_text_alphabetically =  BooleanField(_l('Sort text alphabetically'), default=False)
     strip_ignored_lines = TernaryNoneBooleanField(_l('Strip ignored lines'), default=None)
     trim_text_whitespace = BooleanField(_l('Trim whitespace before and after text'), default=False)

--- a/changedetectionio/model/__init__.py
+++ b/changedetectionio/model/__init__.py
@@ -57,6 +57,7 @@ class watch_base(dict):
             'price_change_threshold_percent': None,
             'proxy': None,  # Preferred proxy connection
             'remote_server_reply': None,  # From 'server' reply header
+            'sort_keys_alphabetically': False,
             'sort_text_alphabetically': False,
             'strip_ignored_lines': None,
             'subtractive_selectors': [],

--- a/changedetectionio/processors/text_json_diff/processor.py
+++ b/changedetectionio/processors/text_json_diff/processor.py
@@ -123,6 +123,19 @@ class ContentTransformer:
         return '\n'.join(line.strip() for line in text.replace("\n\n", "\n").splitlines())
 
     @staticmethod
+    def format_json_output_if_possible(text):
+        """Pretty-print JSON if the entire text is valid JSON."""
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            return text
+
+        try:
+            return json.dumps(parsed, indent=4, ensure_ascii=False)
+        except Exception:
+            return text
+
+    @staticmethod
     def remove_duplicate_lines(text):
         """Remove duplicate lines while preserving order."""
         return '\n'.join(dict.fromkeys(line for line in text.replace("\n\n", "\n").splitlines()))
@@ -457,6 +470,10 @@ class perform_site_check(difference_detection_processor):
                 stripped_text = html_content
 
         # === TEXT TRANSFORMATIONS ===
+        # If JSON/jq filters are used on embedded JSON, reformat output JSON before any text filtering/transformations
+        if filter_config.has_include_json_filters:
+            stripped_text = transformer.format_json_output_if_possible(stripped_text)
+
         if watch.get('trim_text_whitespace'):
             stripped_text = transformer.trim_whitespace(stripped_text)
 

--- a/changedetectionio/processors/text_json_diff/processor.py
+++ b/changedetectionio/processors/text_json_diff/processor.py
@@ -27,6 +27,15 @@ list_badge_text = "Text"
 
 JSON_FILTER_PREFIXES = ['json:', 'jq:', 'jqraw:']
 
+
+def sort_json_keys(value):
+    """Recursively sort JSON object keys while preserving array order."""
+    if isinstance(value, dict):
+        return {key: sort_json_keys(value[key]) for key in sorted(value.keys())}
+    if isinstance(value, list):
+        return [sort_json_keys(item) for item in value]
+    return value
+
 # Assume it's this type if the server says nothing on content-type
 DEFAULT_WHEN_NO_CONTENT_TYPE_HEADER = 'text/html'
 
@@ -131,7 +140,20 @@ class ContentTransformer:
             return text
 
         try:
-            return json.dumps(parsed, indent=4, ensure_ascii=False)
+            return json.dumps(parsed, indent=2, ensure_ascii=False)
+        except Exception:
+            return text
+
+    @staticmethod
+    def sort_json_keys_if_possible(text, indent=2):
+        """Sort JSON object keys recursively if the entire text is valid JSON."""
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            return text
+
+        try:
+            return json.dumps(sort_json_keys(parsed), indent=indent, ensure_ascii=False)
         except Exception:
             return text
 
@@ -295,9 +317,12 @@ class ContentProcessor:
         # Then we re-format it, else it does have filters (later on) which will reformat it anyway
         content = html_tools.extract_json_as_string(content=raw_content, json_filter="json:$")
 
-        # Sort JSON to avoid false alerts from reordering
+        # Format JSON, optionally sorting keys to avoid false alerts from reordering
         try:
-            content = json.dumps(json.loads(content), sort_keys=True, indent=2, ensure_ascii=False)
+            parsed = json.loads(content)
+            if self.watch.get('sort_keys_alphabetically'):
+                parsed = sort_json_keys(parsed)
+            content = json.dumps(parsed, indent=2, ensure_ascii=False)
         except Exception:
             # Might be malformed JSON, continue anyway
             pass
@@ -473,6 +498,8 @@ class perform_site_check(difference_detection_processor):
         # If JSON/jq filters are used on embedded JSON, reformat output JSON before any text filtering/transformations
         if filter_config.has_include_json_filters:
             stripped_text = transformer.format_json_output_if_possible(stripped_text)
+            if watch.get('sort_keys_alphabetically'):
+                stripped_text = transformer.sort_json_keys_if_possible(stripped_text)
 
         if watch.get('trim_text_whitespace'):
             stripped_text = transformer.trim_whitespace(stripped_text)

--- a/changedetectionio/translations/cs/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/cs/LC_MESSAGES/messages.po
@@ -1405,6 +1405,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/de/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/de/LC_MESSAGES/messages.po
@@ -1437,6 +1437,10 @@ msgstr ""
 "hinzugefügt werden. Vergleicht neue Zeilen mit dem gesamten Verlauf dieser Überwachung."
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 "Hilft dabei, erkannte Änderungen zu reduzieren, die durch das Umstellen von Zeilen auf Websites verursacht werden, "

--- a/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
@@ -1401,6 +1401,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
@@ -1401,6 +1401,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/fr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/fr/LC_MESSAGES/messages.po
@@ -1407,6 +1407,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/it/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/it/LC_MESSAGES/messages.po
@@ -1403,6 +1403,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/ko/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ko/LC_MESSAGES/messages.po
@@ -1401,6 +1401,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/messages.pot
+++ b/changedetectionio/translations/messages.pot
@@ -1400,6 +1400,10 @@ msgid ""
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr ""
 

--- a/changedetectionio/translations/zh/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh/LC_MESSAGES/messages.po
@@ -1401,6 +1401,10 @@ msgid ""
 msgstr "适合仅移动内容的网站，想知道新增内容时使用，会将新行与该监控项的全部历史进行比对。"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr "有助于减少因行顺序变化导致的变更，可结合"
 

--- a/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -1401,6 +1401,10 @@ msgid ""
 msgstr "適用於內容僅會移動的網站，且您想知道何時新增了「新」內容，此功能會將新行與此監測任務的所有歷史記錄進行比較。"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+msgid "Helps reduce changes detected caused by inconsistent JSON formatting"
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Helps reduce changes detected caused by sites shuffling lines around, combine with"
 msgstr "有助於減少因網站重新排列行而檢測到的變更，結合"
 


### PR DESCRIPTION
This fixes an issue where `jq:` filters will not pretty-print their output if filtering JSON embedded in HTML, for example.

Reproduction steps:
- Add https://careers.nintendo.com/jobs/?department=Design%C2%A0&department=Software+Development%C2%A0&department=Software+Development+-+Games%C2%A0 as a watched URL
- In "Filters & Triggers", add a filter: `jq:.props.pageProps.jobs[] | select (.metadata["Job Field"].value == "Design " or .metadata["Job Field"].value == "Software Development " or .metadata["Job Field"].value == "Software Development - Games ") | select (.metadata["Worksite Classification"].value != "Onsite") | {id, title, company_name, worksite: .metadata["Worksite Classification"].value, location: .location.name, updated_at }`
- Save the watch.

Preview before this change:
<img width="807" height="177" alt="image" src="https://github.com/user-attachments/assets/0be2be17-c71b-4bad-813d-806eaec20d9e" />

Preview after this change:
<img width="752" height="347" alt="image" src="https://github.com/user-attachments/assets/227f7300-0fa7-4814-a06e-f03242fb43e2" />
