### PR TITLE
feat(fetchers): add FlareSolverr / Byparr content fetcher backend

### DIFF
--- a/changedetectionio/content_fetchers/__init__.py
+++ b/changedetectionio/content_fetchers/__init__.py
@@ -28,6 +28,7 @@ SCREENSHOT_SIZE_STITCH_THRESHOLD = int(os.getenv("SCREENSHOT_CHUNK_HEIGHT", 1000
 # available_fetchers() will scan this implementation looking for anything starting with html_
 # this information is used in the form selections
 from changedetectionio.content_fetchers.requests import fetcher as html_requests
+from changedetectionio.content_fetchers.flaresolverr import fetcher as html_flaresolverr
 
 
 import importlib.resources

--- a/changedetectionio/content_fetchers/flaresolverr.py
+++ b/changedetectionio/content_fetchers/flaresolverr.py
@@ -1,0 +1,199 @@
+import asyncio
+import os
+
+from flask_babel import lazy_gettext as _l
+from loguru import logger
+
+from changedetectionio.content_fetchers.base import Fetcher
+from changedetectionio.content_fetchers.exceptions import (
+    BrowserConnectError,
+    BrowserFetchTimedOut,
+    BrowserStepsInUnsupportedFetcher,
+    EmptyReply,
+    Non200ErrorCodeReceived,
+)
+
+
+class fetcher(Fetcher):
+    fetcher_description = _l(
+        "FlareSolverr / Byparr - Cloudflare-aware solver "
+        "(set FLARESOLVERR_URL env var, e.g. http://flaresolverr:8191/v1)"
+    )
+
+    # FlareSolverr drives its own browser server-side, so changedetection's
+    # browser-step framework (which talks Playwright/CDP) cannot reach into it.
+    supports_browser_steps = False
+    supports_screenshots = False
+    supports_xpath_element_data = False
+
+    def __init__(self, proxy_override=None, custom_browser_connection_url=None, **kwargs):
+        super().__init__(**kwargs)
+
+        # Per-watch override wins (via the "Extra Browsers" connection URL field);
+        # otherwise fall back to FLARESOLVERR_URL env var.
+        if custom_browser_connection_url:
+            self.browser_connection_is_custom = True
+            self.browser_connection_url = custom_browser_connection_url.strip('"')
+        else:
+            self.browser_connection_url = os.getenv(
+                "FLARESOLVERR_URL", "http://flaresolverr:8191/v1"
+            ).strip('"')
+
+        self.proxy_override = proxy_override
+
+    def _post_command(self, payload, timeout):
+        import requests
+
+        try:
+            r = requests.post(
+                self.browser_connection_url,
+                json=payload,
+                timeout=timeout,
+                headers={"Content-Type": "application/json"},
+            )
+        except requests.exceptions.Timeout as e:
+            raise BrowserFetchTimedOut(msg=f"FlareSolverr request timed out after {timeout}s: {e}") from e
+        except requests.exceptions.RequestException as e:
+            raise BrowserConnectError(
+                msg=f"Could not reach FlareSolverr at {self.browser_connection_url}: {e}"
+            ) from e
+
+        if r.status_code != 200:
+            raise BrowserConnectError(
+                msg=f"FlareSolverr returned HTTP {r.status_code}: {r.text[:300]}"
+            )
+
+        try:
+            return r.json()
+        except ValueError as e:
+            raise BrowserConnectError(
+                msg=f"FlareSolverr returned non-JSON response: {e}"
+            ) from e
+
+    def _run_sync(
+        self,
+        url,
+        timeout,
+        request_headers,
+        request_body,
+        request_method,
+        ignore_status_codes=False,
+        empty_pages_are_a_change=False,
+    ):
+        if self.browser_steps:
+            raise BrowserStepsInUnsupportedFetcher(url=url)
+
+        # FlareSolverr's /v1 endpoint expects milliseconds for maxTimeout.
+        # `timeout` is in seconds at this layer (per the Fetcher contract).
+        max_timeout_ms = int((timeout or 60) * 1000)
+
+        # FlareSolverr supports only request.get and request.post on /v1.
+        method = (request_method or "GET").upper()
+        if method == "POST":
+            payload = {
+                "cmd": "request.post",
+                "url": url,
+                "maxTimeout": max_timeout_ms,
+                # FlareSolverr expects form-encoded body as a single string
+                "postData": request_body or "",
+            }
+        else:
+            payload = {
+                "cmd": "request.get",
+                "url": url,
+                "maxTimeout": max_timeout_ms,
+            }
+            if method != "GET":
+                logger.warning(
+                    f"FlareSolverr only supports GET/POST; coercing '{method}' to GET for {url}"
+                )
+
+        if self.proxy_override:
+            # FlareSolverr accepts {"proxy": {"url": "...", "username": "...", "password": "..."}}.
+            # changedetection passes the proxy as a single URL with optional creds embedded;
+            # FlareSolverr's own client will parse the URL.
+            payload["proxy"] = {"url": self.proxy_override}
+
+        # Give the HTTP call a generous buffer over the solver's own deadline so
+        # that we surface FlareSolverr's structured error instead of a connection abort.
+        body = self._post_command(payload, timeout=(timeout or 60) + 30)
+
+        if body.get("status") != "ok":
+            raise BrowserConnectError(
+                msg=f"FlareSolverr could not solve {url}: {body.get('message', 'unknown error')}"
+            )
+
+        solution = body.get("solution") or {}
+        upstream_status = int(solution.get("status") or 0)
+        html = solution.get("response") or ""
+
+        self.headers = solution.get("headers") or {}
+        self.status_code = upstream_status
+        self.content = html
+        self.raw_content = html.encode("utf-8", errors="replace")
+
+        if not html:
+            if not empty_pages_are_a_change:
+                raise EmptyReply(url=url, status_code=upstream_status)
+            logger.debug(
+                f"FlareSolverr returned empty body for {url} (status {upstream_status}), "
+                "but empty_pages_are_a_change=True"
+            )
+
+        if upstream_status != 200 and not ignore_status_codes:
+            raise Non200ErrorCodeReceived(url=url, status_code=upstream_status, page_html=html)
+
+    async def run(
+        self,
+        fetch_favicon=True,
+        current_include_filters=None,
+        empty_pages_are_a_change=False,
+        ignore_status_codes=False,
+        is_binary=False,
+        request_body=None,
+        request_headers=None,
+        request_method=None,
+        screenshot_format=None,
+        timeout=None,
+        url=None,
+        watch_uuid=None,
+    ):
+        if is_binary:
+            # FlareSolverr only returns rendered HTML; binary fetches should fall
+            # back to html_requests at the caller. Surface a clear error.
+            raise BrowserConnectError(
+                msg="FlareSolverr fetcher does not support binary content; use html_requests."
+            )
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: self._run_sync(
+                url=url,
+                timeout=timeout,
+                request_headers=request_headers,
+                request_body=request_body,
+                request_method=request_method,
+                ignore_status_codes=ignore_status_codes,
+                empty_pages_are_a_change=empty_pages_are_a_change,
+            ),
+        )
+
+    async def quit(self, watch=None):
+        return
+
+    def get_last_status_code(self):
+        return self.status_code
+
+    def is_ready(self):
+        return bool(self.browser_connection_url)
+
+
+class FlareSolverrFetcherPlugin:
+    """Plugin class that registers the FlareSolverr fetcher as a built-in plugin."""
+
+    def register_content_fetcher(self):
+        return ("html_flaresolverr", fetcher)
+
+
+flaresolverr_plugin = FlareSolverrFetcherPlugin()

--- a/changedetectionio/pluggy_interface.py
+++ b/changedetectionio/pluggy_interface.py
@@ -299,7 +299,7 @@ def register_builtin_fetchers():
     This is called from content_fetchers/__init__.py after all fetchers are imported
     to avoid circular import issues.
     """
-    from changedetectionio.content_fetchers import requests, playwright, puppeteer, webdriver_selenium
+    from changedetectionio.content_fetchers import requests, playwright, puppeteer, webdriver_selenium, flaresolverr
 
     # Register each built-in fetcher plugin
     if hasattr(requests, 'requests_plugin'):
@@ -313,6 +313,9 @@ def register_builtin_fetchers():
 
     if hasattr(webdriver_selenium, 'webdriver_selenium_plugin'):
         plugin_manager.register(webdriver_selenium.webdriver_selenium_plugin, 'builtin_webdriver_selenium')
+
+    if hasattr(flaresolverr, 'flaresolverr_plugin'):
+        plugin_manager.register(flaresolverr.flaresolverr_plugin, 'builtin_flaresolverr')
 
 
 def register_builtin_restock_plugins():

--- a/changedetectionio/tests/test_flaresolverr_fetcher.py
+++ b/changedetectionio/tests/test_flaresolverr_fetcher.py
@@ -1,0 +1,181 @@
+"""Unit tests for the FlareSolverr / Byparr content fetcher.
+
+These tests stub the HTTP layer with `responses` so we don't depend on a
+running FlareSolverr instance. They cover:
+
+- success path: solution.response surfaces as self.content, status from upstream
+- POST passthrough (cmd=request.post + postData)
+- proxy_override propagates as FlareSolverr `proxy.url`
+- FLARESOLVERR_URL env var honored, custom_browser_connection_url overrides it
+- empty body raises EmptyReply (unless empty_pages_are_a_change=True)
+- non-200 upstream raises Non200ErrorCodeReceived
+- FlareSolverr-level failure ({"status": "error"}) raises BrowserConnectError
+- network timeout raises BrowserFetchTimedOut
+"""
+import asyncio
+import os
+from unittest import mock
+
+import pytest
+import responses
+
+from changedetectionio.content_fetchers import flaresolverr
+from changedetectionio.content_fetchers.exceptions import (
+    BrowserConnectError,
+    BrowserFetchTimedOut,
+    EmptyReply,
+    Non200ErrorCodeReceived,
+)
+
+
+FLARESOLVERR_URL = "http://flaresolverr.test:8191/v1"
+
+
+def _ok_payload(html="<html><body>hi</body></html>", status=200, headers=None):
+    return {
+        "status": "ok",
+        "message": "Challenge solved!",
+        "solution": {
+            "url": "https://target.example.com/",
+            "status": status,
+            "response": html,
+            "headers": headers or {"content-type": "text/html"},
+            "userAgent": "Mozilla/5.0 ...",
+            "cookies": [],
+        },
+    }
+
+
+def _run(fetcher, **kwargs):
+    asyncio.run(fetcher.run(**kwargs))
+
+
+@responses.activate
+def test_success_get_returns_html():
+    responses.add(responses.POST, FLARESOLVERR_URL, json=_ok_payload(), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    _run(f, url="https://target.example.com/", timeout=30,
+         request_method="GET", request_headers={}, request_body=None)
+    assert f.status_code == 200
+    assert f.content == "<html><body>hi</body></html>"
+    assert f.headers["content-type"] == "text/html"
+    assert f.raw_content == b"<html><body>hi</body></html>"
+
+    # The outgoing request used cmd=request.get and propagated maxTimeout in ms
+    sent = responses.calls[0].request
+    import json as _json
+    body = _json.loads(sent.body)
+    assert body["cmd"] == "request.get"
+    assert body["url"] == "https://target.example.com/"
+    assert body["maxTimeout"] == 30 * 1000
+
+
+@responses.activate
+def test_post_passthrough_uses_request_post():
+    responses.add(responses.POST, FLARESOLVERR_URL, json=_ok_payload(html="ok"), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    _run(f, url="https://target.example.com/login", timeout=10,
+         request_method="POST", request_headers={"X-K": "v"},
+         request_body="user=a&pass=b")
+    import json as _json
+    sent = _json.loads(responses.calls[0].request.body)
+    assert sent["cmd"] == "request.post"
+    assert sent["postData"] == "user=a&pass=b"
+
+
+@responses.activate
+def test_proxy_override_propagated():
+    responses.add(responses.POST, FLARESOLVERR_URL, json=_ok_payload(html="x"), status=200)
+    f = flaresolverr.fetcher(
+        custom_browser_connection_url=FLARESOLVERR_URL,
+        proxy_override="http://user:pass@proxy.test:8080",
+    )
+    _run(f, url="https://target.example.com/", timeout=5,
+         request_method="GET", request_headers={}, request_body=None)
+    import json as _json
+    sent = _json.loads(responses.calls[0].request.body)
+    assert sent["proxy"] == {"url": "http://user:pass@proxy.test:8080"}
+
+
+def test_env_var_default_endpoint():
+    with mock.patch.dict(os.environ, {"FLARESOLVERR_URL": "http://from-env:8191/v1"}, clear=False):
+        f = flaresolverr.fetcher()
+    assert f.browser_connection_url == "http://from-env:8191/v1"
+    assert f.browser_connection_is_custom is None
+
+
+def test_custom_url_overrides_env():
+    with mock.patch.dict(os.environ, {"FLARESOLVERR_URL": "http://from-env:8191/v1"}, clear=False):
+        f = flaresolverr.fetcher(custom_browser_connection_url="http://watch-specific:8191/v1")
+    assert f.browser_connection_url == "http://watch-specific:8191/v1"
+    assert f.browser_connection_is_custom is True
+
+
+@responses.activate
+def test_empty_body_raises_empty_reply():
+    responses.add(responses.POST, FLARESOLVERR_URL, json=_ok_payload(html=""), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    with pytest.raises(EmptyReply):
+        _run(f, url="https://target.example.com/", timeout=5,
+             request_method="GET", request_headers={}, request_body=None)
+
+
+@responses.activate
+def test_empty_body_accepted_when_flag_set():
+    responses.add(responses.POST, FLARESOLVERR_URL, json=_ok_payload(html=""), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    _run(f, url="https://target.example.com/", timeout=5,
+         request_method="GET", request_headers={}, request_body=None,
+         empty_pages_are_a_change=True)
+    assert f.content == ""
+    assert f.status_code == 200
+
+
+@responses.activate
+def test_non_200_upstream_raises():
+    responses.add(responses.POST, FLARESOLVERR_URL,
+                  json=_ok_payload(html="<h1>nope</h1>", status=404), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    with pytest.raises(Non200ErrorCodeReceived) as exc:
+        _run(f, url="https://target.example.com/", timeout=5,
+             request_method="GET", request_headers={}, request_body=None)
+    assert exc.value.status_code == 404
+
+
+@responses.activate
+def test_non_200_upstream_swallowed_when_ignored():
+    responses.add(responses.POST, FLARESOLVERR_URL,
+                  json=_ok_payload(html="<h1>nope</h1>", status=404), status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    _run(f, url="https://target.example.com/", timeout=5,
+         request_method="GET", request_headers={}, request_body=None,
+         ignore_status_codes=True)
+    assert f.status_code == 404
+    assert f.content == "<h1>nope</h1>"
+
+
+@responses.activate
+def test_flaresolverr_error_response_raises():
+    responses.add(responses.POST, FLARESOLVERR_URL,
+                  json={"status": "error", "message": "Could not bypass"}, status=200)
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    with pytest.raises(BrowserConnectError):
+        _run(f, url="https://target.example.com/", timeout=5,
+             request_method="GET", request_headers={}, request_body=None)
+
+
+def test_timeout_raises_browser_fetch_timed_out():
+    import requests as real_requests
+    with mock.patch("requests.post", side_effect=real_requests.exceptions.Timeout("boom")):
+        f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+        with pytest.raises(BrowserFetchTimedOut):
+            _run(f, url="https://target.example.com/", timeout=2,
+                 request_method="GET", request_headers={}, request_body=None)
+
+
+def test_binary_fetch_rejected():
+    f = flaresolverr.fetcher(custom_browser_connection_url=FLARESOLVERR_URL)
+    with pytest.raises(BrowserConnectError):
+        _run(f, url="https://target.example.com/file.pdf", timeout=5,
+             request_method="GET", request_headers={}, request_body=None,
+             is_binary=True)


### PR DESCRIPTION
## Summary

Adds a new fetch backend, ` + "`html_flaresolverr`" + `, that talks to any FlareSolverr-compatible solver (FlareSolverr itself, [Byparr](https://github.com/ThePhaseless/Byparr), etc.) via the standard ` + "`/v1`" + ` JSON API.

Modern Cloudflare/Turnstile challenges have outpaced the stock browserless + puppeteer-extra-stealth combo on a growing set of sites (ext.to, many e-commerce storefronts, etc.). Solver services like Byparr — actively maintained, Camoufox-based — still get past these reliably. Until now, wiring them into changedetection required either a private adapter container or per-watch JSON-unwrap filter hacks, neither of which scale across users.

This closes the long-standing request in [discussion #1096](https://github.com/dgtlmoon/changedetection.io/discussions/1096).

## How it works

- New ` + "`fetch_backend`" + ` option ` + "`html_flaresolverr`" + ` appears in the watch form alongside ` + "`html_requests`" + ` / ` + "`html_webdriver`" + `.
- Reads endpoint from ` + "`FLARESOLVERR_URL`" + ` (default ` + "`http://flaresolverr:8191/v1`" + `, matching the de-facto convention).
- Per-watch override via the existing custom-browser-connection-URL field, so users can pin specific watches to a specific solver instance.
- Proxy overrides (per-watch) are forwarded to the solver as ` + "`proxy.url`" + ` so the solver — not the user's outbound — uses the proxy.
- GET and POST are both supported; ` + "`is_binary=True`" + ` is explicitly rejected with a helpful error (solvers only return rendered HTML).
- Upstream ` + "`status`" + ` and ` + "`headers`" + ` are surfaced as ` + "`self.status_code`" + ` / ` + "`self.headers`" + ` so the rest of the pipeline (content-type detection, ` + "`Non200ErrorCodeReceived`" + `) works unchanged.
- Empty solutions raise ` + "`EmptyReply`" + ` unless ` + "`empty_pages_are_a_change=True`" + `; solver-level failures raise ` + "`BrowserConnectError`" + `; network timeouts raise ` + "`BrowserFetchTimedOut`" + `.

## What changed

- ` + "`changedetectionio/content_fetchers/flaresolverr.py`" + ` (new) — the fetcher
- ` + "`changedetectionio/content_fetchers/__init__.py`" + ` — import as ` + "`html_flaresolverr`" + ` so ` + "`available_fetchers()`" + ` picks it up
- ` + "`changedetectionio/pluggy_interface.py`" + ` — register as a built-in pluggy plugin alongside the other fetchers
- ` + "`changedetectionio/tests/test_flaresolverr_fetcher.py`" + ` (new) — unit tests stubbing the HTTP layer with ` + "`responses`" + `

## Notes / open questions for the maintainer

1. **Naming**: I picked ` + "`html_flaresolverr`" + ` because the API is FlareSolverr-shaped. Open to ` + "`html_solver`" + ` if you prefer something neutral.
2. **Browser steps / screenshots**: Set ` + "`supports_browser_steps = False`" + ` etc. — solvers drive their own browser server-side, so CDP/browser-steps can't reach in. Mentioned in your earlier comment on #1096 that FlareSolverr looked dead; Byparr is the actively-maintained successor and the API is identical, so a single backend works for both.
3. **Default URL**: Used ` + "`http://flaresolverr:8191/v1`" + ` to match the upstream FlareSolverr docs. Happy to change.