### PR TITLE
Improved catching of errors/exceptions in Browser Steps steps 

### DIFF
--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -422,11 +422,7 @@ class fetcher(Fetcher):
             except ScreenshotUnavailable:
                 # Re-raise screenshot unavailable exceptions
                 raise ScreenshotUnavailable(url=url, status_code=self.status_code)
-            except BrowserStepsStepException:
-                raise
-            except Exception:
-                # It's likely the screenshot was too long/big and something crashed
-                raise
+
             finally:
                 # Request garbage collection one more time before closing
                 try:


### PR DESCRIPTION
needs a test that going to `chrome://crash` gives the correct exception and returns fast (maybe use CLI mode?? with `timeout` cli command, etc)

maybe CLI option to return the state of the watch after it ran, then select it via `jq`