### PR TITLE
test: add edge case coverage for notification format validation and HTML safety

### DIFF
--- a/changedetectionio/tests/test_notification_format_validation.py
+++ b/changedetectionio/tests/test_notification_format_validation.py
@@ -1,0 +1,62 @@
+import pytest
+from changedetectionio.notification.handler import notification_format_align_with_apprise
+from apprise import NotifyFormat
+
+
+class TestNotificationFormatValidation:
+	"""
+	Tests for notification_format_align_with_apprise() edge cases.
+	Validates the function handles format strings correctly per issue #4119.
+	"""
+
+	def test_empty_format_returns_text(self):
+		"""Empty string should return TEXT (default fallback)."""
+		result = notification_format_align_with_apprise('')
+		assert result == NotifyFormat.TEXT.value
+
+	def test_none_format_returns_text(self):
+		"""None should return TEXT (default fallback)."""
+		result = notification_format_align_with_apprise(None)
+		assert result == NotifyFormat.TEXT.value
+
+	def test_htmlcolor_normalizes_to_html(self):
+		"""htmlcolor format (changedetection default) should normalize to HTML for apprise."""
+		result = notification_format_align_with_apprise('htmlcolor')
+		assert result == NotifyFormat.HTML.value
+
+	def test_html_normalizes_to_html(self):
+		"""Explicit html format should remain HTML."""
+		result = notification_format_align_with_apprise('html')
+		assert result == NotifyFormat.HTML.value
+
+	def test_text_normalizes_to_text(self):
+		"""text format should remain TEXT."""
+		result = notification_format_align_with_apprise('text')
+		assert result == NotifyFormat.TEXT.value
+
+	def test_markdown_normalizes_to_markdown(self):
+		"""markdown format should normalize to MARKDOWN for apprise."""
+		result = notification_format_align_with_apprise('markdown')
+		assert result == NotifyFormat.MARKDOWN.value
+
+	def test_unknown_format_defaults_to_text(self):
+		"""Unknown format strings should fallback to TEXT."""
+		result = notification_format_align_with_apprise('unknownformat')
+		assert result == NotifyFormat.TEXT.value
+
+	def test_case_insensitive_html(self):
+		"""Format matching should be case-insensitive for the prefix check."""
+		result = notification_format_align_with_apprise('HTML')
+		assert result == NotifyFormat.HTML.value
+
+	def test_case_insensitive_text(self):
+		"""Format matching should be case-insensitive."""
+		result = notification_format_align_with_apprise('TEXT')
+		assert result == NotifyFormat.TEXT.value
+
+	def test_system_default_marker_uses_text(self):
+		"""USE_SYSTEM_DEFAULT sentinel value should fallback to TEXT."""
+		from changedetectionio.model import USE_SYSTEM_DEFAULT_NOTIFICATION_FORMAT_FOR_WATCH
+		result = notification_format_align_with_apprise(USE_SYSTEM_DEFAULT_NOTIFICATION_FORMAT_FOR_WATCH)
+		# The sentinel is not a valid format for apprise, so it defaults to TEXT
+		assert result == NotifyFormat.TEXT.value

--- a/changedetectionio/tests/test_notification_html_safety.py
+++ b/changedetectionio/tests/test_notification_html_safety.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import MagicMock
+from changedetectionio.notification.handler import notification_format_align_with_apprise, markup_text_links_to_html
+from apprise import NotifyFormat
+
+
+class TestMarkupTextLinksToHtml:
+	"""Edge case tests for markup_text_links_to_html() XSS safety."""
+
+	def test_plain_text_no_links(self):
+		"""Plain text without URLs should be escaped and returned as safe HTML."""
+		input_text = "This is plain text with <special> characters"
+		result = markup_text_links_to_html(input_text)
+		# Result should be Markup (safe) not raw HTML
+		assert '<a href=' not in str(result) or '&lt;' in str(result)
+
+	def test_single_url_converted_to_link(self):
+		"""Single URL in text should be converted to clickable link."""
+		input_text = "Visit https://example.com for more info"
+		result = markup_text_links_to_html(input_text)
+		assert 'href="https://example.com"' in str(result) or 'href="https://example.com/' in str(result)
+
+	def test_multiple_urls(self):
+		"""Multiple URLs should each become clickable links."""
+		input_text = "Check https://foo.com and https://bar.com today"
+		result = markup_text_links_to_html(input_text)
+		result_str = str(result)
+		# Both URLs should be linked
+		assert 'href="https://foo.com"' in result_str or 'href="https://foo.com/' in result_str
+		assert 'href="https://bar.com"' in result_str or 'href="https://bar.com/' in result_str
+
+	def test_empty_string(self):
+		"""Empty string input should return empty safe HTML."""
+		result = markup_text_links_to_html('')
+		assert result == '' or str(result) == ''
+
+	def test_xss_attempt_script_tag(self):
+		"""XSS attempts like <script> should be escaped, not rendered."""
+		input_text = "Click <script>alert('xss')</script> here"
+		result = markup_text_links_to_html(input_text)
+		result_str = str(result)
+		# Script tag should be escaped, not executable
+		assert '&lt;script&gt;' in result_str or '<script>' not in result_str
+
+	def test_xss_attempt_onclick(self):
+		"""onclick XSS in URL should be escaped."""
+		input_text = "See https://evil.com/p?q=<img onerror=alert(1)>"
+		result = markup_text_links_to_html(input_text)
+		result_str = str(result)
+		# The malicious part should be escaped
+		assert '&lt;' in result_str or '<img' not in result_str


### PR DESCRIPTION
## Summary
- Add test_notification_format_validation.py with 10 tests for notification_format_align_with_apprise() edge cases
- Add test_notification_html_safety.py with 6 tests for markup_text_links_to_html() XSS safety
- Covers: empty/None input, htmlcolor normalization, case insensitivity, unknown format fallback, XSS attempts

## Problem
- notification_format_align_with_apprise() had no dedicated unit tests
- markup_text_links_to_html() had no XSS safety regression tests
- Issue #4119 identified notification format cascade as a fragile code path

## Solution
Tests that verify:
1. Empty string → TEXT (default)
2. None → TEXT (default)
3. htmlcolor → HTML (apprise alignment)
4. html/text/markdown normalization
5. Unknown format → TEXT fallback
6. Case insensitivity
7. Plain text with no links → escaped
8. Single/multiple URL → clickable links
9. XSS attempt with script tag → escaped (not executable)
10. XSS attempt with onclick → escaped

## Tests
pytest tests can be run with: pytest changedetectionio/tests/test_notification_format_validation.py changedetectionio/tests/test_notification_html_safety.py -v

## Risk / Compatibility
- Risk: LOW — test-only additions
- Affects: tests only