### PR TITLE
LLM: strip sampling params and retry when the model rejects them

### DIFF
--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -90,13 +90,24 @@ def completion(model: str, messages: list, api_key: str = None,
 
     _retryable = (litellm.Timeout, litellm.APIConnectionError)
 
+    # Some models reject sampling params outright: Anthropic Claude Opus 4.7/4.8 and
+    # Fable return HTTP 400 for 'temperature', and OpenAI reasoning models (o1/o3/gpt-5)
+    # only accept the default. litellm's per-model param metadata lags new releases, so
+    # drop_params can't be relied on for freshly released models — instead, if the provider
+    # rejects a sampling param, strip them and retry once. Models that accept them are
+    # unaffected (they still receive temperature=0).
+    _sampling_params = ('temperature', 'top_p', 'top_k')
+    _stripped_sampling = False
+
     logger.debug(
         f"LLM client: calling model={model!r} api_base={api_base!r} "
         f"timeout={_timeout}s max_tokens={kwargs['max_tokens']}"
     )
     logger.trace(messages)
 
-    for attempt in range(1, DEFAULT_RETRIES + 1):
+    attempt = 0
+    while attempt < DEFAULT_RETRIES:
+        attempt += 1
         try:
             response = litellm.completion(**kwargs)
             choice   = response.choices[0]
@@ -155,6 +166,25 @@ def completion(model: str, messages: list, api_key: str = None,
                 f"LLM call failed after {DEFAULT_RETRIES} attempts ({_timeout}s timeout) "
                 f"model={model!r} error={e}"
             )
+            raise
+
+        except litellm.BadRequestError as e:
+            # If the provider rejected an unsupported sampling param (and we haven't
+            # already stripped them), drop them and retry once. attempt-=1 keeps this
+            # off the timeout-retry budget; _stripped_sampling prevents a loop.
+            msg = str(e).lower()
+            if (not _stripped_sampling
+                    and any(p in kwargs for p in _sampling_params)
+                    and any(p in msg for p in _sampling_params)):
+                dropped = [p for p in _sampling_params if kwargs.pop(p, None) is not None]
+                _stripped_sampling = True
+                attempt -= 1
+                logger.warning(
+                    f"LLM client: model={model!r} rejected sampling params {dropped} "
+                    f"({e}); retrying without them"
+                )
+                continue
+            logger.warning(f"LLM call failed: model={model!r} error={e}")
             raise
 
         except Exception as e:


### PR DESCRIPTION
Closes #4240.

`llm/client.py` sends `temperature: 0` on every `litellm.completion` call. Some current models reject that parameter:

- **Anthropic** Claude Opus 4.7, Opus 4.8, and Fable return HTTP `400` — `` `temperature` is deprecated for this model. ``
- **OpenAI** reasoning models (o1 / o3 / gpt‑5) accept only the default temperature.

The effect is that the LLM change-summary / evaluation feature is completely non-functional on those models — every call fails before any output is produced, and token/cost counters stay at zero.

### Why not `drop_params=True`?

`drop_params` relies on litellm's per-model parameter metadata, and that metadata lags new releases. `litellm.get_supported_openai_params("claude-opus-4-8", custom_llm_provider="anthropic")` still lists `temperature` as supported, so litellm forwards it and the provider 400s anyway. I confirmed `drop_params=True` does **not** fix this for `claude-opus-4-8`.

### Change

Catch the provider's `BadRequestError`; if the message names a sampling param we sent (`temperature` / `top_p` / `top_k`) and we haven't already stripped them, drop them and retry once. The retry doesn't consume the timeout-retry budget, and a flag prevents looping. Models that accept these params are unaffected — they still receive `temperature: 0`. This needs no per-model allow/deny list and keeps working as new models ship, regardless of litellm metadata freshness.

### Testing

Verified against `anthropic/claude-opus-4-8`: the initial call returns `400 "temperature is deprecated for this model."`, the client strips `temperature` and retries, and the retry succeeds. Models that accept `temperature` (e.g. `claude-opus-4-6`) are unchanged — no extra round-trip.