### PR TITLE
fix: don't save HTML soft-404 pages as the favicon (#4207)

### DIFF
--- a/changedetectionio/content_fetchers/res/favicon-fetcher.js
+++ b/changedetectionio/content_fetchers/res/favicon-fetcher.js
@@ -87,6 +87,12 @@
 
         const blob = await resp.blob();
 
+        // A server may answer /favicon.ico (or a declared icon URL) with HTTP 200 and an HTML
+        // body - a soft-404 or SPA catch-all page. Skip obvious non-image content types so the
+        // markup is never handed back as an icon. https://github.com/dgtlmoon/changedetection.io/issues/4207
+        const contentType = (blob.type || '').split(';')[0].trim().toLowerCase();
+        if (contentType === 'text/html' || contentType === 'application/xhtml+xml' || contentType === 'text/plain') continue;
+
         if (blob.size > MAX_BYTES) continue;
 
         // Convert blob to base64

--- a/changedetectionio/model/Watch.py
+++ b/changedetectionio/model/Watch.py
@@ -864,6 +864,15 @@ class model(EntityPersistenceMixin, watch_base):
             logger.warning(f"UUID: {self.get('uuid')} Favicon too large ({len(decoded)} bytes), skipping")
             return None
 
+        # Reject non-image payloads such as an HTML soft-404 or SPA catch-all page that a server
+        # returns with HTTP 200 for /favicon.ico - otherwise the raw markup gets written out as
+        # the favicon. https://github.com/dgtlmoon/changedetection.io/issues/4207
+        normalized_mime = mime_type.lower().split(';')[0].strip() if mime_type else ''
+        head = decoded[:512].lstrip().lower()
+        if normalized_mime in ('text/html', 'application/xhtml+xml') or head.startswith((b'<!doctype html', b'<html')):
+            logger.warning(f"UUID: {self.get('uuid')} Favicon from '{url}' looks like an HTML page, not an image - skipping")
+            return None
+
         try:
             with open(fname, 'wb') as f:
                 f.write(decoded)

--- a/changedetectionio/tests/test_security.py
+++ b/changedetectionio/tests/test_security.py
@@ -133,6 +133,31 @@ def test_favicon_oversized_rejected(client, live_server, measure_memory_usage, d
     assert watch.get_favicon_filename() is None, "No favicon file should have been written"
 
 
+def test_favicon_html_page_rejected(client, live_server, measure_memory_usage, datastore_path):
+    """
+    A server can answer /favicon.ico (or a declared icon URL) with HTTP 200 and an HTML body -
+    a soft-404 or SPA catch-all page. That markup must never be saved as the favicon.
+    https://github.com/dgtlmoon/changedetection.io/issues/4207
+    """
+    import base64
+
+    html_page = b'<!DOCTYPE html>\n<html><head><title>Not found</title></head><body>404</body></html>'
+    html_b64 = base64.b64encode(html_page).decode()
+
+    # The server was honest about the content type (blob.type == 'text/html')
+    uuid = client.application.config.get('DATASTORE').add_watch(url='https://localhost')
+    watch = live_server.app.config['DATASTORE'].data['watching'][uuid]
+    result = watch.bump_favicon(url='https://example.com/favicon.ico', favicon_base_64=html_b64, mime_type='text/html')
+    assert result is None, "bump_favicon should reject an HTML payload"
+    assert watch.get_favicon_filename() is None, "HTML must not be saved as a favicon (#4207)"
+
+    # The content type was missing/misleading, so the payload itself has to be sniffed
+    uuid2 = client.application.config.get('DATASTORE').add_watch(url='https://localhost')
+    watch2 = live_server.app.config['DATASTORE'].data['watching'][uuid2]
+    watch2.bump_favicon(url='https://example.com/favicon.ico', favicon_base_64=html_b64, mime_type=None)
+    assert watch2.get_favicon_filename() is None, "HTML must not be saved even with no content type (#4207)"
+
+
 def test_bad_access(client, live_server, measure_memory_usage, datastore_path):
 
     res = client.post(


### PR DESCRIPTION
When a watched site has no declared favicon, the fetcher falls back to `/favicon.ico`. Some servers answer that path with HTTP 200 and an HTML body (a soft-404 or SPA catch-all page) rather than a real 404. The fetcher only checked `resp.ok`, so that HTML response was returned as the "favicon" blob, and `bump_favicon()` then wrote the raw markup to `favicon.ico` (its `mime_type` fallback resolves the extension from the `.ico` URL path and never checks that the bytes are an image).

## Fix

- `Watch.bump_favicon()` now rejects a payload whose content type is `text/html` / `application/xhtml+xml`, or whose bytes start with an HTML doctype / `<html>` tag. This is the authoritative server-side guard.
- `favicon-fetcher.js` skips obvious non-image content types (`text/html`, `application/xhtml+xml`, `text/plain`) before returning the blob, so the markup is not transferred in the first place.

Both guards are conservative: SVG icons and real images served with a wrong or absent content type still save fine, since they are not `text/html` and do not start with an HTML tag.

## Verification

- Added `test_favicon_html_page_rejected` covering both the honest `text/html` content type and the missing-content-type (byte-sniff) case. It fails on master (the HTML is saved) and passes with this change.
- Existing favicon tests still pass (SVG, PNG data URI, mime-overrides-extension, oversized): `pytest tests/test_security.py -k favicon` gives 5 passed.
- Full unit suite green: `pytest tests/unit/` gives 186 passed.
- Ran in the project's Docker test image.

Note: only the server-side `bump_favicon()` guard has an automated regression test. The `favicon-fetcher.js` guard runs inside the browser fetchers (Playwright/Puppeteer) and is not exercised by an automated test here; it is defense-in-depth, so the server-side guard is the one that actually prevents the bad save.

Fixes #4207