### PR TITLE
fix: safe-empty restock default so restock notification tokens work for any watch

### DIFF
--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -207,6 +207,10 @@ class NotificationContextData(dict):
             # Always the raw +/- diff regardless of LLM summary override (populated in handler.py from {{diff}})
             'raw_diff': FormattableDiff('', ''),
             'markup_text_links_to_html_links': False, # If automatic conversion of plaintext to HTML should happen
+            # Safe-empty default so restock tokens ({{ restock.price }} etc.) are a valid,
+            # non-crashing token for every watch. Restock watches override this via
+            # processors/restock_diff extra_notification_token_values().
+            'restock': {},
             'notification_timestamp': time.time(),
             'prev_snapshot': None,
             'preview_url': None,

--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -210,7 +210,7 @@ class NotificationContextData(dict):
             # Safe-empty default so restock tokens ({{ restock.price }} etc.) are a valid,
             # non-crashing token for every watch. Restock watches override this via
             # processors/restock_diff extra_notification_token_values().
-            'restock': {},
+            'restock': {}, #@TODO ! should be fixed in a refactor of all processor types, maybe fetching a empty key returns null or even restock (or similar) should actually come from the JSON in the datadir processor-restock-diff.json etc
             'notification_timestamp': time.time(),
             'prev_snapshot': None,
             'preview_url': None,

--- a/changedetectionio/tests/test_notification_restock_token.py
+++ b/changedetectionio/tests/test_notification_restock_token.py
@@ -1,0 +1,43 @@
+"""
+Regression tests for issue #3490 - "'restock' is undefined".
+
+A `{{ restock.price }}` token is accepted in a per-watch notification body (restock
+watches inject the value via processors/restock_diff extra_notification_token_values()),
+but the same token in a system-wide / non-restock context had no default. That made it:
+
+  1. crash rendering at send time for a non-restock watch (UndefinedError), and
+  2. fail save-time validation of a system-wide notification body (ValidationError),
+
+because `restock` was absent from NotificationContextData's default token set.
+
+These tests exercise the real send-time (jinja2_custom.render) and save-time
+(ValidateJinja2Template) code paths. They fail on a tree without the safe-empty
+default and pass with it.
+"""
+from changedetectionio.notification_service import NotificationContextData
+
+
+def test_restock_token_present_in_default_context():
+    assert 'restock' in NotificationContextData()
+
+
+def test_restock_token_renders_safely_for_non_restock_watch():
+    """Send time: a non-restock watch must not crash on {{ restock.price }}."""
+    from changedetectionio.jinja2_custom import render as jinja_render
+
+    ctx = NotificationContextData()  # a plain, non-restock watch context
+    rendered = jinja_render(template_str="Price is {{ restock.price }}", **ctx)
+    # The undefined price renders as empty rather than raising UndefinedError.
+    assert rendered == "Price is "
+
+
+def test_restock_token_validates_in_system_settings():
+    """Save time: a system-wide body using {{ restock.price }} must validate."""
+    from changedetectionio.forms import ValidateJinja2Template
+
+    class _Field:
+        def __init__(self, data):
+            self.data = data
+
+    # Raised ValidationError before the fix; must not raise now.
+    ValidateJinja2Template()(None, _Field("Price is {{ restock.price }}"))


### PR DESCRIPTION
### Root cause

`{{ restock.price }}` (and the other `restock.*` tokens) are only added to the
notification context for restock watches, in
`processors/restock_diff` `extra_notification_token_values()`. The base token set in
`NotificationContextData.__init__` (`changedetectionio/notification_service.py`) has no
`restock` key, so for a non-restock watch, or for a system-wide notification body, the
token is undefined. That produces two failures:

1. Send time: rendering a body containing `{{ restock.price }}` for a non-restock watch
   raises `jinja2 UndefinedError: 'restock' is undefined` (the exact error in #3490).
2. Save time: `ValidateJinja2Template` builds its valid-token set from the same defaults,
   so a system-wide body using `{{ restock.price }}` is rejected unless a restock watch
   happens to exist.

### Invariant

A notification token that is valid in a per-watch body should also be a valid,
non-crashing token in a system-wide body, independent of the current watch inventory.

### Fix

Add a safe-empty `'restock': {}` to the `NotificationContextData` default token set.
Restock watches still override it with the real price object via
`extra_notification_token_values()`, so their notifications are unchanged. Every other
watch now renders `{{ restock.price }}` as empty rather than raising, and system-wide
bodies validate.

This is intentionally the narrow token-availability fix for #3490, not the separate
restock-data storage change noted in the issue thread.

### How I verified

In a clean `python:3.11-slim` Docker container against `master` HEAD (ee84ece):

- Reproduced both failures on `master`: `render('{{ restock.price }}', **NotificationContextData())`
  raises `UndefinedError`, and `ValidateJinja2Template` raises `ValidationError`, both
  `'restock' is undefined`.
- Added `tests/test_notification_restock_token.py` covering the default token, the
  send-time render, and the save-time validation. It fails on `master` (3 failed) and
  passes with the fix (3 passed).
- Ran the existing `tests/llm/test_notification_tokens.py` and
  `tests/llm/test_llm_restock_plugin.py` with the fix: 36 passed.

I did not run the full browser/selenium/playwright suite or the SMTP integration tests;
this change only touches the in-memory default token dict.

Run: `pytest tests/test_notification_restock_token.py`

AI assistance was used to help write this change; I reproduced and verified it as
described above.

Fixes #3490
