### PR TITLE
docs(proposal): Firefox-based stealth fetcher plugin

### DIFF
--- a/docs/fetchers/invisible-firefox.md
+++ b/docs/fetchers/invisible-firefox.md
@@ -1,0 +1,24 @@
+# Firefox-based stealth fetcher (proposal)
+
+> Draft proposal, opened to gauge interest before building. Tracking discussion: TBD
+
+## What it would be
+
+A separate pypi package (`changedetection.io-invisible-firefox`) installed via `EXTRA_PACKAGES`, exposing a new option in the Fetch Method dropdown. Mirrors the shape of the existing `changedetection.io-cloak-browser` integration.
+
+## Backend
+
+- patched Firefox 150, stealth applied at the C++ source level (no JS shims to detect)
+- source: https://github.com/feder-cr/invisible_firefox (MPL-2, same license as Firefox upstream)
+- Python wrapper: https://github.com/feder-cr/invisible_playwright
+
+## Relevance
+
+- #4141 (cloak fetcher broken on install)
+- #3645 (native Playwright Firefox)
+- #2198 (bot detection evasion)
+- #3249 (Camoufox integration, open ~2 years)
+
+## Maintenance
+
+Plugin lives in its own repo. Issues against the plugin route there directly, not to this repo.


### PR DESCRIPTION
opening as draft to check interest before building the integration.

would a Firefox-based stealth fetcher plugin be in scope? structured as a separate pypi package similar to changedetection.io-cloak-browser, installed via EXTRA_PACKAGES, appearing in the Fetch Method dropdown.

backend exists and works today: feder-cr/invisible_playwright (MPL-2, on PyPI as invisible-playwright), which drives a patched Firefox (source at feder-cr/firefox_antidetect_patch) with stealth applied at the C++ source level, so there are no JS shims to detect. the missing piece is the plugin glue + a `serve` mode in invisible_playwright, which i'd build if there's appetite.

context: #4141 just broke the existing cloak fetcher, #3645 has been open asking for native Playwright Firefox, #2198 on bot detection is still open.

this PR only adds a stub docs page so the proposal has somewhere concrete to land. tracking discussion: #4187

if the answer is "not in scope" i'll close it without noise.

---

docs/fetchers/invisible-firefox.md, "Backend" section, corrected to:

## Backend

- patched Firefox, stealth applied at the C++ source level (no JS shims to detect)
- source: https://github.com/feder-cr/firefox_antidetect_patch (MPL-2, same license as Firefox upstream)
- Python wrapper: https://github.com/feder-cr/invisible_playwright (PyPI: invisible-playwright), backed by https://github.com/feder-cr/invisible_core (PyPI: invisible-core)