### PR TITLE
Use mapping syntax for environment variables in docker-compose example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
   #      - USE_X_SETTINGS: 1
   #
   #        Hides the `Referer` header so that monitored websites can't see the changedetection.io hostname.
-  #      - HIDE_REFERER: true
+  #      - HIDE_REFERER: 'true'
   #        
   #        Default number of parallel/concurrent fetchers
   #      - FETCH_WORKERS: 10
@@ -65,10 +65,10 @@ services:
   #      - MINIMUM_SECONDS_RECHECK_TIME: 3
   #
   #        If you want to watch local files file:///path/to/file.txt (careful! security implications!)
-  #      - ALLOW_FILE_URI: False
+  #      - ALLOW_FILE_URI: 'False'
   #
   #        For complete privacy if you don't want to use the 'check version' / telemetry service
-  #      - DISABLE_VERSION_CHECK: true
+  #      - DISABLE_VERSION_CHECK: 'true'
   #
   #        A valid timezone name to run as (for scheduling watch checking) see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   #      - TZ: America/Los_Angeles
@@ -86,7 +86,7 @@ services:
   #      - SSL_PRIVKEY_FILE: privkey.pem
   #
   #        LISTEN_HOST / "host", Same as -h
-  #      - LISTEN_HOST: ::
+  #      - LISTEN_HOST: '::'
   #      - LISTEN_HOST: 0.0.0.0
 
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,26 +10,26 @@ services:
 
   #    environment:
   #        Default listening port, can also be changed with the -p option (not to be confused with ports: below)
-  #      - PORT=5000
+  #      - PORT: 5000
   #
   #        Log levels are in descending order. (TRACE is the most detailed one)
   #        Log output levels: TRACE, DEBUG(default), INFO, SUCCESS, WARNING, ERROR, CRITICAL
-  #      - LOGGER_LEVEL=TRACE
+  #      - LOGGER_LEVEL: TRACE
   #
   #        Plugins! See https://changedetection.io/plugins for more plugins.
   #        Install additional Python packages (processor plugins, etc.)
   #        Example: Install the OSINT reconnaissance processor plugin
-  #      - EXTRA_PACKAGES=changedetection.io-osint-processor
+  #      - EXTRA_PACKAGES: changedetection.io-osint-processor
   #        Multiple packages can be installed by separating with spaces:
-  #      - EXTRA_PACKAGES=changedetection.io-osint-processor another-plugin
+  #      - EXTRA_PACKAGES: changedetection.io-osint-processor another-plugin
   #
   #
   #       Uncomment below and the "sockpuppetbrowser" to use a real Chrome browser (It uses the "playwright" protocol)
-  #      - PLAYWRIGHT_DRIVER_URL=ws://browser-sockpuppet-chrome:3000
+  #      - PLAYWRIGHT_DRIVER_URL: ws://browser-sockpuppet-chrome:3000
   #
   #
   #       Alternative WebDriver/selenium URL, do not use "'s or 's! (old, deprecated, does not support screenshots very well, Can't handle custom headers etc)
-  #      - WEBDRIVER_URL=http://browser-selenium-chrome:4444/wd/hub
+  #      - WEBDRIVER_URL: http://browser-selenium-chrome:4444/wd/hub
   #
   #       WebDriver proxy settings webdriver_proxyType, webdriver_ftpProxy, webdriver_noProxy,
   #                                webdriver_proxyAutoconfigUrl, webdriver_autodetect,
@@ -43,51 +43,51 @@ services:
   #             https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-option-proxy
   #
   #        Plain requests - proxy support example.
-  #      - HTTP_PROXY=socks5h://10.10.1.10:1080
-  #      - HTTPS_PROXY=socks5h://10.10.1.10:1080
+  #      - HTTP_PROXY: socks5h://10.10.1.10:1080
+  #      - HTTPS_PROXY: socks5h://10.10.1.10:1080
   #
   #        An exclude list (useful for notification URLs above) can be specified by with
-  #      - NO_PROXY="localhost,192.168.0.0/24"
+  #      - NO_PROXY: "localhost,192.168.0.0/24"
   #
   #        Base URL of your changedetection.io install (Added to the notification alert)
-  #      - BASE_URL=https://mysite.com
+  #      - BASE_URL: https://mysite.com
   #        Respect proxy_pass type settings, `proxy_set_header Host "localhost";` and `proxy_set_header X-Forwarded-Prefix /app;`
   #        More here https://github.com/dgtlmoon/changedetection.io/wiki/Running-changedetection.io-behind-a-reverse-proxy
-  #      - USE_X_SETTINGS=1
+  #      - USE_X_SETTINGS: 1
   #
   #        Hides the `Referer` header so that monitored websites can't see the changedetection.io hostname.
-  #      - HIDE_REFERER=true
+  #      - HIDE_REFERER: true
   #        
   #        Default number of parallel/concurrent fetchers
-  #      - FETCH_WORKERS=10
+  #      - FETCH_WORKERS: 10
   #
   #        Absolute minimum seconds to recheck, overrides any watch minimum, change to 0 to disable
-  #      - MINIMUM_SECONDS_RECHECK_TIME=3
+  #      - MINIMUM_SECONDS_RECHECK_TIME: 3
   #
   #        If you want to watch local files file:///path/to/file.txt (careful! security implications!)
-  #      - ALLOW_FILE_URI=False
+  #      - ALLOW_FILE_URI: False
   #
   #        For complete privacy if you don't want to use the 'check version' / telemetry service
-  #      - DISABLE_VERSION_CHECK=true
+  #      - DISABLE_VERSION_CHECK: true
   #
   #        A valid timezone name to run as (for scheduling watch checking) see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  #      - TZ=America/Los_Angeles
+  #      - TZ: America/Los_Angeles
   #
   #        Text processing locale, en_US.UTF-8 used by default unless defined as something else here, UTF-8 should cover 99.99% of cases.
-  #      - LC_ALL=en_US.UTF-8
+  #      - LC_ALL: en_US.UTF-8
   #
   #        Maximum height of screenshots, default is 16000 px, screenshots will be clipped to this if exceeded.
   #        RAM usage will be higher if you increase this.
-  #      - SCREENSHOT_MAX_HEIGHT=16000
+  #      - SCREENSHOT_MAX_HEIGHT: 16000
   #
   #        HTTPS SSL Mode for webserver, unset both of these, you may need to volume mount these files also.
   #        ./cert.pem:/app/cert.pem and ./privkey.pem:/app/privkey.pem
-  #      - SSL_CERT_FILE=cert.pem
-  #      - SSL_PRIVKEY_FILE=privkey.pem
+  #      - SSL_CERT_FILE: cert.pem
+  #      - SSL_PRIVKEY_FILE: privkey.pem
   #
   #        LISTEN_HOST / "host", Same as -h
-  #      - LISTEN_HOST=::
-  #      - LISTEN_HOST=0.0.0.0
+  #      - LISTEN_HOST: ::
+  #      - LISTEN_HOST: 0.0.0.0
 
   
       # Comment out ports: when using behind a reverse proxy , enable networks: etc.
@@ -117,10 +117,10 @@ services:
 ## SYS_ADMIN might be too much, but it can be needed on your platform https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-on-gitlabci
 #        restart: unless-stopped
 #        environment:
-#            - SCREEN_WIDTH=1920
-#            - SCREEN_HEIGHT=1024
-#            - SCREEN_DEPTH=16
-#            - MAX_CONCURRENT_CHROME_PROCESSES=10
+#            - SCREEN_WIDTH: 1920
+#            - SCREEN_HEIGHT: 1024
+#            - SCREEN_DEPTH: 16
+#            - MAX_CONCURRENT_CHROME_PROCESSES: 10
 
      # Used for fetching pages via Playwright+Chrome where you need Javascript support.
      # Note: Works well but is deprecated, does not fetch full page screenshots (doesnt work with Visual Selector)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,14 +129,14 @@ services:
 #        hostname: browser-selenium-chrome
 #        image: selenium/standalone-chrome:4
 #        environment:
-#            - VNC_NO_PASSWORD=1
-#            - SCREEN_WIDTH=1920
-#            - SCREEN_HEIGHT=1080
-#            - SCREEN_DEPTH=24
-#          CHROME_OPTIONS: |
-#            --window-size=1280,1024
-#            --headless
-#            --disable-gpu
+#            VNC_NO_PASSWORD: 1
+#            SCREEN_WIDTH: 1920
+#            SCREEN_HEIGHT: 1080
+#            SCREEN_DEPTH: 24
+#            CHROME_OPTIONS: >
+#                --window-size=1280,1024
+#                --headless
+#                --disable-gpu
 #        volumes:
 #            # Workaround to avoid the browser crashing inside a docker container
 #            # See https://github.com/SeleniumHQ/docker-selenium#quick-start


### PR DESCRIPTION
- Convert environment entries from list syntax to key/value mapping syntax
- Keep existing variable values and behavior unchanged
