### PR TITLE
i18n: Ruff INT (flake8-gettext)

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Lint with Ruff
         run: |
           pip install ruff
-          # Check for syntax errors and undefined names
-          ruff check . --select E9,F63,F7,F82
+          # Check for syntax errors and undefined names, and gettext misuse
+          ruff check . --select E9,F63,F7,F82,INT
           # Complete check with errors treated as warnings
           ruff check . --exit-zero
       - name: Validate OpenAPI spec

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -20,10 +20,11 @@ exclude = [
 select = [
     "B", # flake8-bugbear
     "B9",
-    "C", 
+    "C",
     "E", # pycodestyle
     "F", # Pyflakes
     "I", # isort
+    "INT", # flake8-gettext
     "N", # pep8-naming
     "UP", # pyupgrade
     "W", # pycodestyle
@@ -42,6 +43,9 @@ ignore = [
 
 [lint.mccabe]
 max-complexity = 12
+
+[lint.flake8-gettext]
+extend-function-names = ["_l", "lazy_gettext", "pgettext", "npgettext"]
 
 [format]
 indent-style = "space"


### PR DESCRIPTION
## Motivation

Enable [Ruff's `INT` rules (flake8-gettext)](https://docs.astral.sh/ruff/rules/#flake8-gettext-int)
to catch `_(f"...")`, `_("...".format(...))`, and `_("..." % arg)`,
where the `msgid` is resolved before the `gettext` call.
The `msgid` that the runtime queries does not exist in the catalog as written,
leaving the string silently untranslated in every locale.

## Configuration

Ruff's flake8-gettext targets `_` / `gettext` / `ngettext` by default.
To cover all the lazy / contextual variants Flask-Babel provides, this PR extends
the target list via [`lint.flake8-gettext.extend-function-names`](https://docs.astral.sh/ruff/settings/#lint_flake8-gettext_extend-function-names)
to also cover `_l` / `lazy_gettext` / `pgettext` / `npgettext`.