### PR TITLE
Expose restock settings to use in notification tags

### DIFF
--- a/changedetectionio/processors/restock_diff/__init__.py
+++ b/changedetectionio/processors/restock_diff/__init__.py
@@ -72,6 +72,7 @@ class Watch(BaseWatch):
     def extra_notification_token_values(self):
         values = super().extra_notification_token_values()
         values['restock'] = self.get('restock', {})
+        values['restock_settings'] = self.get('restock_settings', {})
         return values
 
     def extra_notification_token_placeholder_info(self):
@@ -79,6 +80,9 @@ class Watch(BaseWatch):
 
         values.append(('restock.price', "Price detected"))
         values.append(('restock.original_price', "Original price at first check"))
+        values.append(('restock_settings.price_change_min', "Minimum price threshold"))
+        values.append(('restock_settings.price_change_max', "Maximum price threshold"))
+        values.append(('restock_settings.price_change_threshold_percent', "Price change percentage threshold"))
 
         return values
 

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -189,6 +189,7 @@ class perform_site_check(difference_detection_processor):
             if tag.get('overrides_watch'):
                 restock_settings = tag.get('restock_settings', {})
                 logger.info(f"Watch {watch.get('uuid')} - Tag '{tag.get('title')}' selected for restock settings override")
+                watch['restock_settings'] = restock_settings
                 break
 
 


### PR DESCRIPTION
When receiving notifications I would like to list the restock settings (notifiy when lower than) options in the notification email.

For example, I set a watch to notify me when a product is below the MSRP (Minimum Suggested Retail Price). When the notification is received it would be handy to have all information in one email. Old price, New price and MSRP. Then I can act on the information provided without searching for the initial MSRP setting.

<img width="228" height="200" alt="image" src="https://github.com/user-attachments/assets/8779414e-bef7-431b-9cd2-af8dcfcece67" />

```
Target: 39.95

Previous amount: 39.94
New amount: 39.9
```

Also adds the hints/tags:

<img width="641" height="116" alt="image" src="https://github.com/user-attachments/assets/c456d769-6b8f-499e-b1d8-a3cf0ce42c0d" />
