### PR TITLE
fix: .gitignore the real test-log path (changedetectionio/tests/logs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,6 @@ test-datastore/
 
 # Memory consumption log
 test-memory.log
-tests/logs/
+
+# Per-test loguru logs written by tests/conftest.py (dirname(__file__)/logs)
+changedetectionio/tests/logs/


### PR DESCRIPTION
## Problem

Running the test suite locally leaves ~200 untracked `*_master.log` files in the working tree — `git status` reports the whole `changedetectionio/tests/logs/` directory as untracked after any local `pytest` run.

`changedetectionio/tests/conftest.py` writes a per-test loguru log to:

```python
log_dir = os.path.join(os.path.dirname(__file__), "logs")   # -> changedetectionio/tests/logs/
```

`.gitignore` already intends to ignore these (`tests/logs/`), but because that pattern contains a slash, git anchors it to the **repo root**. There is no repo-root `tests/`, so the rule matches nothing:

```
$ git check-ignore -v changedetectionio/tests/logs/test_bad_access_master.log
(no match)
```

## Fix

Point the pattern at the path the harness actually writes to, `changedetectionio/tests/logs/`, and add a comment noting where it comes from. `.gitignore`-only; no code/behavior change.

## Verification

```
$ git check-ignore -v changedetectionio/tests/logs/test_probe_master.log
.gitignore:34:changedetectionio/tests/logs/   changedetectionio/tests/logs/test_probe_master.log
```

The directory is now correctly ignored, and a fresh test run no longer dirties the working tree.
