### PR TITLE
Add tags to notifications for restock settings

### DIFF
--- a/changedetectionio/processors/restock_diff/__init__.py
+++ b/changedetectionio/processors/restock_diff/__init__.py
@@ -72,6 +72,10 @@ class Watch(BaseWatch):
     def extra_notification_token_values(self):
         values = super().extra_notification_token_values()
         values['restock'] = self.get('restock', {})
+        
+        # Add restock_settings as a nested object
+        values['restock_settings'] = self.get('restock_settings', {})
+        
         return values
 
     def extra_notification_token_placeholder_info(self):
@@ -80,5 +84,9 @@ class Watch(BaseWatch):
         values.append(('restock.price', "Price detected"))
         values.append(('restock.original_price', "Original price at first check"))
 
-        return values
+        # Add restock_setttings descriptions
+        values.append(('restock_settings.price_change_max', "Above price change to trigger notification"))
+        values.append(('restock_settings.price_change_min', "Below price change to trigger notification"))
+        values.append(('restock_settings.price_change_threshold_percent', "Price threshold to trigger notification"))
 
+        return values


### PR DESCRIPTION
NEW PR, this time with correct understanding of the code base ^^. 

When receiving notifications I would like to list the restock settings (notifiy when lower than) options in the notification email.

For example, I set a watch to notify me when a product is below the MSRP (Minimum Suggested Retail Price). When the notification is received it would be handy to have all information in one email. Old price, New price and MSRP. Then I can act on the information provided without searching for the initial MSRP setting

<img width="456" height="399" alt="image" src="https://github.com/user-attachments/assets/51b57de9-ced8-4dab-98fc-164d911bb014" />

```
Target: 39.95

Previous amount: 39.94
New amount: 39.9
```

Also adds the hints/tags:
<img width="1282" height="232" alt="image" src="https://github.com/user-attachments/assets/49543406-407d-4db0-b7d7-62d10ccd0780" />
