### PR TITLE
Move development tools out of runtime requirements

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -33,7 +33,7 @@ jobs:
           done
       - name: Lint .pot template with dennis
         run: |
-          pip install "$(grep -E '^dennis ?>=' requirements.txt)"
+          pip install "$(grep -E '^dennis ?>=' requirements-dev.txt)"
           dennis-cmd lint --strict changedetectionio/translations/messages.pot
       - name: Lint .po files with dennis
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ I am no professional flask developer, if you know a better way that something ca
 
 Otherwise, it's always best to PR into the `master` branch.
 
+Install the development and test dependencies with `pip install -r requirements-dev.txt`.
+
 Please be sure that all new functionality has a matching test!
 
 Use `pytest` to validate/test, you can run the existing tests as `pytest tests/test_notification.py` for example

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+ruff >= 0.11.2
+pre_commit >= 4.2.0
+dennis >= 1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,12 +157,7 @@ rank-bm25>=0.2.2
 # Needed for testing, cross-platform for process and system monitoring
 psutil==7.2.2
 
-ruff >= 0.11.2
-pre_commit >= 4.2.0
-dennis >= 1.3.0
-
 # For events between checking and socketio updates
 blinker
 pytest-xdist
-
 


### PR DESCRIPTION
## Summary

- move Ruff, pre-commit, and Dennis out of production requirements
- add a development requirements file that includes runtime dependencies
- keep the translation lint workflow reading the shared Dennis constraint
- document the contributor install command

## Testing

- generated package metadata with `python setup.py egg_info`
- confirmed production metadata excludes `ruff`, `pre_commit`, and `dennis`
- confirmed all three constraints are present in `requirements-dev.txt`
- `git diff --check`

Fixes #4109.
