### PR TITLE
Fix unresponsive "help and tips" button on tag edit screen

### DIFF
--- a/changedetectionio/blueprint/tags/templates/edit-tag.html
+++ b/changedetectionio/blueprint/tags/templates/edit-tag.html
@@ -17,6 +17,7 @@
 
 </script>
 
+<script src="{{url_for('static_content', group='js', filename='global-settings.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='watch-settings.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='notifications.js')}}" defer></script>
 


### PR DESCRIPTION
## Problem

On the tag edit screen, the following buttons on the "Filters & Triggers" and "Notifications" tabs do nothing when clicked:

- **Show advanced help and tips** (Filters & Triggers tab / Notifications tab)
- **Show token/placeholders** (Notifications tab)

All of them are toggle buttons with the `.toggle-show` class.
**The same buttons work correctly on the watch edit screen.**

## Chrome DevTools Event Listeners panel

Checking the Event Listeners tab shows whether a click handler is bound.

**Tag edit screen (before fix, click handler missing):**

<img width="1377" height="479" alt="group_before" src="https://github.com/user-attachments/assets/f652380f-bdac-48d2-8543-d84a1fb196bd" />

**Watch edit screen (working, click handler present):**

<img width="1386" height="533" alt="watch" src="https://github.com/user-attachments/assets/2f967bc9-f079-4e7b-8260-34a19d7a780d" />

## Cause

https://github.com/dgtlmoon/changedetection.io/blob/8cfa6eb336c78ba73b7f84e173eaf486a262c0e4/changedetectionio/static/js/global-settings.js#L21-L25

The tag edit screen does not load `global-settings.js`,
so the click handler for `.toggle-show` is never bound.
The watch edit screen loads it as below, which is why the same buttons work there.

https://github.com/dgtlmoon/changedetection.io/blob/8cfa6eb336c78ba73b7f84e173eaf486a262c0e4/changedetectionio/blueprint/ui/templates/edit.html#L7

## Verification

- Tag edit > Filters & Triggers > "Show advanced help and tips" expands the help
- Tag edit > Notifications > "Show advanced help and tips" expands the help
- Tag edit > Notifications > "Show token/placeholders" expands the placeholders