### PR TITLE
fix: strip null/placeholder browser_steps on save and add migration

### DIFF
--- a/changedetectionio/blueprint/ui/edit.py
+++ b/changedetectionio/blueprint/ui/edit.py
@@ -195,6 +195,13 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
                 # And del(form.data['tags'] ) wont work either for some reason
                 datastore.data['watching'][uuid]['tags'] = []
 
+            # clean null/placeholder browser_steps from form submission
+            if datastore.data['watching'][uuid].get('browser_steps'):
+                datastore.data['watching'][uuid]['browser_steps'] = [
+                    s for s in datastore.data['watching'][uuid]['browser_steps']
+                    if s.get('operation') and s['operation'] not in ('Choose one', 'Goto site')
+                ]
+
             # Recast it if need be to right data Watch handler
             watch_class = processors.get_custom_watch_obj_for_processor(form.data.get('processor'))
             datastore.data['watching'][uuid] = watch_class(datastore_path=datastore.datastore_path, __datastore=datastore.data, default=datastore.data['watching'][uuid])

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -998,9 +998,13 @@ class model(EntityPersistenceMixin, watch_base):
         # Exclude processor config keys (stored separately)
         watch_dict = {k: copy.deepcopy(v) for k, v in snapshot.items() if not k.startswith('processor_config_')}
 
-        # Normalize browser_steps: if no meaningful steps, save as empty list
-        if not self.has_browser_steps:
-            watch_dict['browser_steps'] = []
+        # strip null/placeholder browser_steps entries before saving
+        if watch_dict.get('browser_steps'):
+            watch_dict['browser_steps'] = [
+                step for step in watch_dict['browser_steps']
+                if step.get('operation')
+                and step['operation'] not in ('Choose one', 'Goto site')
+            ]
 
         return watch_dict
 

--- a/changedetectionio/store/updates.py
+++ b/changedetectionio/store/updates.py
@@ -723,3 +723,16 @@ class DatastoreUpdatesMixin:
         logger.info("Future tag edits will update both locations (dual storage)")
         logger.critical("=" * 80)
 
+    def update_29(self):
+        """clean browser_steps with null/placeholder operations from saved watches"""
+        for uuid, watch in self.data['watching'].items():
+            steps = watch.get('browser_steps', [])
+            if steps:
+                cleaned = [
+                    s for s in steps
+                    if s.get('operation')
+                    and s['operation'] not in ('Choose one', 'Goto site')
+                ]
+                if len(cleaned) != len(steps):
+                    self.data['watching'][uuid]['browser_steps'] = cleaned
+


### PR DESCRIPTION
fixes #3874

the frontend always renders 10 browser step form slots but when only a few are configured, the remaining ones get saved with operation=null or 'Choose one'. this caused API validation errors when the data was read back and resubmitted.

changes:
- _get_commit_data now always strips entries with null/empty/placeholder operations before persisting, instead of only clearing the whole list when theres no valid steps
- form save in edit.py also cleans up before writing
- added update_29 migration to fix existing watch data that has these bad entries

tested by creating a watch with browser steps, confirming only the valid steps get persisted