### PR TITLE
docs: fix Docker Compose wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Easily add the current web page to your changedetection.io tool, simply install 
 
 ### Docker
 
-With Docker composer, just clone this repository and..
+With Docker Compose, just clone this repository and run:
 
 ```bash
 $ docker compose up -d


### PR DESCRIPTION
## Summary\n- fix the Docker install sentence in the README\n- change "Docker composer" to "Docker Compose" and make the instruction read naturally\n\n## Why\nThis is a small docs polish that removes a common naming mistake and makes the quick-start instruction clearer for new users.\n\n## Verification\n- verified the README now says: "With Docker Compose, just clone this repository and run:"