### PR TITLE
Fix broken opacity feedback for restock/price fields on tag edit screen

### DIFF
--- a/changedetectionio/blueprint/tags/templates/edit-tag.html
+++ b/changedetectionio/blueprint/tags/templates/edit-tag.html
@@ -17,6 +17,7 @@
 
 </script>
 
+<script src="{{url_for('static_content', group='js', filename='plugins.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='global-settings.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='watch-settings.js')}}" defer></script>
 <script src="{{url_for('static_content', group='js', filename='notifications.js')}}" defer></script>


### PR DESCRIPTION
## Background

While opening the tag edit screen, I noticed the following error in the browser console:

```js
Uncaught ReferenceError: toggleOpacity is not defined
```

After investigating, I found that `toggleOpacity` is defined in `plugins.js`:

https://github.com/dgtlmoon/changedetection.io/blob/4f61f65769106ef986dffe558b55cd1fca0d8803/changedetectionio/static/js/plugins.js#L166

But only the tag edit screen template (`edit-tag.html`) was missing the `plugins.js` import.
It is loaded on the watch edit screen (`edit.html`), `settings.html`, `diff.html`, and `preview.html`.

## User impact

On the "Restock & Price Detection" extras tab,
the opacity feedback tied to the following two checkboxes was not working:

1. **"Activate for individual watches in this tag/group?"**
2. **"Follow price changes"**

## Screenshots

### Before
<img width="1696" height="814" alt="before_opacity" src="https://github.com/user-attachments/assets/857b1395-4b5b-4fc4-8047-4b97fe3e74fb" />

### After
<img width="1696" height="814" alt="after_opacity" src="https://github.com/user-attachments/assets/09a46d13-4df8-4861-b2b6-f2ccdebbe61a" />

## Note: a different console error still remains

After loading `plugins.js`, the `ReferenceError` goes away, but a different error now shows up in the console:

```js
Uncaught TypeError: Cannot read properties of null (reading 'checked')
```

There does not appear to be any functional impact, but it still pollutes the console.
If that bothers you, it might be worth adding a null guard to `toggleOpacity` / `toggleVisibility` in `plugins.js`.
