### PR TITLE
fix: report the actual 1-based failed browser-step number (#4200)

### DIFF
--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -512,7 +512,7 @@ Thanks - Your omniscient changedetection.io installation.
             return
         threshold = self.datastore.data['settings']['application'].get('filter_failure_notification_threshold_attempts')
 
-        step = step_n + 1
+        step = step_n
         # @todo - This could be a markdown template on the disk, apprise will convert the markdown to HTML+Plaintext parts in the email, and then 'markup_text_links_to_html_links' is not needed
 
         # {{{{ }}}} because this will be Jinja2 {{ }} tokens

--- a/changedetectionio/tests/unit/test_step_failure_notification.py
+++ b/changedetectionio/tests/unit/test_step_failure_notification.py
@@ -65,4 +65,28 @@ def test_send_step_failure_notification_queues_item():
     assert not notification_q.empty(), "Expected a notification to be queued"
     item = notification_q.get_nowait()
     assert 'notification_title' in item
-    assert 'position 2' in item['notification_title']
+    # step_n is already 1-based (base.py increments step_n before running each step, so the
+    # first browser step raises with step_n=1), so the reported position must equal step_n.
+    assert 'position 1' in item['notification_title']
+
+
+def test_send_step_failure_notification_position_matches_step_number():
+    """Regression for #4200: the reported browser-step position must equal the 1-based
+    step_n, not step_n + 1. step_n arrives already 1-based (BrowserStepsStepException is
+    raised with the post-increment counter, and worker.py passes e.step_n through), and the
+    frontend highlights nth-child(browser_steps_last_error_step) / compares === i+1, both
+    1-based. An extra +1 mis-numbers the notification and highlights the wrong step."""
+    from changedetectionio.notification_service import NotificationService
+
+    for step_n in (1, 2, 5):
+        watch_uuid = f'test-uuid-pos-{step_n}'
+        notification_q = queue.Queue()
+        datastore, _ = _make_datastore(watch_uuid, 'post://localhost/test')
+        service = NotificationService(datastore=datastore, notification_q=notification_q)
+
+        service.send_step_failure_notification(watch_uuid=watch_uuid, step_n=step_n)
+
+        item = notification_q.get_nowait()
+        assert f'position {step_n} could not be run' in item['notification_title']
+        assert f'position {step_n + 1}' not in item['notification_title']
+        assert f'position {step_n} for the web page watch' in item['notification_body']

--- a/changedetectionio/worker.py
+++ b/changedetectionio/worker.py
@@ -324,7 +324,7 @@ async def async_update_worker(worker_id, q, notification_q, app, datastore, exec
                     if not datastore.data['watching'].get(uuid):
                         continue
 
-                    error_step = e.step_n + 1
+                    error_step = e.step_n
                     from playwright._impl._errors import TimeoutError, Error
 
                     # Generally enough info for TimeoutError (couldnt locate the element after default seconds)


### PR DESCRIPTION
## Root cause

`BrowserStepsStepException` is raised with an already 1-based `step_n`. In `content_fetchers/base.py`, `iterate_browser_steps` starts `step_n = 0` and does `step_n += 1` **before** running each step (base.py:169-199), so the first browser step fails with `step_n=1`.

Two consumers then add another `+1`:

- `worker.py:327`: `error_step = e.step_n + 1`, stored as `browser_steps_last_error_step` and used in the error text and debug log.
- `notification_service.py:515`: `step = step_n + 1`, used in the step-failure notification title and body (worker.py passes `e.step_n` straight through at line 354).

So the value is double-counted: a first-step failure is reported as "position 2" and `browser_steps_last_error_step` is stored as 2. That matches the report in #4200 (2 steps, step 2 fails, stored value 3).

## Invariant

`e.step_n` is 1-based (1 = first browser step), and the frontend already treats `browser_steps_last_error_step` as 1-based: `static/js/browser-steps.js` highlights `nth-child(browser_steps_last_error_step)` (line 455, 1-based) and compares `browser_steps_last_error_step === i+1` (line 368, with `i` 0-based). So the stored/reported step must equal `e.step_n`, not `e.step_n + 1`. The extra `+1` mis-numbers the log and notification and highlights the wrong `<li>`.

## Fix

Remove the `+1` at both sites so the reported/stored value equals `e.step_n`. Two-line source change.

## How I verified

Ran in a clean `python:3.11-slim-bookworm` container (matching the repo Dockerfile), against current HEAD (6e6a744):

- Updated the existing browser-free unit test and added a regression test in `tests/unit/test_step_failure_notification.py` asserting the reported position equals the 1-based `step_n`.
- Differential: with the source unchanged the updated/new tests FAIL (`step_n=1` yields "position 2"); with the fix they PASS.
- Full `tests/unit/` suite: 193 passed, no regressions.

Command:
`docker run --rm -v $PWD:/app -w /app <img> python -m pytest changedetectionio/tests/unit/test_step_failure_notification.py -v`

What I did not verify: the `worker.py` stored-value line (`browser_steps_last_error_step`) is the same off-by-one and is fixed symmetrically, but it sits inline in `async_update_worker` with no seam to unit-test in isolation, so it is covered by reading it against the frontend's 1-based consumers rather than by an automated test. I did not run the full playwright/selenium browser-steps integration path.

Fixes #4200
