### PR TITLE
Add Flowtriq notification provider

### DIFF
--- a/changedetectionio/blueprint/ui/notification.py
+++ b/changedetectionio/blueprint/ui/notification.py
@@ -22,6 +22,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         from changedetectionio.jinja2_custom import render as jinja_render
 
         from changedetectionio.notification.apprise_plugin.custom_handlers import apprise_http_custom_handler
+        from changedetectionio.notification.apprise_plugin.flowtriq import NotifyFlowtriq  # noqa: F401
 
         apobj = apprise.Apprise(asset=apprise_asset)
 

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -506,6 +506,7 @@ class ValidateAppRiseServers(object):
         import apprise
         from .notification.apprise_plugin.assets import apprise_asset
         from .notification.apprise_plugin.custom_handlers import apprise_http_custom_handler  # noqa: F401
+        from .notification.apprise_plugin.flowtriq import NotifyFlowtriq  # noqa: F401
         from changedetectionio.jinja2_custom import render as jinja_render
 
         apobj = apprise.Apprise(asset=apprise_asset)

--- a/changedetectionio/notification/apprise_plugin/flowtriq.py
+++ b/changedetectionio/notification/apprise_plugin/flowtriq.py
@@ -14,18 +14,20 @@ Examples:
 
 The plugin POSTs a JSON payload containing:
     - source: "changedetection"
-    - watch_url: the URL being monitored
     - title: notification title
     - body: notification body (change details / diff)
     - status: "change_detected"
 """
 
 import json
+import os
 
 import requests
 from apprise import NotifyBase, NotifyType
 from apprise.common import NotifyFormat
 from loguru import logger
+
+from changedetectionio.validate_url import is_url_private_or_parser_confused
 
 
 class NotifyFlowtriq(NotifyBase):
@@ -70,6 +72,15 @@ class NotifyFlowtriq(NotifyBase):
         """
         Send a structured JSON payload to the Flowtriq webhook endpoint.
         """
+        # SSRF protection — block private/loopback addresses unless explicitly allowed.
+        if not os.getenv('ALLOW_IANA_RESTRICTED_ADDRESSES', '').lower() in ('true', '1', 'yes'):
+            if is_url_private_or_parser_confused(self.webhook_url):
+                logger.warning(
+                    f"Flowtriq target '{self.webhook_url}' is a private/reserved address. "
+                    f"Set ALLOW_IANA_RESTRICTED_ADDRESSES=true to allow."
+                )
+                return False
+
         headers = {
             'Content-Type': 'application/json',
             'User-Agent': 'changedetection.io',
@@ -80,7 +91,6 @@ class NotifyFlowtriq(NotifyBase):
 
         payload = {
             'source': 'changedetection',
-            'watch_url': title,
             'title': title,
             'body': body,
             'status': 'change_detected',
@@ -93,6 +103,7 @@ class NotifyFlowtriq(NotifyBase):
                 self.webhook_url,
                 data=json.dumps(payload),
                 headers=headers,
+                verify=self.verify_certificate,
                 timeout=30,
             )
             response.raise_for_status()
@@ -110,18 +121,17 @@ class NotifyFlowtriq(NotifyBase):
         """
         default_port = 443
 
-        url = '{schema}://{hostname}{port}{path}?key={apikey}'.format(
+        url = '{schema}://{hostname}{port}{path}'.format(
             schema=self.protocol,
             hostname=self.host,
             port='' if not self.port or self.port == default_port
             else f':{self.port}',
             path=self.fullpath if self.fullpath else '',
-            apikey=self.pprint(self.apikey, 'key', safe='')
-            if self.apikey else '',
         )
 
-        # Remove trailing ?key= when no API key is set
-        url = url.rstrip('?key=')
+        if self.apikey:
+            url += '?key={}'.format(
+                self.pprint(self.apikey, 'key', safe=''))
 
         return url
 

--- a/changedetectionio/notification/apprise_plugin/flowtriq.py
+++ b/changedetectionio/notification/apprise_plugin/flowtriq.py
@@ -1,0 +1,141 @@
+"""
+Custom Flowtriq notification plugin for changedetection.io
+
+Sends structured webhook payloads to Flowtriq (https://flowtriq.com) for
+correlating website changes and outages with DDoS attack data.
+
+Usage:
+    flowtriq://{hostname}/{path}
+    flowtriq://{hostname}/{path}?key={api_key}
+
+Examples:
+    flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection
+    flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection?key=your-api-key
+
+The plugin POSTs a JSON payload containing:
+    - source: "changedetection"
+    - watch_url: the URL being monitored
+    - title: notification title
+    - body: notification body (change details / diff)
+    - status: "change_detected"
+"""
+
+import json
+
+import requests
+from apprise import NotifyBase, NotifyType
+from apprise.common import NotifyFormat
+from loguru import logger
+
+
+class NotifyFlowtriq(NotifyBase):
+    """
+    Flowtriq webhook notification plugin.
+    """
+
+    app_id = 'NotifyFlowtriq'
+    app_desc = 'Flowtriq DDoS Detection & Traffic Analytics'
+    default_port = 443
+    default_secure_protocol = 'flowtriq'
+    notify_url_prefix = 'https'
+
+    # Plugin identification
+    protocol = 'flowtriq'
+    secure_protocol = 'flowtriq'
+    notify_format = NotifyFormat.TEXT
+
+    # Title is not used in the JSON payload structure directly,
+    # but we accept it for compatibility
+    title_maxlen = 250
+
+    def __init__(self, apikey=None, **kwargs):
+        super().__init__(**kwargs)
+
+        # API key for X-API-Key header (optional)
+        self.apikey = apikey
+
+        # Build the webhook URL from the parsed components
+        schema = 'https'
+        self.webhook_url = f'{schema}://{self.host}'
+
+        if self.port and self.port != 443:
+            self.webhook_url += f':{self.port}'
+
+        if self.fullpath:
+            self.webhook_url += self.fullpath
+
+        return
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Send a structured JSON payload to the Flowtriq webhook endpoint.
+        """
+        headers = {
+            'Content-Type': 'application/json',
+            'User-Agent': 'changedetection.io',
+        }
+
+        if self.apikey:
+            headers['X-API-Key'] = self.apikey
+
+        payload = {
+            'source': 'changedetection',
+            'watch_url': title,
+            'title': title,
+            'body': body,
+            'status': 'change_detected',
+        }
+
+        logger.info(f'Sending Flowtriq notification to {self.webhook_url}')
+
+        try:
+            response = requests.post(
+                self.webhook_url,
+                data=json.dumps(payload),
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+
+        except requests.RequestException as e:
+            logger.warning(f'Flowtriq notification failed: {e}')
+            return False
+
+        logger.info(f'Flowtriq notification sent successfully to {self.webhook_url}')
+        return True
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Return the URL representation of this notification.
+        """
+        default_port = 443
+
+        url = '{schema}://{hostname}{port}{path}?key={apikey}'.format(
+            schema=self.protocol,
+            hostname=self.host,
+            port='' if not self.port or self.port == default_port
+            else f':{self.port}',
+            path=self.fullpath if self.fullpath else '',
+            apikey=self.pprint(self.apikey, 'key', safe='')
+            if self.apikey else '',
+        )
+
+        # Remove trailing ?key= when no API key is set
+        url = url.rstrip('?key=')
+
+        return url
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parse the Flowtriq URL and return the components needed to
+        re-instantiate this plugin.
+        """
+        results = NotifyBase.parse_url(url, verify_host=True)
+        if not results:
+            return results
+
+        # Extract API key from ?key= query parameter
+        results['apikey'] = results['qsd'].get('key')
+
+        return results

--- a/changedetectionio/notification/handler.py
+++ b/changedetectionio/notification/handler.py
@@ -311,6 +311,8 @@ def process_notification(n_object: NotificationContextData, datastore):
     from .apprise_plugin.custom_handlers import apprise_http_custom_handler
     # Register custom Discord plugin
     from .apprise_plugin.discord import NotifyDiscordCustom
+    # Register Flowtriq plugin
+    from .apprise_plugin.flowtriq import NotifyFlowtriq
 
     if not isinstance(n_object, NotificationContextData):
         raise TypeError(f"Expected NotificationContextData, got {type(n_object)}")
@@ -353,6 +355,9 @@ def process_notification(n_object: NotificationContextData, datastore):
     # First remove the built-in discord plugin, then add our custom one
     apprise.plugins.N_MGR.remove('discord')
     apprise.plugins.N_MGR.add(NotifyDiscordCustom, schemas='discord')
+
+    # Register Flowtriq notification plugin
+    apprise.plugins.N_MGR.add(NotifyFlowtriq, schemas='flowtriq')
 
     if not n_object.get('notification_urls'):
         return None

--- a/changedetectionio/tests/apprise/test_apprise_flowtriq.py
+++ b/changedetectionio/tests/apprise/test_apprise_flowtriq.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -110,8 +111,34 @@ def test_flowtriq_payload_structure(mock_post):
     payload = json.loads(mock_post.call_args[1]['data'])
     assert payload == {
         'source': 'changedetection',
-        'watch_url': 'https://monitored-site.com/status',
         'title': 'https://monitored-site.com/status',
         'body': 'Line removed: old content\nLine added: new content',
         'status': 'change_detected',
     }
+
+
+def test_flowtriq_ssrf_blocks_private_address():
+    """Test that SSRF protection blocks private/loopback addresses."""
+    plugin = NotifyFlowtriq(
+        host='localhost',
+        fullpath='/api/v1/webhooks/changedetection',
+    )
+
+    # Ensure ALLOW_IANA_RESTRICTED_ADDRESSES is not set
+    with patch.dict(os.environ, {}, clear=True):
+        result = plugin.send(body='Page changed', title='test')
+
+    assert result is False
+
+
+@patch("requests.post")
+def test_flowtriq_url_without_apikey(mock_post):
+    """Test url() does not leave trailing ?key= when no API key is set."""
+    plugin = NotifyFlowtriq(
+        host='app.flowtriq.com',
+        fullpath='/api/v1/webhooks/changedetection',
+    )
+
+    url = plugin.url()
+    assert url == 'flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection'
+    assert '?key=' not in url

--- a/changedetectionio/tests/apprise/test_apprise_flowtriq.py
+++ b/changedetectionio/tests/apprise/test_apprise_flowtriq.py
@@ -1,0 +1,117 @@
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from changedetectionio.notification.apprise_plugin.flowtriq import NotifyFlowtriq
+
+
+def test_flowtriq_parse_url_basic():
+    """Test basic URL parsing without API key."""
+    result = NotifyFlowtriq.parse_url(
+        'flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection'
+    )
+    assert result is not None
+    assert result['host'] == 'app.flowtriq.com'
+    assert result['apikey'] is None
+
+
+def test_flowtriq_parse_url_with_apikey():
+    """Test URL parsing with API key."""
+    result = NotifyFlowtriq.parse_url(
+        'flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection?key=test-key-123'
+    )
+    assert result is not None
+    assert result['host'] == 'app.flowtriq.com'
+    assert result['apikey'] == 'test-key-123'
+
+
+@patch("requests.post")
+def test_flowtriq_send_success(mock_post):
+    """Test successful notification send."""
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_post.return_value.raise_for_status.return_value = None
+
+    plugin = NotifyFlowtriq(
+        host='app.flowtriq.com',
+        fullpath='/api/v1/webhooks/changedetection',
+        apikey='test-key',
+    )
+
+    result = plugin.send(body='Page changed', title='https://example.com')
+
+    assert result is True
+    mock_post.assert_called_once()
+
+    call_args = mock_post.call_args
+    assert call_args[0][0] == 'https://app.flowtriq.com/api/v1/webhooks/changedetection'
+
+    headers = call_args[1]['headers']
+    assert headers['Content-Type'] == 'application/json'
+    assert headers['X-API-Key'] == 'test-key'
+
+    payload = json.loads(call_args[1]['data'])
+    assert payload['source'] == 'changedetection'
+    assert payload['status'] == 'change_detected'
+    assert payload['body'] == 'Page changed'
+
+
+@patch("requests.post")
+def test_flowtriq_send_without_apikey(mock_post):
+    """Test notification send without API key (no X-API-Key header)."""
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_post.return_value.raise_for_status.return_value = None
+
+    plugin = NotifyFlowtriq(
+        host='app.flowtriq.com',
+        fullpath='/api/v1/webhooks/changedetection',
+    )
+
+    result = plugin.send(body='Page changed', title='https://example.com')
+
+    assert result is True
+    headers = mock_post.call_args[1]['headers']
+    assert 'X-API-Key' not in headers
+
+
+@patch("requests.post")
+def test_flowtriq_send_failure(mock_post):
+    """Test notification failure handling."""
+    mock_post.side_effect = requests.RequestException("Connection refused")
+
+    plugin = NotifyFlowtriq(
+        host='app.flowtriq.com',
+        fullpath='/api/v1/webhooks/changedetection',
+    )
+
+    result = plugin.send(body='Page changed', title='https://example.com')
+
+    assert result is False
+
+
+@patch("requests.post")
+def test_flowtriq_payload_structure(mock_post):
+    """Test the JSON payload structure matches what Flowtriq expects."""
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_post.return_value.raise_for_status.return_value = None
+
+    plugin = NotifyFlowtriq(
+        host='app.flowtriq.com',
+        fullpath='/api/v1/webhooks/changedetection',
+        apikey='my-key',
+    )
+
+    plugin.send(
+        body='Line removed: old content\nLine added: new content',
+        title='https://monitored-site.com/status',
+    )
+
+    payload = json.loads(mock_post.call_args[1]['data'])
+    assert payload == {
+        'source': 'changedetection',
+        'watch_url': 'https://monitored-site.com/status',
+        'title': 'https://monitored-site.com/status',
+        'body': 'Line removed: old content\nLine added: new content',
+        'status': 'change_detected',
+    }


### PR DESCRIPTION
## Summary

Adds [Flowtriq](https://flowtriq.com) as a native notification provider via a custom Apprise plugin. Flowtriq is a DDoS detection and traffic analytics platform -- correlating website changes/outages detected by changedetection.io with DDoS attack data is a natural fit.

**Usage:**

```
flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection
flowtriq://app.flowtriq.com/api/v1/webhooks/changedetection?key=your-api-key
```

**What this does:**

- Registers a `flowtriq://` URL scheme as a custom Apprise notification plugin
- POSTs a structured JSON payload (`source`, `watch_url`, `title`, `body`, `status`) to the configured Flowtriq webhook endpoint
- Supports optional API key authentication via the `X-API-Key` header (passed as `?key=` in the URL)
- Follows the existing pattern established by the custom Discord plugin

**Files changed:**

- `changedetectionio/notification/apprise_plugin/flowtriq.py` -- the plugin (NotifyFlowtriq class extending NotifyBase)
- `changedetectionio/notification/handler.py` -- registers the plugin with Apprise's plugin manager
- `changedetectionio/forms.py` -- imports the plugin so URL validation recognizes `flowtriq://`
- `changedetectionio/blueprint/ui/notification.py` -- imports the plugin for test notification support
- `changedetectionio/tests/apprise/test_apprise_flowtriq.py` -- unit tests covering URL parsing, send success/failure, payload structure, and API key handling

## Test plan

- [ ] Verify `flowtriq://` URLs are accepted in the notification URL field without validation errors
- [ ] Verify test notification sends the correct JSON payload structure to the webhook endpoint
- [ ] Verify API key is included as `X-API-Key` header when `?key=` is provided
- [ ] Verify notifications work without an API key
- [ ] Verify connection failures are handled gracefully (returns False, no crash)
- [ ] Run `pytest changedetectionio/tests/apprise/test_apprise_flowtriq.py`