### PR TITLE
i18n: Enforce dennis lint warnings in CI

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -36,23 +36,19 @@ jobs:
           pip install "$(grep -E '^dennis ?>=' requirements.txt)"
           dennis-cmd lint --errorsonly changedetectionio/translations/
       - name: Lint .pot template with dennis (baseline-limited warnings)
-        # BASELINE: this limit reflects pre-existing dennis warnings present
-        # when this check was introduced.
-        # It must only ever go DOWN. Each time you fix a warning,
-        # lower BASELINE_LIMIT below so the improvement is locked in.
-        # When the count reaches 0, replace this step with `dennis-cmd lint --errorsonly`
-        # plus a strict warnings>0 fail check.
+        # BASELINE: dennis warnings present when this check was introduced. Ratchet down only.
+        # Each time a warning is fixed, lower BASELINE_LIMIT to lock in the improvement.
+        # Once it reaches 0, replace this step with a strict (`warnings > 0` fails) check,
+        # matching the `.po` step.
         env:
           BASELINE_LIMIT: 12
         run: |
           output=$(dennis-cmd lint changedetectionio/translations/messages.pot)
           echo "$output"
           warnings=$(echo "$output" | awk '/Warnings:/ {print $NF; exit}')
-          warnings=${warnings:-0}
-          echo "dennis warnings in messages.pot: ${warnings} (limit: ${BASELINE_LIMIT})"
-          if (( warnings > BASELINE_LIMIT )); then
-            echo "ERROR: ${warnings} warnings exceed baseline of ${BASELINE_LIMIT}."
-            echo "Fix new warnings in source code, or lower BASELINE_LIMIT if you fixed some."
+          if (( ${warnings:-0} > BASELINE_LIMIT )); then
+            echo "ERROR: ${warnings} dennis warning(s) exceed baseline of ${BASELINE_LIMIT} in messages.pot"
+            echo "Fix the new warning(s). BASELINE_LIMIT may only ratchet downward."
             exit 1
           fi
       - name: Lint .po files with dennis (warnings)
@@ -67,7 +63,8 @@ jobs:
           echo "$output"
           warnings=$(echo "$output" | awk '/Total number of warnings:/ {print $NF; exit}')
           if (( ${warnings:-0} > 0 )); then
-            echo "ERROR: dennis reported ${warnings} warning(s) in .po files."
+            echo "ERROR: ${warnings} dennis warning(s) detected in .po files"
+            echo "Fix the warning(s)."
             exit 1
           fi
       - name: Check translation catalog is up-to-date

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -35,9 +35,26 @@ jobs:
         run: |
           pip install "$(grep -E '^dennis ?>=' requirements.txt)"
           dennis-cmd lint --errorsonly changedetectionio/translations/
-      - name: Lint .pot template with dennis (warnings, informational)
+      - name: Lint .pot template with dennis (baseline-limited warnings)
+        # BASELINE: this limit reflects pre-existing dennis warnings present
+        # when this check was introduced.
+        # It must only ever go DOWN. Each time you fix a warning,
+        # lower BASELINE_LIMIT below so the improvement is locked in.
+        # When the count reaches 0, replace this step with `dennis-cmd lint --errorsonly`
+        # plus a strict warnings>0 fail check.
+        env:
+          BASELINE_LIMIT: 11
         run: |
-          dennis-cmd lint changedetectionio/translations/messages.pot
+          output=$(dennis-cmd lint changedetectionio/translations/messages.pot)
+          echo "$output"
+          warnings=$(echo "$output" | awk '/Warnings:/ {print $2; exit}')
+          warnings=${warnings:-0}
+          echo "dennis warnings in messages.pot: ${warnings} (limit: ${BASELINE_LIMIT})"
+          if (( warnings > BASELINE_LIMIT )); then
+            echo "ERROR: ${warnings} warnings exceed baseline of ${BASELINE_LIMIT}."
+            echo "Fix new warnings in source code, or lower BASELINE_LIMIT if you fixed some."
+            exit 1
+          fi
       - name: Lint .po files with dennis (warnings, informational)
         # W302 (unchanged) and W303 (html mismatch) are excluded due to
         # high false-positive rate in this codebase:

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           output=$(dennis-cmd lint changedetectionio/translations/messages.pot)
           echo "$output"
-          warnings=$(echo "$output" | awk '/Warnings:/ {print $2; exit}')
+          warnings=$(echo "$output" | awk '/Warnings:/ {print $NF; exit}')
           warnings=${warnings:-0}
           echo "dennis warnings in messages.pot: ${warnings} (limit: ${BASELINE_LIMIT})"
           if (( warnings > BASELINE_LIMIT )); then
@@ -55,15 +55,21 @@ jobs:
             echo "Fix new warnings in source code, or lower BASELINE_LIMIT if you fixed some."
             exit 1
           fi
-      - name: Lint .po files with dennis (warnings, informational)
+      - name: Lint .po files with dennis (warnings)
         # W302 (unchanged) and W303 (html mismatch) are excluded due to
         # high false-positive rate in this codebase:
         # many msgstrs intentionally match msgid (units like "Mb", proper nouns),
         # and many msgids contain literal "<title>"/"<description>" text that isn't actual HTML.
         run: |
-          dennis-cmd lint \
+          output=$(dennis-cmd lint \
             --excluderules=W302,W303 \
-            changedetectionio/translations/*/LC_MESSAGES/messages.po
+            changedetectionio/translations/*/LC_MESSAGES/messages.po)
+          echo "$output"
+          warnings=$(echo "$output" | awk '/Total number of warnings:/ {print $NF; exit}')
+          if (( ${warnings:-0} > 0 )); then
+            echo "ERROR: dennis reported ${warnings} warning(s) in .po files."
+            exit 1
+          fi
       - name: Check translation catalog is up-to-date
         run: |
           pip install "$(grep -E '^babel==' requirements.txt)"

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -43,7 +43,7 @@ jobs:
         # When the count reaches 0, replace this step with `dennis-cmd lint --errorsonly`
         # plus a strict warnings>0 fail check.
         env:
-          BASELINE_LIMIT: 11
+          BASELINE_LIMIT: 12
         run: |
           output=$(dennis-cmd lint changedetectionio/translations/messages.pot)
           echo "$output"


### PR DESCRIPTION
## Problem

1. `dennis-cmd lint` exits 0 when only warnings are present.
1. The warning steps added in #4097 therefore never fail.
1. New warnings can slip into CI undetected.

## Approach

Inspired by the [`BASELINE_LIMIT` pattern in the `lint-template-i18n` job](https://github.com/dgtlmoon/changedetection.io/blob/e4bc048280af72adf07f6213cd23ef763087a00a/.github/workflows/test-only.yml#L71) of the same workflow,
add a fail check to the dennis warning steps:

- `.pot`: 12 pre-existing warnings (`W501`×2, `W502`×10) — baseline at `BASELINE_LIMIT=12`.
- `.po`: 0 warnings once `W302`/`W303` are excluded — strict (`warnings > 0` fails).

> [!NOTE]
> `BASELINE_LIMIT` for `.pot` ratchets downward only; once it reaches 0,
> replace this step with a strict (`warnings > 0` fails) check.
> The policy is noted inline in the workflow.

## Changes

1. f4cc4fb: Add the baseline fail check for the `.pot` step
   (`BASELINE_LIMIT=11` here — a deliberate off-by-one to confirm the boundary check fails CI as expected).
1. e8c53e2: Bump `BASELINE_LIMIT` back to 12 (the actual warning count) to bring CI back to green.
1. ccd5df5: Switch the `.po` step to strict (`warnings > 0` fails).
