### PR TITLE
fix: repoint dead changedetection.io/plugins link to the live plugin README

### DIFF
--- a/changedetectionio/blueprint/watchlist/templates/watch-overview.html
+++ b/changedetectionio/blueprint/watchlist/templates/watch-overview.html
@@ -1,7 +1,7 @@
 {%- extends 'base.html' -%}
 {%- block content -%}
 {%- set tips = [
-    _("Changedetection.io can monitor more than just web-pages! See our plugins!") ~ ' <a href="https://changedetection.io/plugins">' ~ _('More info') ~ '</a>',
+    _("Changedetection.io can monitor more than just web-pages! See our plugins!") ~ ' <a href="https://github.com/dgtlmoon/changedetection.io/blob/master/changedetectionio/PLUGIN_README.md">' ~ _('More info') ~ '</a>',
     _("You can also add 'shared' watches.") ~ ' <a href="https://github.com/dgtlmoon/changedetection.io/wiki/Sharing-a-Watch">' ~ _('More info') ~ '</a>'
 ] -%}
 {%- from '_helpers.html' import render_simple_field, render_field, render_nolabel_field, sort_by_title -%}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   #        Log output levels: TRACE, DEBUG(default), INFO, SUCCESS, WARNING, ERROR, CRITICAL
   #      - LOGGER_LEVEL=TRACE
   #
-  #        Plugins! See https://changedetection.io/plugins for more plugins.
+  #        Plugins! See https://github.com/dgtlmoon/changedetection.io/blob/master/changedetectionio/PLUGIN_README.md for more plugins.
   #        Install additional Python packages (processor plugins, etc.)
   #        Example: Install the OSINT reconnaissance processor plugin
   #      - EXTRA_PACKAGES=changedetection.io-osint-processor


### PR DESCRIPTION
`https://changedetection.io/plugins` returns 404. The link is hardcoded in two places: the "See our plugins!" tip on the watchlist page, and a comment in `docker-compose.yml`.

Repoints both at `changedetectionio/PLUGIN_README.md`, which documents the same plugin system and is live in this repo. No wiki page for plugins exists either (`wiki/Plugins` redirects to the wiki root), so the in-repo doc is the closest live target.

Verified: `curl -I https://changedetection.io/plugins` returns 404; `curl -I` on the PLUGIN_README.md blob URL returns 200. Confirmed no other reference to the dead link remains (`grep -rn "changedetection.io/plugins" .`). Neither changed line touches a translated string, so the translation catalog is unaffected. Ran this repo's `ruff check . --select E9,F63,F7,F82,INT` and the `lint-template-i18n` fragmented-gettext check locally; both pass unchanged (44 fragments, same as the baseline).

Fixes #4006
