### PR TITLE
DeprecationWarning: codecs.open() is deprecated. Use open() instead.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-import codecs
 import os.path
 import re
-import sys
 
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
@@ -12,7 +10,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 
 def read(*parts):
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    with open(os.path.join(here, *parts), 'r', encoding='utf-8') as f:
+        return f.read()
 
 
 def find_version(*file_paths):


### PR DESCRIPTION
## Issue

On Python 3.14, running `python setup.py` command emits the following `DeprecationWarning`:

```console
$ python setup.py compile_catalog
setup.py:15: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  return codecs.open(os.path.join(here, *parts), 'r').read()
running compile_catalog
compiling catalog changedetectionio/translations/en_US/LC_MESSAGES/messages.po to changedetectionio/translations/en_US/LC_MESSAGES/messages.mo
...

$ python setup.py update_catalog
setup.py:15: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  return codecs.open(os.path.join(here, *parts), 'r').read()
running update_catalog
updating catalog changedetectionio/translations/en_US/LC_MESSAGES/messages.po based on changedetectionio/translations/messages.pot
...
```

This warning was introduced in Python 3.14 ([`codecs` — Python official docs](https://docs.python.org/3/library/codecs.html#codecs.open)):

> Deprecated since version 3.14: `codecs.open()` has been superseded by `open()`.

## Verification

Ran `python setup.py compile_catalog` and `python setup.py update_catalog`; the `DeprecationWarning` is gone.
