### PR TITLE
fix: crash in send_step_failure_notification — wrong _check_cascading_vars call

### DIFF
--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -496,7 +496,7 @@ Thanks - Your omniscient changedetection.io installation.
         n_object = NotificationContextData({
             'notification_title': f"Changedetection.io - Alert - Browser step at position {step} could not be run",
             'notification_body': body,
-            'notification_format': self._check_cascading_vars('notification_format', watch),
+            'notification_format': _check_cascading_vars(self.datastore, 'notification_format', watch),
         })
         n_object['markup_text_links_to_html_links'] = n_object.get('notification_format').startswith('html')
 


### PR DESCRIPTION
## Problem

`send_step_failure_notification` (line 499) calls `_check_cascading_vars` incorrectly:

```python
# broken — _check_cascading_vars is a module-level function, not a method
'notification_format': self._check_cascading_vars('notification_format', watch),
```

This raises `AttributeError: 'NotificationService' object has no attribute '_check_cascading_vars'` every time a browser step failure notification fires.

## Fix

Use the same call pattern already used at lines 408–411 and 450:

```python
'notification_format': _check_cascading_vars(self.datastore, 'notification_format', watch),
```

## Before / After

**Before:** Any watch with browser steps configured that hits the step-failure notification threshold crashes instead of notifying the user.

**After:** The notification is sent using the correct cascading format (watch → tag → global → default), matching `send_filter_failure_notification` and `send_content_changed_notification`.

## Checks

Verified by reading the code — `_check_cascading_vars` is defined at module level (line 17) with signature `(datastore, var_name, watch)`. The broken call omits `datastore` and uses `self.` prefix on a non-method.