### PR TITLE
Show regex-tagged watches under their group tab

### DIFF
--- a/changedetectionio/blueprint/ui/__init__.py
+++ b/changedetectionio/blueprint/ui/__init__.py
@@ -243,7 +243,7 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, worker_pool, 
             marked_count = 0
             try:
                 for watch_uuid, watch in datastore.data['watching'].items():
-                    if not wl_filters.watch_matches_filters(watch, list_filters):
+                    if not wl_filters.watch_matches_filters(datastore, watch, list_filters):
                         continue
 
                     datastore.set_last_viewed(watch_uuid, now)
@@ -322,7 +322,7 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, worker_pool, 
             for k in sorted(datastore.data['watching'].items(), key=lambda item: item[1].get('last_checked', 0)):
                 watch_uuid = k[0]
                 watch = k[1]
-                if not watch['paused'] and watch_uuid and wl_filters.watch_matches_filters(watch, list_filters):
+                if not watch['paused'] and watch_uuid and wl_filters.watch_matches_filters(datastore, watch, list_filters):
                     watches_to_queue.append(watch_uuid)
 
             # If less than 20 watches, queue synchronously for immediate feedback

--- a/changedetectionio/blueprint/watchlist/__init__.py
+++ b/changedetectionio/blueprint/watchlist/__init__.py
@@ -61,7 +61,7 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
             # The processor facet is counted over the tag/search base (ignoring the
             # selected processor) so every detected processor shows up and you can
             # switch between them.
-            if not wl_filters.watch_matches_tag(watch, list_filters):
+            if not wl_filters.watch_matches_tag(datastore, watch, list_filters):
                 continue
             if not wl_filters.watch_passes_search(watch, list_filters):
                 continue

--- a/changedetectionio/blueprint/watchlist/filters.py
+++ b/changedetectionio/blueprint/watchlist/filters.py
@@ -45,13 +45,16 @@ def watch_is_deal(watch):
     return pct is not None and pct < 0
 
 
-def watch_matches_tag(watch, f):
-    return not f['tag_uuid'] or f['tag_uuid'] in watch['tags']
+def watch_matches_tag(datastore, watch, f):
+    # Membership includes tags auto-applied via a Tag's url_match_pattern, not just
+    # watch['tags'] (manually-assigned) — otherwise a regex-matched watch shows its
+    # tag badge on the row but silently drops out of that tag's filtered/tab view.
+    return not f['tag_uuid'] or f['tag_uuid'] in datastore.get_all_tags_for_watch(watch['uuid'])
 
 
-def watch_in_context(watch, f):
+def watch_in_context(datastore, watch, f):
     """Tag + processor — the working set the operator is looking at."""
-    if not watch_matches_tag(watch, f):
+    if not watch_matches_tag(datastore, watch, f):
         return False
     if f['processor'] and watch.get('processor') != f['processor']:
         return False
@@ -80,15 +83,15 @@ def watch_passes_search(watch, f):
     return False
 
 
-def watch_matches_filters(watch, f):
+def watch_matches_filters(datastore, watch, f):
     """The full filter the watch list applies: context + status + search."""
-    return watch_in_context(watch, f) and watch_passes_status(watch, f) and watch_passes_search(watch, f)
+    return watch_in_context(datastore, watch, f) and watch_passes_status(watch, f) and watch_passes_search(watch, f)
 
 
 def matching_watch_uuids(datastore, args):
     """UUIDs of every watch matching the watch-list filters in `args` (no pagination)."""
     f = list_filters_from_args(datastore, args)
-    return [uuid for uuid, watch in datastore.data['watching'].items() if watch_matches_filters(watch, f)]
+    return [uuid for uuid, watch in datastore.data['watching'].items() if watch_matches_filters(datastore, watch, f)]
 
 
 # The query-string keys that define a watch-list view.

--- a/changedetectionio/tests/test_tag_url_match.py
+++ b/changedetectionio/tests/test_tag_url_match.py
@@ -142,3 +142,47 @@ def test_multiple_pattern_tags_all_applied(client, live_server, measure_memory_u
     assert tag_docs_uuid in resolved, "First matching tag must be included"
     assert tag_python_uuid in resolved, "Second matching tag must be included"
     assert tag_rust_uuid not in resolved, "Non-matching tag must NOT be included"
+
+
+def test_tag_url_pattern_watch_appears_under_tag_tab_filter(client, live_server, measure_memory_usage, datastore_path):
+    """A watch that only received its tag via url_match_pattern (no manual tag assignment)
+    must still appear when the watch list is filtered to that tag, same as a manually-tagged watch."""
+    set_original_response(datastore_path=datastore_path)
+
+    api_key = live_server.app.config['DATASTORE'].data['settings']['application'].get('api_access_token')
+
+    # Auto-match tag
+    res = client.post(
+        url_for("tag"),
+        data=json.dumps({"title": "Auto Gitlab", "url_match_pattern": "*gitlab.com*"}),
+        headers={'content-type': 'application/json', 'x-api-key': api_key},
+    )
+    assert res.status_code == 201, res.data
+
+    # Watch that matches the pattern, tagged only via regex (no manual "tags")
+    res = client.post(
+        url_for("createwatch"),
+        data=json.dumps({"url": "https://gitlab.com/someuser/repo"}),
+        headers={'content-type': 'application/json', 'x-api-key': api_key},
+    )
+    assert res.status_code == 201, res.data
+    auto_tagged_watch_uuid = res.json['uuid']
+
+    # Watch that does not match, must not show up under the tag's filtered view
+    res = client.post(
+        url_for("createwatch"),
+        data=json.dumps({"url": "https://example.com/page"}),
+        headers={'content-type': 'application/json', 'x-api-key': api_key},
+    )
+    assert res.status_code == 201, res.data
+    non_matching_watch_uuid = res.json['uuid']
+
+    # Filter the watch list by the tag's title, same as clicking its tab
+    res = client.get(url_for("watchlist.index", tag="Auto Gitlab"))
+    assert res.status_code == 200
+    html = res.get_data(as_text=True)
+
+    assert auto_tagged_watch_uuid in html, \
+        "Watch auto-tagged via url_match_pattern must appear when filtering by that tag's tab"
+    assert non_matching_watch_uuid not in html, \
+        "Non-matching watch must not appear when filtering by the tag's tab"


### PR DESCRIPTION
Resolves #4193

Watches can get a group (tag) two ways: manually via the watch edit form, or automatically when a group's `url_match_pattern` regex matches the watch URL. Clicking a group's tab in the main UI filters the watch list by tag, but only manually-assigned watches showed up. Regex-matched watches would display the tag badge on their row but vanish when you clicked that tag's tab.

Root cause: `watch_matches_tag()` in `changedetectionio/blueprint/watchlist/filters.py` checked membership against the raw, persisted `watch['tags']` list. Manual assignment writes into that list. Regex auto-matching does not, it's computed on the fly by `datastore.get_all_tags_for_watch()` and was only ever consumed by the tag badge template, never by the tab filter.

Fix threads `datastore` through the filter chain (`watch_matches_tag`, `watch_in_context`, `watch_matches_filters`, and their call sites in the `watchlist` and `ui` blueprints) so the tab filter and bulk actions check the same effective tag set the badge already uses, instead of the raw list.

Added a regression test in `changedetectionio/tests/test_tag_url_match.py` covering a watch tagged only via regex showing up under that tag's filtered view.

## Test plan

- [x] `pytest changedetectionio/tests/test_tag_url_match.py`, all pass including the new test
- [x] `pytest changedetectionio/tests/test_api.py`, no regressions from this change