### PR TITLE
Fix Jinja2 false-positive when URL contains `{%`

### DIFF
--- a/.github/workflows/test-stack-reusable-workflow.yml
+++ b/.github/workflows/test-stack-reusable-workflow.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Build the Docker image once and share it with all test jobs
   build:

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 from changedetectionio.content_fetchers import SCREENSHOT_MAX_HEIGHT_DEFAULT
 from changedetectionio.content_fetchers.base import manage_user_agent
-from changedetectionio.jinja2_custom import render as jinja_render
+from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN, render as jinja_render
 
 def browser_steps_get_valid_steps(browser_steps: list):
     if browser_steps is not None and len(browser_steps):
@@ -95,10 +95,10 @@ class steppable_browser_interface():
         action_handler = getattr(self, "action_" + call_action_name)
 
         # Support for Jinja2 variables in the value and selector
-        if selector and ('{%' in selector or '{{' in selector):
+        if selector and JINJA2_MARKER_PATTERN.search(selector):
             selector = jinja_render(template_str=selector)
 
-        if optional_value and ('{%' in optional_value or '{{' in optional_value):
+        if optional_value and JINJA2_MARKER_PATTERN.search(optional_value):
             optional_value = jinja_render(template_str=optional_value)
 
         # Trigger click and cautiously handle potential navigation

--- a/changedetectionio/content_fetchers/base.py
+++ b/changedetectionio/content_fetchers/base.py
@@ -165,7 +165,7 @@ class Fetcher():
     async def iterate_browser_steps(self, start_url=None):
         from changedetectionio.browser_steps.browser_steps import steppable_browser_interface, browser_steps_get_valid_steps
         from playwright._impl._errors import TimeoutError, Error
-        from changedetectionio.jinja2_custom import render as jinja_render
+        from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN, render as jinja_render
         step_n = 0
 
         if self.browser_steps:
@@ -183,9 +183,9 @@ class Fetcher():
                     optional_value = step['optional_value']
                     selector = step['selector']
                     # Support for jinja2 template in step values, with date module added
-                    if '{%' in step['optional_value'] or '{{' in step['optional_value']:
+                    if JINJA2_MARKER_PATTERN.search(step['optional_value']):
                         optional_value = jinja_render(template_str=step['optional_value'])
-                    if '{%' in step['selector'] or '{{' in step['selector']:
+                    if JINJA2_MARKER_PATTERN.search(step['selector']):
                         selector = jinja_render(template_str=step['selector'])
 
                     await getattr(interface, "call_action")(action_name=step['operation'],

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -901,7 +901,7 @@ class processor_text_json_diff_form(commonSettingsForm):
         if not super().validate():
             return False
 
-        from changedetectionio.jinja2_custom import render as jinja_render
+        from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN, render as jinja_render
         result = True
 
         # Fail form validation when a body is set for a GET
@@ -910,37 +910,40 @@ class processor_text_json_diff_form(commonSettingsForm):
             result = False
 
         # Attempt to validate jinja2 templates in the URL
-        try:
-            jinja_render(template_str=self.url.data)
-        except ModuleNotFoundError as e:
-            # incase jinja2_time or others is missing
-            logger.error(e)
-            self.url.errors.append(gettext('Invalid template syntax configuration: %(error)s') % {'error': e})
-            result = False
-        except Exception as e:
-            logger.error(e)
-            self.url.errors.append(gettext('Invalid template syntax: %(error)s') % {'error': e})
-            result = False
-
-        # Attempt to validate jinja2 templates in the body
-        if self.body.data and self.body.data.strip():
+        if JINJA2_MARKER_PATTERN.search(self.url.data):
             try:
-                jinja_render(template_str=self.body.data)
+                jinja_render(template_str=self.url.data)
             except ModuleNotFoundError as e:
                 # incase jinja2_time or others is missing
                 logger.error(e)
-                self.body.errors.append(gettext('Invalid template syntax configuration: %(error)s') % {'error': e})
+                self.url.errors.append(gettext('Invalid template syntax configuration: %(error)s') % {'error': e})
                 result = False
             except Exception as e:
                 logger.error(e)
-                self.body.errors.append(gettext('Invalid template syntax: %(error)s') % {'error': e})
+                self.url.errors.append(gettext('Invalid template syntax: %(error)s') % {'error': e})
                 result = False
+
+        # Attempt to validate jinja2 templates in the body
+        if self.body.data and self.body.data.strip():
+            if JINJA2_MARKER_PATTERN.search(self.body.data):
+                try:
+                    jinja_render(template_str=self.body.data)
+                except ModuleNotFoundError as e:
+                    # incase jinja2_time or others is missing
+                    logger.error(e)
+                    self.body.errors.append(gettext('Invalid template syntax configuration: %(error)s') % {'error': e})
+                    result = False
+                except Exception as e:
+                    logger.error(e)
+                    self.body.errors.append(gettext('Invalid template syntax: %(error)s') % {'error': e})
+                    result = False
 
         # Attempt to validate jinja2 templates in the headers
         if len(self.headers.data) > 0:
             try:
                 for header, value in self.headers.data.items():
-                    jinja_render(template_str=value)
+                    if JINJA2_MARKER_PATTERN.search(value):
+                        jinja_render(template_str=value)
             except ModuleNotFoundError as e:
                 # incase jinja2_time or others is missing
                 logger.error(e)

--- a/changedetectionio/jinja2_custom/__init__.py
+++ b/changedetectionio/jinja2_custom/__init__.py
@@ -1,6 +1,8 @@
 """
 Jinja2 custom extensions and safe rendering utilities.
 """
+import re
+
 from .extensions.TimeExtension import TimeExtension
 from .safe_jinja import (
     render,
@@ -11,6 +13,8 @@ from .safe_jinja import (
 )
 from .plugins.regex import regex_replace
 
+JINJA2_MARKER_PATTERN = re.compile(r'{%[-+]?\s*[a-zA-Z_]|{{')
+
 __all__ = [
     'TimeExtension',
     'render',
@@ -19,4 +23,5 @@ __all__ = [
     'JINJA2_MAX_RETURN_PAYLOAD_SIZE',
     'DEFAULT_JINJA2_EXTENSIONS',
     'regex_replace',
+    'JINJA2_MARKER_PATTERN',
 ]

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -29,7 +29,7 @@ from blinker import signal
 from changedetectionio.validate_url import is_safe_valid_url
 
 from changedetectionio.strtobool import strtobool
-from changedetectionio.jinja2_custom import render as jinja_render
+from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN, render as jinja_render
 from . import watch_base
 from .persistence import EntityPersistenceMixin
 import os
@@ -272,7 +272,7 @@ class model(EntityPersistenceMixin, watch_base):
             return 'DISABLED'
 
         ready_url = url
-        if '{%' in url or '{{' in url:
+        if JINJA2_MARKER_PATTERN.search(url):
             # Jinja2 available in URLs along with https://pypi.org/project/jinja2-time/
             try:
                 ready_url = jinja_render(template_str=url)

--- a/changedetectionio/tests/test_security.py
+++ b/changedetectionio/tests/test_security.py
@@ -831,6 +831,16 @@ def test_unresolvable_hostname_is_allowed(client, live_server, monkeypatch):
         "Unresolvable hostname watch should appear in the watch overview list"
 
 
+@pytest.mark.parametrize("url", [
+    "https://example.com/{{watch_url}}",
+    "https://example.com/{% if foo %}bar{% endif %}",
+    "https://example.com/api?q={%22key%22:1}",
+])
+def test_is_safe_valid_url_accepts_valid_urls(url):
+    from changedetectionio.validate_url import is_safe_valid_url
+    assert is_safe_valid_url(url)
+
+
 def test_ghsa_rph4_96w6_q594_urlparse_urllib3_parser_differential_ssrf(client, live_server, monkeypatch, measure_memory_usage, datastore_path):
     """
     GHSA-rph4-96w6-q594: SSRF via urlparse/urllib3 parser differential.

--- a/changedetectionio/tests/unit/test_jinja2_security.py
+++ b/changedetectionio/tests/unit/test_jinja2_security.py
@@ -4,6 +4,7 @@
 # python3 -m unittest changedetectionio.tests.unit.test_jinja2_security
 
 import unittest
+import pytest
 from changedetectionio import jinja2_custom as safe_jinja
 
 
@@ -54,6 +55,27 @@ class TestJinja2SSTI(unittest.TestCase):
     def test_jinja2_escaped_html(self):
         x = safe_jinja.render_fully_escaped('woo <a href="https://google.com">dfdfd</a>')
         self.assertEqual(x, "woo &lt;a href=&#34;https://google.com&#34;&gt;dfdfd&lt;/a&gt;")
+
+
+@pytest.mark.parametrize("text", [
+    'https://example.com/{{watch_url}}',
+    'https://example.com/{% if foo %}bar{% endif %}',
+    "https://example.com/{% now 'Europe/Berlin', '%Y' %}",
+    '{%- if foo -%}',
+    '{%+ if foo +%}',
+])
+def test_jinja2_marker_pattern_true_positives(text):
+    from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN
+    assert JINJA2_MARKER_PATTERN.search(text)
+
+
+@pytest.mark.parametrize("text", [
+    '',
+    'https://example.com/api?q={%22key%22:1}',
+])
+def test_jinja2_marker_pattern_false_positives(text):
+    from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN
+    assert not JINJA2_MARKER_PATTERN.search(text)
 
 
 

--- a/changedetectionio/tests/visualselector/test_fetch_data.py
+++ b/changedetectionio/tests/visualselector/test_fetch_data.py
@@ -112,7 +112,7 @@ def test_basic_browserstep(client, live_server, measure_memory_usage, datastore_
             # Should get set to the actual text (jinja2 rendered)
             'browser_steps-5-optional_value': "Hello-Jinja2-{% now  'Europe/Berlin', '%Y-%m-%d' %}",
             'browser_steps-8-operation': 'Click element',
-            'browser_steps-8-selector': 'button[name=test-button]',
+            'browser_steps-8-selector': "{% if true %}button[name=test-button]{% endif %}",
             'browser_steps-8-optional_value': '',
             # For now, cookies doesnt work in headers because it must be a full cookiejar object
             'headers': "testheader: yes\buser-agent: MyCustomAgent",
@@ -128,7 +128,7 @@ def test_basic_browserstep(client, live_server, measure_memory_usage, datastore_
     # 3874 - should have tidied up any blanks
     watch = live_server.app.config['DATASTORE'].data['watching'][uuid]
     assert watch['browser_steps'][0].get('operation') == 'Enter text in field'
-    assert watch['browser_steps'][1].get('selector') == 'button[name=test-button]'
+    assert watch['browser_steps'][1].get('selector') == "{% if true %}button[name=test-button]{% endif %}"
 
 
     # This part actually needs the browser, before this we are just testing data

--- a/changedetectionio/validate_url.py
+++ b/changedetectionio/validate_url.py
@@ -1,6 +1,6 @@
 import ipaddress
+import re
 import socket
-from functools import lru_cache
 from loguru import logger
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode, quote, unquote
 
@@ -172,11 +172,13 @@ def is_llm_api_base_safe(api_base):
     return True, ''
 
 
+_JINJA2_MARKER_PATTERN = re.compile(r'{%[^}%]*%}|{{[^}]*}}')
+
+
 def is_safe_valid_url(test_url):
     from changedetectionio import strtobool
     from changedetectionio.jinja2_custom import render as jinja_render
     import os
-    import re
     import validators
 
     # Validate input type first - must be a non-empty string
@@ -219,7 +221,7 @@ def is_safe_valid_url(test_url):
     # Check the actual rendered URL in case of any Jinja markup
     # Only run jinja_render when the URL actually contains Jinja2 syntax - creating a new
     # ImmutableSandboxedEnvironment is expensive and is called once per watch per page load
-    if '{%' in test_url or '{{' in test_url:
+    if _JINJA2_MARKER_PATTERN.search(test_url):
         try:
             test_url = jinja_render(test_url)
         except Exception as e:

--- a/changedetectionio/validate_url.py
+++ b/changedetectionio/validate_url.py
@@ -172,12 +172,9 @@ def is_llm_api_base_safe(api_base):
     return True, ''
 
 
-_JINJA2_MARKER_PATTERN = re.compile(r'{%[^}%]*%}|{{[^}]*}}')
-
-
 def is_safe_valid_url(test_url):
     from changedetectionio import strtobool
-    from changedetectionio.jinja2_custom import render as jinja_render
+    from changedetectionio.jinja2_custom import JINJA2_MARKER_PATTERN, render as jinja_render
     import os
     import validators
 
@@ -221,7 +218,7 @@ def is_safe_valid_url(test_url):
     # Check the actual rendered URL in case of any Jinja markup
     # Only run jinja_render when the URL actually contains Jinja2 syntax - creating a new
     # ImmutableSandboxedEnvironment is expensive and is called once per watch per page load
-    if _JINJA2_MARKER_PATTERN.search(test_url):
+    if JINJA2_MARKER_PATTERN.search(test_url):
         try:
             test_url = jinja_render(test_url)
         except Exception as e:


### PR DESCRIPTION
Fixes #4452.

## Cause

`is_safe_valid_url()` incorrectly returns `False` when Jinja2 rendering fails on `{%` in the URL:

https://github.com/dgtlmoon/changedetection.io/blob/08017d66d6df809a7cebdf938555d9bccead9c1f/changedetectionio/validate_url.py#L215-L220

```console
| ERROR    | changedetectionio.validate_url:is_safe_valid_url:219 - URL "https://`https://example.com/api?q={%22key%22:1}`" is not correct Jinja2? tag name expected
```

which in turn causes `validate_url()` to raise the error:

https://github.com/dgtlmoon/changedetection.io/blob/851c054f8bf1edd97cce81645f00a510d38d5071/changedetectionio/forms.py#L582-L584

## Changes

🔴 RED → 🟢 GREEN cycle:

1. 182df559: Add failing test for `{%` in URL-encoded JSON  – 🔴 **RED** at this point ([job log](https://github.com/skkzsh/changedetection.io/actions/runs/26766981409/job/78896691992#step:5:49037))
2. 18c61fca: Fix Jinja2 false-positive when URL contains `{%`  – 🟢 **GREEN** 

## Verification

Confirmed that a URL containing `{%` now accepted and registered as a watch.
