### PR TITLE
fix: XLSX import error messages report wrong row number after failed rows

### DIFF
--- a/changedetectionio/blueprint/imports/importer.py
+++ b/changedetectionio/blueprint/imports/importer.py
@@ -160,8 +160,7 @@ class import_xlsx_wachete(Importer):
             flash(gettext("Unable to read export XLSX file, something wrong with the file?"), 'error')
             return
 
-        row_id = 2
-        for row in wb.active.iter_rows(min_row=row_id):
+        for row_id, row in enumerate(wb.active.iter_rows(min_row=2), start=2):
             try:
                 extras = {}
                 data = {}
@@ -212,8 +211,6 @@ class import_xlsx_wachete(Importer):
             except Exception as e:
                 logger.error(e)
                 flash(gettext("Error processing row number {}, check all cell data types are correct, row was skipped.").format(row_id), 'error')
-            else:
-                row_id += 1
 
         flash(gettext("{} imported from Wachete .xlsx in {:.2f}s").format(len(self.new_uuids), time.time() - now))
 
@@ -241,10 +238,10 @@ class import_xlsx_custom(Importer):
 
         # @todo cehck atleast 2 rows, same in other method
         from changedetectionio.forms import validate_url
-        row_i = 1
+        row_i = 0
 
         try:
-            for row in wb.active.iter_rows():
+            for row_i, row in enumerate(wb.active.iter_rows(), start=1):
                 url = None
                 tags = None
                 extras = {}
@@ -295,7 +292,5 @@ class import_xlsx_custom(Importer):
         except Exception as e:
             logger.error(e)
             flash(gettext("Error processing row number {}, check all cell data types are correct, row was skipped.").format(row_i), 'error')
-        else:
-            row_i += 1
 
         flash(gettext("{} imported from custom .xlsx in {:.2f}s").format(len(self.new_uuids), time.time() - now))

--- a/changedetectionio/tests/test_import.py
+++ b/changedetectionio/tests/test_import.py
@@ -214,3 +214,85 @@ def test_import_watchete_xlsx(client, live_server, measure_memory_usage, datasto
             assert watch.get('fetch_backend') == 'system' # uses default if blank
 
     delete_all_watches(client)
+
+
+def test_import_wachete_xlsx_row_counter(client, live_server, measure_memory_usage, datastore_path):
+    """Row counter in Wachete XLSX import must advance even after a failed row.
+
+    Regression: row_id was only incremented in the try/else (on success), so
+    after any failure the counter froze and all subsequent errors cited the
+    stale number.  With the enumerate() fix, row 5 must say "row 5", not "row 3".
+    """
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    # Header row (row 1)
+    ws.append(['Name', 'Id', 'Url', 'Interval (min)', 'XPath', 'Dynamic Wachet', 'Portal Wachet', 'Folder'])
+    # Row 2: valid
+    ws.append(['Site A', '001', 'https://example.com/a', 60, None, None, None, None])
+    # Row 3: bad URL — must report row 3
+    ws.append(['Site B', '002', 'not-a-valid-url', 60, None, None, None, None])
+    # Row 4: valid
+    ws.append(['Site C', '003', 'https://example.com/c', 60, None, None, None, None])
+    # Row 5: bad URL — must report row 5, not "row 3" (the pre-fix stale value)
+    ws.append(['Site D', '004', 'also-not-valid', 60, None, None, None, None])
+
+    xlsx_bytes = io.BytesIO()
+    wb.save(xlsx_bytes)
+    xlsx_bytes.seek(0)
+
+    res = client.post(
+        url_for("imports.import_page"),
+        data={'file_mapping': 'wachete', 'xlsx_file': (xlsx_bytes, 'test.xlsx')},
+        follow_redirects=True,
+    )
+
+    assert b'2 imported from Wachete .xlsx' in res.data
+    assert b'Error processing row number 3' in res.data
+    assert b'Error processing row number 5' in res.data
+
+    delete_all_watches(client)
+
+
+def test_import_custom_xlsx_row_counter(client, live_server, measure_memory_usage, datastore_path):
+    """Row counter in custom XLSX import must reflect the actual row, not always row 1.
+
+    Regression: row_i was incremented in the else clause of the *outer* try/except
+    (which only fired once, after the whole loop), so every URL-validation error
+    inside the loop reported "row 1".  With enumerate() the third row must say
+    "row 3", not "row 1".
+    """
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    # Row 1: bad URL — must report row 1
+    ws.append(['not-valid-url-row1'])
+    # Row 2: valid
+    ws.append(['https://example.com/b'])
+    # Row 3: bad URL — must report row 3, not "row 1" (the pre-fix value)
+    ws.append(['not-valid-url-row3'])
+    # Row 4: valid
+    ws.append(['https://example.com/d'])
+
+    xlsx_bytes = io.BytesIO()
+    wb.save(xlsx_bytes)
+    xlsx_bytes.seek(0)
+
+    res = client.post(
+        url_for("imports.import_page"),
+        data={
+            'file_mapping': 'custom',
+            'custom_xlsx[col_0]': '1',
+            'custom_xlsx[col_type_0]': 'url',
+            'xlsx_file': (xlsx_bytes, 'test.xlsx'),
+        },
+        follow_redirects=True,
+    )
+
+    assert b'2 imported from custom .xlsx' in res.data
+    assert b'Error processing row number 1' in res.data
+    assert b'Error processing row number 3' in res.data
+
+    delete_all_watches(client)


### PR DESCRIPTION
Both XLSX importers (`import_xlsx_wachete` and `import_xlsx_custom`) report the wrong row number in error messages when a row fails to import.

**Wachete importer**: `row_id` was only incremented inside the `try/except`'s `else` clause, meaning it only advanced on success. After any failed row, the counter froze and all subsequent error messages pointed to the stale row number.

For example, if rows 2-4 succeed but row 5 fails, `row_id` is 5 (correct). But if row 3 fails, `row_id` stays at 3, and if row 4 also fails, its error also says "row 3".

**Custom XLSX importer**: `row_i` started at 1 and was incremented in the `else` clause of the *outer* `try/except` that wraps the entire for loop — so it only incremented once, after all rows finished. Every URL validation error inside the loop always said "row 1" regardless of which row actually had the problem.

**Fix**: Replace manual counters with `enumerate()` so the row number tracks the actual iteration position regardless of success or failure.

The existing test (`test_import_custom_xlsx` checking for `'Error processing row number 1'`) still passes because the first data row is what triggers the error.