### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Easily add the current web page to your changedetection.io tool, simply install 
 
 ## Installation
 
+### One-click managed hosting
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/changedetection-io) managed changedetection.io with storage, backups, email and a free subdomain included, no server required.
+
 ### Docker
 
 With Docker composer, just clone this repository and..


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added changedetection.io to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Installation section (links to https://zenith.hosting/host/changedetection-io).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting