### PR TITLE
lint: Bump dennis — adopt `--strict` mode and drop false-positive workarounds

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -37,8 +37,7 @@ jobs:
           dennis-cmd lint --strict changedetectionio/translations/messages.pot
       - name: Lint .po files with dennis
         run: |
-          dennis-cmd lint --strict changedetectionio/translations/*/LC_MESSAGES/messages.po
-        # --excluderules=W302
+          dennis-cmd lint --strict --excluderules=W302 changedetectionio/translations/*/LC_MESSAGES/messages.po
         # W302 (unchanged) is excluded due to high false-positive rate in this codebase:
         # many msgstrs intentionally match msgid (units like "AI", "LLM", and proper nouns).
       - name: Check translation catalog is up-to-date

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -31,33 +31,16 @@ jobs:
             echo "Checking $f"
             msgfmt --check-format -o /dev/null "$f"
           done
-      - name: Lint .po/.pot files with dennis (errors only)
+      - name: Lint .pot template with dennis
         run: |
           pip install "$(grep -E '^dennis ?>=' requirements.txt)"
-          dennis-cmd lint --errorsonly changedetectionio/translations/
-      - name: Lint .pot template with dennis (warnings)
+          dennis-cmd lint --strict changedetectionio/translations/messages.pot
+      - name: Lint .po files with dennis
         run: |
-          output=$(dennis-cmd lint changedetectionio/translations/messages.pot)
-          echo "$output"
-          warnings=$(echo "$output" | awk '/Warnings:/ {print $NF; exit}')
-          if (( ${warnings:-0} > 0 )); then
-            echo "ERROR: ${warnings} dennis warning(s) detected in messages.pot"
-            echo "Fix the warning(s)."
-            exit 1
-          fi
-      - name: Lint .po files with dennis (warnings)
+          dennis-cmd lint --strict changedetectionio/translations/*/LC_MESSAGES/messages.po
+        # --excluderules=W302
         # W302 (unchanged) is excluded due to high false-positive rate in this codebase:
         # many msgstrs intentionally match msgid (units like "AI", "LLM", and proper nouns).
-        run: |
-          output=$(dennis-cmd lint --excluderules=W302 \
-            changedetectionio/translations/*/LC_MESSAGES/messages.po)
-          echo "$output"
-          warnings=$(echo "$output" | awk '/Total number of warnings:/ {print $NF; exit}')
-          if (( ${warnings:-0} > 0 )); then
-            echo "ERROR: ${warnings} dennis warning(s) detected in .po files"
-            echo "Fix the warning(s)."
-            exit 1
-          fi
       - name: Check translation catalog is up-to-date
         run: |
           pip install "$(grep -E '^babel==' requirements.txt)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,19 @@ repos:
         args: [--fix]
       # Fomrat
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: dennis-lint-pot
+        name: dennis lint pot
+        language: system
+        entry: dennis-cmd lint --strict
+        files: ^changedetectionio/translations/messages\.pot$
+        pass_filenames: true
+
+      - id: dennis-lint-po
+        name: dennis lint po
+        language: system
+        entry: dennis-cmd lint --strict --excluderules=W302
+        files: ^changedetectionio/translations/\w+/LC_MESSAGES/messages\.po$
+        pass_filenames: true

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -887,7 +887,6 @@ class processor_text_json_diff_form(commonSettingsForm):
 
     conditions_match_logic = RadioField(_l('Match'), choices=[('ALL', _l('Match all of the following')),('ANY', _l('Match any of the following'))], default='ALL')
     conditions = FieldList(FormField(ConditionFormRow), min_entries=1)  # Add rule logic here
-    # dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
     use_page_title_in_list = TernaryNoneBooleanField(_l('Use page <title> in list'), default=None)
 
     history_snapshot_max_length = IntegerField(_l('Number of history items per watch to keep'), render_kw={"style": "width: 5em;"}, validators=[validators.Optional(), validators.NumberRange(min=2)])
@@ -1036,7 +1035,6 @@ class globalSettingsApplicationUIForm(Form):
     open_diff_in_new_tab = BooleanField(_l("Open 'History' page in a new tab"), default=True, validators=[validators.Optional()])
     socket_io_enabled = BooleanField(_l('Realtime UI Updates Enabled'), default=True, validators=[validators.Optional()])
     favicons_enabled = BooleanField(_l('Favicons Enabled'), default=True, validators=[validators.Optional()])
-    # dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
     use_page_title_in_list = BooleanField(_l('Use page <title> in watch overview list')) #BooleanField=True
 
 # datastore.data['settings']['application']..

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -34,7 +34,6 @@
             </tr>
             <tr>
                 <td><code>{{ '{{watch_title}}' }}</code></td>
-                {# TRANSLATORS: dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213 #}
                 <td>{{ _('The page title of the watch, uses <title> if not set, falls back to URL') }}</td>
             </tr>
             <tr>

--- a/changedetectionio/translations/README.md
+++ b/changedetectionio/translations/README.md
@@ -247,33 +247,30 @@ dennis-cmd lint --excluderules=W302 changedetectionio/translations/
 
 The `W303` rule ensures that HTML tags in the `msgstr` match the `msgid`. This is crucial for catching broken markup (e.g., missing closing tags).
 
-##### Handling intentional deviations and false positives
+##### Handling intentional deviations
 
-Some W303 warnings are intentional or result from upstream false positives.
+Some W303 warnings are intentional.
 Use the `dennis-ignore: W303` comment in the source files (templates or Python code) within a `TRANSLATORS` comment to suppress these warnings.
 This ensures the ignore instruction is extracted into the `.po` files.
 
 - **CJK italic policy**: When replacing `<i>` with locale-conventional quotation marks, tags will no longer match.
-- **Upstream false positive**: Dennis misinterprets certain HTML tags (e.g., `<title>`) within `msgstr`. See https://github.com/mozilla/dennis/issues/213.
 
 **Examples in Jinja2 templates:**
 
 ```jinja
 {# TRANSLATORS: CJK fonts lack native italics; allow substitution with conventional local styling. dennis-ignore: W303 #}
 <p>{{ _('These settings are <strong><i>added</i></strong> to any existing watch configurations.')|safe }}</p>
-
-{# TRANSLATORS: dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213 #}
-<td>{{ _('The page title of the watch, uses <title> if not set, falls back to URL') }}</td>
 ```
 
 **Example in Python source:**
 
 ```python
-# dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
-use_page_title_in_list = BooleanField(_l('Use page <title> in watch overview list'))
+# dennis-ignore: W303 - CJK fonts lack native italics; allow substitution with conventional local styling.
+message = StringField(_l('This is <i>experimental</i> and may change'))
 ```
 
 ---
+
 
 ## CI linter
 

--- a/changedetectionio/translations/cs/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/cs/LC_MESSAGES/messages.po
@@ -2959,7 +2959,6 @@ msgstr "Spojit všechny následující položky"
 msgid "Match any of the following"
 msgstr "Přiřaďte kteroukoli z následujících možností"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "V seznamu použijte stránku <title>"
@@ -3059,7 +3058,6 @@ msgstr "Aktualizace UI v reálném čase"
 msgid "Favicons Enabled"
 msgstr "Povolit favikony"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Použijte stránku <title> v přehledu sledování"
@@ -3453,7 +3451,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr "UUID monitoru."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/de/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/de/LC_MESSAGES/messages.po
@@ -3011,7 +3011,6 @@ msgstr "Passen Sie alle folgenden Punkte an"
 msgid "Match any of the following"
 msgstr "Entspricht einer der folgenden Bedingungen"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Verwenden Sie Seite <title> in der Liste"
@@ -3111,7 +3110,6 @@ msgstr "Echtzeit-UI-Updates aktiviert"
 msgid "Favicons Enabled"
 msgstr "Favicons Aktiviert"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Verwenden Sie die Seite <title> in der Übersichtsliste der Beobachtungen"
@@ -3507,7 +3505,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr "Die UUID der Überwachung."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
@@ -2953,7 +2953,6 @@ msgstr ""
 msgid "Match any of the following"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr ""
@@ -3053,7 +3052,6 @@ msgstr ""
 msgid "Favicons Enabled"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr ""
@@ -3447,7 +3445,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
@@ -2953,7 +2953,6 @@ msgstr ""
 msgid "Match any of the following"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr ""
@@ -3053,7 +3052,6 @@ msgstr ""
 msgid "Favicons Enabled"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr ""
@@ -3447,7 +3445,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/es/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/es/LC_MESSAGES/messages.po
@@ -3026,7 +3026,6 @@ msgstr "Coincide con todo lo siguiente"
 msgid "Match any of the following"
 msgstr "Coincide con cualquiera de los siguientes"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Usar página <title> en la lista"
@@ -3126,7 +3125,6 @@ msgstr "Actualizaciones de UI en tiempo real habilitadas"
 msgid "Favicons Enabled"
 msgstr "Favicones habilitados"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Usar <title> de la página en la lista general de monitores"
@@ -3520,7 +3518,6 @@ msgstr "La URL que se está viendo."
 msgid "The UUID of the watch."
 msgstr "El UUID del monitor."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "El título de la página del monitor, utiliza <title> si no se establece, vuelve a la URL"

--- a/changedetectionio/translations/fr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/fr/LC_MESSAGES/messages.po
@@ -2966,7 +2966,6 @@ msgstr "Faites correspondre tous les éléments suivants"
 msgid "Match any of the following"
 msgstr "Faites correspondre l'un des éléments suivants"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Utiliser la page <title> dans la liste"
@@ -3066,7 +3065,6 @@ msgstr "Mises à jour en temps réel hors ligne"
 msgid "Favicons Enabled"
 msgstr "Favicons Activés"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Utiliser la page <title> dans la liste de présentation des moniteurs"
@@ -3460,7 +3458,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr "L'UUID du moniteur."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/it/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/it/LC_MESSAGES/messages.po
@@ -2955,7 +2955,6 @@ msgstr "Corrisponde a tutti i seguenti"
 msgid "Match any of the following"
 msgstr "Corrisponde a uno qualsiasi dei seguenti"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Usa <title> pagina nell'elenco"
@@ -3055,7 +3054,6 @@ msgstr "Aggiornamenti UI in tempo reale attivi"
 msgid "Favicons Enabled"
 msgstr "Favicon attive"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Usa <title> pagina nell'elenco osservati"
@@ -3449,7 +3447,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr "L'UUID del monitor."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/ja/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ja/LC_MESSAGES/messages.po
@@ -2972,7 +2972,6 @@ msgstr "以下のすべてに一致"
 msgid "Match any of the following"
 msgstr "以下のいずれかに一致"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "リストでページの <title> を使用"
@@ -3072,7 +3071,6 @@ msgstr "リアルタイムUI更新を有効化"
 msgid "Favicons Enabled"
 msgstr "ファビコンを有効化"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "ウォッチ一覧リストでページの <title> を使用"
@@ -3466,7 +3464,6 @@ msgstr "監視中のURL。"
 msgid "The UUID of the watch."
 msgstr "ウォッチのUUID。"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "ウォッチのページタイトル。設定されていない場合は <title> を使用し、それもなければURLにフォールバックします。"

--- a/changedetectionio/translations/ko/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ko/LC_MESSAGES/messages.po
@@ -2963,7 +2963,6 @@ msgstr "다음 모두와 일치"
 msgid "Match any of the following"
 msgstr "다음 중 하나와 일치"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "목록에 페이지 <title> 사용"
@@ -3063,7 +3062,6 @@ msgstr "실시간 UI 업데이트 활성화"
 msgid "Favicons Enabled"
 msgstr "파비콘 활성화"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "모니터링 목록에 페이지 <title> 사용"
@@ -3457,7 +3455,6 @@ msgstr "모니터링 중인 URL입니다."
 msgid "The UUID of the watch."
 msgstr "모니터링 UUID입니다."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "모니터링의 페이지 제목입니다. 설정되지 않았으면 <title> 을 사용하고, 없으면 URL을 사용합니다."

--- a/changedetectionio/translations/messages.pot
+++ b/changedetectionio/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: changedetection.io 0.55.5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-25 10:09+0200\n"
+"POT-Creation-Date: 2026-05-25 01:33+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2952,7 +2952,6 @@ msgstr ""
 msgid "Match any of the following"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr ""
@@ -3052,7 +3051,6 @@ msgstr ""
 msgid "Favicons Enabled"
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr ""
@@ -3446,7 +3444,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr ""
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3003,7 +3003,6 @@ msgstr "Corresponder a TODOS os seguintes"
 msgid "Match any of the following"
 msgstr "Corresponder a QUALQUER um dos seguintes"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Usar <title> da página na lista"
@@ -3103,7 +3102,6 @@ msgstr "Atualizações de Interface em Tempo Real Ativadas"
 msgid "Favicons Enabled"
 msgstr "Favicons Ativados"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Usar <title> da página na lista de visão geral"
@@ -3497,7 +3495,6 @@ msgstr "A URL que está sendo monitorada."
 msgid "The UUID of the watch."
 msgstr "O UUID do monitoramento."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "O título da página do monitoramento, usa <title> se não definido, ou a URL"

--- a/changedetectionio/translations/tr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/tr/LC_MESSAGES/messages.po
@@ -3006,7 +3006,6 @@ msgstr "Aşağıdakilerin tümünü eşleştir"
 msgid "Match any of the following"
 msgstr "Aşağıdakilerden herhangi birini eşleştir"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Listede sayfa <title>'ını kullan"
@@ -3106,7 +3105,6 @@ msgstr "Gerçek Zamanlı Arayüz Güncellemeleri Etkin"
 msgid "Favicons Enabled"
 msgstr "Favicon'lar Etkin"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "İzleyici genel bakış listesinde sayfa <title>'ını kullan"
@@ -3500,7 +3498,6 @@ msgstr "İzlenen URL."
 msgid "The UUID of the watch."
 msgstr "İzleyicinin UUID'si."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "İzleyicinin sayfa başlığı, ayarlanmamışsa <title> kullanır, URL'ye geri döner"

--- a/changedetectionio/translations/uk/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/uk/LC_MESSAGES/messages.po
@@ -2985,7 +2985,6 @@ msgstr "Збіг усіх наступних умов"
 msgid "Match any of the following"
 msgstr "Збіг будь-якої з наступних умов"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "Використовувати <title> сторінки у списку"
@@ -3085,7 +3084,6 @@ msgstr "Оновлення UI в реальному часі увімкнено"
 msgid "Favicons Enabled"
 msgstr "Фавіконки увімкнено"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "Використовувати <title> сторінки у списку огляду завдань"
@@ -3479,7 +3477,6 @@ msgstr "URL, за яким ведеться спостереження."
 msgid "The UUID of the watch."
 msgstr "UUID завдання."
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "Заголовок сторінки завдання, використовує <title>, якщо не задано - URL"

--- a/changedetectionio/translations/zh/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh/LC_MESSAGES/messages.po
@@ -2958,7 +2958,6 @@ msgstr "匹配以下全部"
 msgid "Match any of the following"
 msgstr "匹配以下任意"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "列表中使用页面 <title>"
@@ -3058,7 +3057,6 @@ msgstr "启用实时界面更新"
 msgid "Favicons Enabled"
 msgstr "启用站点图标"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "在监控概览列表中使用页面 <title>"
@@ -3452,7 +3450,6 @@ msgstr "被监控的 URL。"
 msgid "The UUID of the watch."
 msgstr "监视器的UUID。"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr "监控项的页面标题，未设置时使用 <title>，否则回退为 URL"

--- a/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -2957,7 +2957,6 @@ msgstr "符合以下所有條件"
 msgid "Match any of the following"
 msgstr "符合以下任一條件"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in list"
 msgstr "在列表中使用頁面 <title>"
@@ -3057,7 +3056,6 @@ msgstr "已啟用即時 UI 更新"
 msgid "Favicons Enabled"
 msgstr "啟用網站圖示 (Favicons)"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/forms.py
 msgid "Use page <title> in watch overview list"
 msgstr "在監測概覽列表中使用頁面 <title>"
@@ -3451,7 +3449,6 @@ msgstr ""
 msgid "The UUID of the watch."
 msgstr "監測任務的 UUID。"
 
-#. dennis-ignore: W303 - False positive caused by <title>. https://github.com/mozilla/dennis/issues/213
 #: changedetectionio/templates/_common_fields.html
 msgid "The page title of the watch, uses <title> if not set, falls back to URL"
 msgstr ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,7 +159,7 @@ psutil==7.2.2
 
 ruff >= 0.11.2
 pre_commit >= 4.2.0
-dennis >= 1.2.0
+dennis >= 1.3.0
 
 # For events between checking and socketio updates
 blinker


### PR DESCRIPTION
## Background

- #4116 added `dennis-ignore` comments — dennis misreported `<title>` as mismatched HTML (mozilla/dennis#213), causing false positives.
- #4105 added a hacky `awk`-based pass/fail counter — `dennis-cmd lint` exits 0 when only warnings are present, letting new warnings slip through CI undetected.

## Resolved upstream

Dennis 1.3.0 ([changelog](https://github.com/mozilla/dennis/blob/v1.3.0/CHANGELOG#L8-L18)) resolved both issues:
- Fixed the false positive for unclosed CDATA/RCDATA tags (including `<title>`).
- Implemented `--strict` mode so `dennis-cmd lint` exits non-zero when any warnings are present.

## Changes

This PR:
- af4a2787: Drops the `dennis-ignore` workarounds for the `<title>` false positive from source, re-extracts `.pot`/`.po`, and updates the translations README.
- c5923dcd, ba3cf0fb: Replaces the `awk` counting hack with `--strict` mode in CI.
- ad1e053b: Adds dennis pre-commit hooks.
