### PR TITLE
[feature] Restock LLM fallback: make the 8000 char content limit configurable, change to 15,000 chars by default #4213

### DIFF
--- a/changedetectionio/processors/restock_diff/plugins/llm_restock.py
+++ b/changedetectionio/processors/restock_diff/plugins/llm_restock.py
@@ -10,6 +10,7 @@ The module-level `datastore` variable is injected at startup by
 `inject_datastore_into_plugins()` in pluggy_interface.py.
 """
 import json
+import os
 import re
 from loguru import logger
 from changedetectionio.pluggy_interface import hookimpl
@@ -86,7 +87,11 @@ SYSTEM_PROMPT = (
     'No markdown, no backticks, no explanation — pure JSON only.'
 )
 
-_MAX_CONTENT_CHARS = 8_000
+# Max characters of page content (JSON-LD + stripped text) sent to the LLM.
+# Some retailers (e.g. Amazon.de) place the buy-box price well past 8k chars,
+# so this is env-configurable. Larger values increase input-token cost per
+# check and may exceed local-model context windows (bump Ollama num_ctx to match).
+_MAX_CONTENT_CHARS = int(os.getenv('LLM_RESTOCK_MAX_CONTENT_CHARS', 15_000))
 
 
 def _extract_jsonld(html_content: str) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,9 +73,11 @@ services:
   #        Disable all LLM / AI features, prompts etc
   #      - LLM_FEATURES_DISABLED=true
   #
-  #        Max characters of page content sent to the LLM for price/restock fallback extraction, default 15000.
-  #        Increase if a retailer places the price deep in the page (e.g. Amazon), higher values cost more input tokens
-  #        and may exceed local-model context windows (bump Ollama num_ctx to match).
+  #        How much of the page text the AI reads when finding the price/stock, default 15000 characters.
+  #        Raise it if the price is missed (some shops put it far down the page).
+  #        Using a local model (Ollama)? It may only read the first part unless you raise its context size
+  #        (num_ctx) to about 8192 or more, otherwise it can miss the price.
+  #        In Ollama: run `ollama run <model>` then `/set parameter num_ctx 8192`
   #      - LLM_RESTOCK_MAX_CONTENT_CHARS=15000
   #
   #        A valid timezone name to run as (for scheduling watch checking) see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,12 @@ services:
   #      - DISABLE_VERSION_CHECK=true
   #
   #        Disable all LLM / AI features, prompts etc
-  #      - LLM_FEATURES_DISABLED=true  
+  #      - LLM_FEATURES_DISABLED=true
+  #
+  #        Max characters of page content sent to the LLM for price/restock fallback extraction, default 15000.
+  #        Increase if a retailer places the price deep in the page (e.g. Amazon), higher values cost more input tokens
+  #        and may exceed local-model context windows (bump Ollama num_ctx to match).
+  #      - LLM_RESTOCK_MAX_CONTENT_CHARS=15000
   #
   #        A valid timezone name to run as (for scheduling watch checking) see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   #      - TZ=America/Los_Angeles


### PR DESCRIPTION
Closes #4213