### PR TITLE
docs: fix plugins link

### DIFF
--- a/changedetectionio/blueprint/watchlist/templates/watch-overview.html
+++ b/changedetectionio/blueprint/watchlist/templates/watch-overview.html
@@ -1,7 +1,7 @@
 {%- extends 'base.html' -%}
 {%- block content -%}
 {%- set tips = [
-    _("Changedetection.io can monitor more than just web-pages! See our plugins!") ~ ' <a href="https://changedetection.io/plugins">' ~ _('More info') ~ '</a>',
+    _("Changedetection.io can monitor more than just web-pages! See our plugins!") ~ ' <a href="https://github.com/dgtlmoon/changedetection.io/blob/master/changedetectionio/PLUGIN_README.md">' ~ _('More info') ~ '</a>',
     _("You can also add 'shared' watches.") ~ ' <a href="https://github.com/dgtlmoon/changedetection.io/wiki/Sharing-a-Watch">' ~ _('More info') ~ '</a>'
 ] -%}
 {%- from '_helpers.html' import render_simple_field, render_field, render_nolabel_field, sort_by_title -%}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   #        Log output levels: TRACE, DEBUG(default), INFO, SUCCESS, WARNING, ERROR, CRITICAL
   #      - LOGGER_LEVEL=TRACE
   #
-  #        Plugins! See https://changedetection.io/plugins for more plugins.
+  #        Plugins! See https://github.com/dgtlmoon/changedetection.io/blob/master/changedetectionio/PLUGIN_README.md for more plugins.
   #        Install additional Python packages (processor plugins, etc.)
   #        Example: Install the OSINT reconnaissance processor plugin
   #      - EXTRA_PACKAGES=changedetection.io-osint-processor
@@ -148,4 +148,3 @@ services:
 
 volumes:
   changedetection-data:
-


### PR DESCRIPTION
## Summary
- point the homepage plugins tip at the repository plugin README instead of the missing `changedetection.io/plugins` page
- update the matching Docker Compose comment to the same live plugin documentation

Closes #4006

## Verification
- `git diff --check`
- `rg -n "changedetection\.io/plugins|PLUGIN_README\.md" changedetectionio/blueprint/watchlist/templates/watch-overview.html docker-compose.yml`
- curl check: `https://changedetection.io/plugins` returns 404; the GitHub plugin README URL returns 200