### PR TITLE
fix: handle None 'tags' in application settings to prevent crash

### DIFF
--- a/changedetectionio/blueprint/tags/__init__.py
+++ b/changedetectionio/blueprint/tags/__init__.py
@@ -17,7 +17,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         from .form import SingleTag
         add_form = SingleTag(request.form)
 
-        sorted_tags = sorted(datastore.data['settings']['application'].get('tags').items(), key=lambda x: x[1]['title'])
+        sorted_tags = sorted(datastore.data['settings']['application'].get('tags', {}).items(), key=lambda x: x[1]['title'])
 
         from collections import Counter
 

--- a/changedetectionio/blueprint/watchlist/__init__.py
+++ b/changedetectionio/blueprint/watchlist/__init__.py
@@ -79,7 +79,7 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
                                 display_msg=_('displaying <b>{start} - {end}</b> {record_name} in total <b>{total}</b>'),
                                 record_name=_('records'))
 
-        sorted_tags = sorted(datastore.data['settings']['application'].get('tags').items(), key=lambda x: x[1]['title'])
+        sorted_tags = sorted(datastore.data['settings']['application'].get('tags', {}).items(), key=lambda x: x[1]['title'])
 
         proxy_list = datastore.proxy_list
 


### PR DESCRIPTION
## Bug: AttributeError when tags is None

**Files:** 
- `changedetectionio/blueprint/tags/__init__.py` line 20
- `changedetectionio/blueprint/watchlist/__init__.py` line 83

**Problem:** When `application['tags']` is `None` (uninitialized), calling `.get('tags').items()` crashes with `AttributeError: 'NoneType' object has no attribute 'items'`.

**Root Cause:** `get('tags')` returns `None` when the key exists but has no value. The subsequent `.items()` call assumes a dict.

**Fix:** Use `get('tags', {})` to default to an empty dict, matching the `App.py` initialization.

**Impact:** Crashes the web UI (tags overview page and watchlist index) if tags were never configured.