### PR TITLE
Restock detection - fix inverted condition that skipped the OpenGraph availability fallback

### DIFF
--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -369,7 +369,7 @@ def get_itemprop_availability(html_content) -> Restock:
                                            value.get('availability').strip(' "\'').lower()) if value.get('availability') else None
 
         # Second, go dig OpenGraph which is something that jsonpath_ng cant do because of the tuples and double-dots (:)
-        if not value.get('price') or value.get('availability'):
+        if not value.get('price') or not value.get('availability') or not value.get('currency'):
             logger.debug("Alternatively digging through OpenGraph properties for restock/price info..")
             jsonpath_expr = parse('$..properties')
 

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -364,10 +364,6 @@ def get_itemprop_availability(html_content) -> Restock:
         if availability_result:
             value['availability'] = availability_result[0].value
 
-        if value.get('availability'):
-            value['availability'] = re.sub(r'(?i)^(https|http)://schema.org/', '',
-                                           value.get('availability').strip(' "\'').lower()) if value.get('availability') else None
-
         # Second, go dig OpenGraph which is something that jsonpath_ng cant do because of the tuples and double-dots (:)
         if not value.get('price') or not value.get('availability') or not value.get('currency'):
             logger.debug("Alternatively digging through OpenGraph properties for restock/price info..")
@@ -380,6 +376,14 @@ def get_itemprop_availability(html_content) -> Restock:
                     value['availability'] = _search_prop_by_value([match.value], "product:availability")
                 if not value.get('currency'):
                     value['currency'] = _search_prop_by_value([match.value], "price:currency")
+
+        # Normalise after both sources have been tried, otherwise an availability that came from
+        # OpenGraph stays raw. The OpenGraph vocabulary spells it "in stock" while the in-stock
+        # matcher looks for "instock", so the spaces have to go too.
+        if value.get('availability'):
+            value['availability'] = re.sub(r'(?i)^(https|http)://schema.org/', '',
+                                           value.get('availability').strip(' "\'').lower())
+            value['availability'] = re.sub(r'\s+', '', value['availability'])
     logger.trace(f"Processed with Extruct in {time.time()-now:.3f}s")
 
     return value

--- a/changedetectionio/tests/unit/test_restock_logic.py
+++ b/changedetectionio/tests/unit/test_restock_logic.py
@@ -17,5 +17,28 @@ class TestDiffBuilder(unittest.TestCase):
         assert restock_diff.is_between(number=10, lower=None, upper=11) == True, "Between None and 11"
         assert not restock_diff.is_between(number=12, lower=None, upper=11) == True, "12 is not between None and 11"
 
+    def test_itemprop_availability_opengraph_fallback(self):
+        """Availability/currency missing from JSON-LD should be filled from OpenGraph
+        (Facebook commerce 'product:availability' / 'product:price:currency' meta tags)."""
+        html_content = """<!DOCTYPE html>
+        <html prefix="og: https://ogp.me/ns# product: https://ogp.me/ns/product#">
+        <head>
+        <meta property="og:type" content="product">
+        <meta property="og:title" content="Some Product">
+        <meta property="product:availability" content="in stock">
+        <meta property="product:price:currency" content="EUR">
+        <script type="application/ld+json">
+        {"@context": "https://schema.org", "@type": "Product", "name": "Some Product",
+         "offers": {"@type": "Offer", "price": "155.55"}}
+        </script>
+        </head>
+        <body><h1>Some Product</h1></body>
+        </html>"""
+
+        value = restock_diff.get_itemprop_availability(html_content)
+        assert value.get('price') == 155.55, "price should be found via JSON-LD"
+        assert value.get('availability') == 'in stock', "availability should be found via OpenGraph fallback"
+        assert value.get('currency') == 'EUR', "currency should be found via OpenGraph fallback"
+
 if __name__ == '__main__':
     unittest.main()

--- a/changedetectionio/tests/unit/test_restock_logic.py
+++ b/changedetectionio/tests/unit/test_restock_logic.py
@@ -37,8 +37,12 @@ class TestDiffBuilder(unittest.TestCase):
 
         value = restock_diff.get_itemprop_availability(html_content)
         assert value.get('price') == 155.55, "price should be found via JSON-LD"
-        assert value.get('availability') == 'in stock', "availability should be found via OpenGraph fallback"
         assert value.get('currency') == 'EUR', "currency should be found via OpenGraph fallback"
+        # Normalised the same way a schema.org value is, so that the in-stock matcher
+        # (which looks for 'instock') sees it. OpenGraph spells it 'in stock'.
+        assert value.get('availability') == 'instock', "availability should be found via OpenGraph fallback and normalised"
+        assert any(s in value.get('availability') for s in ['instock', 'instoreonly']), \
+            "a product advertised as available must read as in stock, not out of stock"
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`get_itemprop_availability()` was only digging through OpenGraph properties when a price was missing **or when availability was already found** - the condition `if not value.get('price') or value.get('availability'):` is inverted on the second term. So on product pages that expose price via JSON-LD but stock state only via the standard OpenGraph commerce tags (`<meta property="product:availability" content="in stock">`), availability (and currency) was silently dropped, and the restock processor fell back to having no stock metadata at all.

The inner loop already guards each field with `if not value.get(...)`, so this changes the outer gate to match that intent: dig OpenGraph when any of price / availability / currency is still missing. (Keeping the currency term preserves the existing behaviour where currency is filled from OpenGraph when JSON-LD lacks it.)

Includes a regression test in `tests/unit/test_restock_logic.py` - fails with `availability = None` before the fix, passes after.

Disclosure: this fix was prepared with AI assistance (Claude); it was empirically verified with a standalone reproduction and the repo's unit tests.
