### PR TITLE
fix: keep jinja2 blocks intact when splitting tags from imported URLs (#1516)

### DIFF
--- a/changedetectionio/blueprint/imports/importer.py
+++ b/changedetectionio/blueprint/imports/importer.py
@@ -1,10 +1,31 @@
 from abc import abstractmethod
+import re
 import time
 from wtforms import ValidationError
 from loguru import logger
 from flask_babel import gettext
 
 from changedetectionio.forms import validate_url
+
+# A jinja2 block in a watch URL can legitimately contain spaces
+# (eg. "https://example.com/?date={% now 'utc', '%d' %}"), so the space that separates
+# the URL from its tags can only be one that sits OUTSIDE of such a block.
+JINJA2_BLOCK_PATTERN = re.compile(r'\{%.*?%\}|\{\{.*?\}\}', re.DOTALL)
+
+
+def split_url_and_tags(line):
+    """Split a "<url> <tags>" import line on the first space outside any jinja2 block.
+
+    Returns (url, tags), tags is "" when the line has no separating space.
+    """
+    # Blank out the jinja2 blocks so their spaces can't be mistaken for the separator,
+    # keeping the length the same so the offset still maps back to the original line.
+    masked = JINJA2_BLOCK_PATTERN.sub(lambda m: '_' * len(m.group(0)), line)
+    idx = masked.find(' ')
+    if idx == -1:
+        return line, ""
+
+    return line[:idx], line[idx + 1:]
 
 
 class Importer():
@@ -52,8 +73,7 @@ class import_url_list(Importer):
             tags = ""
 
             # 'tags' should be a csv list after the URL
-            if ' ' in url:
-                url, tags = url.split(" ", 1)
+            url, tags = split_url_and_tags(url)
 
             # Flask wtform validators wont work with basic auth, use validators package
             # Up to 5000 per batch so we dont flood the server

--- a/changedetectionio/tests/test_import.py
+++ b/changedetectionio/tests/test_import.py
@@ -34,6 +34,35 @@ https://example.com tag1, other tag"""
     res = client.get( url_for("watchlist.index"))
     res = client.get( url_for("watchlist.index"))
 
+def test_import_url_with_jinja2_whitespace(client, live_server, measure_memory_usage, datastore_path):
+    """Spaces inside a jinja2 block are part of the URL, not the URL/tag separator #1516"""
+    wait_for_all_checks(client)
+
+    test_url = url_for('test_return_query', _external=True)
+    full_url = test_url + "?date={% now 'utc', '%d' %}"
+
+    res = client.post(
+        url_for("imports.import_page"),
+        data={
+            "distill-io": "",
+            "urls": full_url + " tag-a"
+        },
+        follow_redirects=True,
+    )
+
+    assert b"1 Imported" in res.data
+    assert b"tag-a" in res.data
+
+    # The jinja2 block should survive intact, only the space after it separates the tags
+    urls = [watch.get('url') for watch in live_server.app.config['DATASTORE'].data['watching'].values()]
+    assert urls == [full_url]
+
+    delete_all_watches(client)
+
+    # Clear flask alerts
+    res = client.get( url_for("watchlist.index"))
+    res = client.get( url_for("watchlist.index"))
+
 def xtest_import_skip_url(client, live_server, measure_memory_usage, datastore_path):
 
 


### PR DESCRIPTION
### Root cause

`import_url_list.run()` separates each import line into URL and tags by splitting on the first space:

```python
if ' ' in url:
    url, tags = url.split(" ", 1)
```

A jinja2 block in a watch URL can legitimately contain spaces, so the split cuts the block in half. Importing

```
https://example.com/?date={% now 'utc', '%d' %} tag-a
```

produces `url="https://example.com/?date={%"` and `tags="now 'utc', '%d' %} tag-a"`.

The truncated URL is then rejected downstream: `add_watch()` calls `is_safe_valid_url()`, which jinja2-renders any URL containing `{%`, and `?date={%` is a template syntax error. So `add_watch()` returns `None` and the line is counted as skipped rather than imported. Jinja2 in a watch URL is a supported feature (`is_safe_valid_url()` renders it deliberately, and the quick-add form has `test_jinja2_time_offset_in_url_query` for it), so the same URL is accepted when added through the form and mangled when imported.

### The invariant

Whitespace inside a jinja2 block is part of the URL. Only whitespace outside `{% %}` / `{{ }}` can separate the URL from its tags.

### The fix

`split_url_and_tags()` masks the jinja2 blocks (keeping the length, so offsets still map back to the line) and splits on the first space outside them. Lines without a jinja2 block take exactly the previous path.

I kept this to the jinja2 case only. A URL with a literal, un-encoded space (#1568) stays ambiguous, since the import format uses a space as the URL/tag separator, and disambiguating that is a separate decision.

### How I verified it

All of this ran in the `test-changedetectionio` container built from this repo's Dockerfile at 5eb2638 (I had to strip the BuildKit cache mounts, no buildx on my box, dependencies are otherwise unchanged):

- **Fails on master, passes here.** The new test `test_import_url_with_jinja2_whitespace` fails on unmodified master (`Imported 0 new UUIDs`, the watch is skipped) and passes with the fix.
- **`pytest tests/test_import.py`: 7 passed**, so the existing space-separated tag tests (`https://example.com tag1, other tag`) still behave the same.
- **`pytest tests/unit/`: passed.**
- **CI's lint gate** (`ruff check . --select E9,F63,F7,F82,INT`, per `test-only.yml`): passes.

What I did **not** verify: `tests/test_jinja2.py` has 2 failures (`test_jinja2_in_url_query`, `test_jinja2_time_offset_in_url_query`) in my environment, but they fail identically on unmodified master with the same 500 from the preview page, so they are pre-existing here and unrelated to the importer. I did not run the playwright/selenium legs of the CI matrix, which this change does not touch.

I did not run `pre-commit` as a whole: its `ruff --fix` / `ruff-format` hooks reformat these two files wholesale (import reordering, `class Importer():` to `class Importer:`, and so on) and they do the same to unmodified master, so I matched the existing file style and checked the lint that CI actually gates on instead. Happy to run the formatter over the files if you would rather have that.

This was written with AI assistance. The root cause, the fix, and every result above are mine and were reproduced and run as described.

Fixes #1516
