### PR TITLE
Add extra notification restock tokens

### DIFF
--- a/changedetectionio/processors/restock_diff/__init__.py
+++ b/changedetectionio/processors/restock_diff/__init__.py
@@ -87,7 +87,7 @@ class Watch(BaseWatch):
         values.append(('restock.price', "Price detected"))
         values.append(('restock.original_price', "Original price at first check"))
 
-        # Add restock_setttings descriptions
+        # Add restock_settings descriptions
         values.append(('restock.price_change_max', "Above price change to trigger notification"))
         values.append(('restock.price_change_min', "Below price change to trigger notification"))
         values.append(('restock.price_change_threshold_percent', "Price threshold to trigger notification"))


### PR DESCRIPTION
When receiving notifications I would like to list additional restock tokens in the notification email:
```
price_change_max
price_change_min
price_change_threshold_percent
```

Usecase: I set a watch to notify me when a product is below the MSRP (Minimum Suggested Retail Price). When the notification is received it would be handy to have all information in one email. Old price, New price and MSRP. Then I can act on the information provided without searching for the initial MSRP setting.
```
Target amount: 39.95 (restock.min_price_change)
Previous amount: 39.94 
New amount: 39.9
```

PR also adds the token hints. I chose to use `restock.varname` instead of `restock_setting.varname` because for end user `restock` can already be considered the settings.
```
restock.price_change_max > Above price change to trigger notification
restock.price_change_min > Below price change to trigger notification
restock.price_change_threshold_percent > Price threshold to trigger notification
```
