### PR TITLE
fix: Visual Selector renders scraped selectors as text, not markup

### DIFF
--- a/changedetectionio/content_fetchers/res/xpath_element_scraper.js
+++ b/changedetectionio/content_fetchers/res/xpath_element_scraper.js
@@ -13,7 +13,10 @@ async (options) => {
 // Include the getXpath script directly, easier than fetching
     function getxpath(e) {
         var n = e;
-        if (n && n.id) return '//*[@id="' + n.id + '"]';
+        // A double quote cannot be expressed inside a double-quoted xpath literal, and an angle
+        // bracket would carry page markup into whatever displays the selector later, so for those
+        // ids build the positional path below instead of an unusable '//*[@id="..."]'.
+        if (n && n.id && !/["<>]/.test(n.id)) return '//*[@id="' + n.id + '"]';
         for (var o = []; n && Node.ELEMENT_NODE === n.nodeType;) {
             for (var i = 0, r = !1, d = n.previousSibling; d;) d.nodeType !== Node.DOCUMENT_TYPE_NODE && d.nodeName === n.nodeName && i++, d = d.previousSibling;
             for (d = n.nextSibling; d;) {

--- a/changedetectionio/static/js/visual-selector.js
+++ b/changedetectionio/static/js/visual-selector.js
@@ -253,7 +253,8 @@ window.initVisualSelector = function (opts) {
     }
 
     function setCurrentSelectedText(s) {
-        $selectorCurrentXpathElem[0].innerHTML = s;
+        // Selectors come from the scraped page, display them as text and never as markup
+        $selectorCurrentXpathElem[0].textContent = s;
     }
 
     function drawHighlight(sel) {

--- a/changedetectionio/tests/visualselector/test_fetch_data.py
+++ b/changedetectionio/tests/visualselector/test_fetch_data.py
@@ -255,3 +255,65 @@ def test_browsersteps_edit_UI_startsession(client, live_server, measure_memory_u
         url_for("ui.form_delete", uuid="all"),
         follow_redirects=True
     )
+
+def test_visual_selector_xpath_carries_no_page_markup(client, live_server, measure_memory_usage, datastore_path):
+    # The scraped element id ends up in the selector that the Visual Selector displays, so it must
+    # not be able to carry markup from the watched page into it.
+    import json
+    import zlib
+
+    assert os.getenv('PLAYWRIGHT_DRIVER_URL'), "Needs PLAYWRIGHT_DRIVER_URL set for this test"
+
+    # The same id on two elements, findUpTag() only returns a selector when the id is unique on the
+    # page, so this is what reaches the fallback xpath builder
+    duplicate_id = 'dupe"><img src=x onerror=console.log(1)>'
+    page_content = f"""<html><body>
+    <div id='{duplicate_id}' style="width:400px;height:300px">first</div>
+    <div id='{duplicate_id}' style="width:400px;height:300px">second</div>
+    <p id="unique" style="width:400px;height:60px">unique id, stays on the id shortcut</p>
+    </body></html>"""
+
+    test_url = url_for('test_endpoint', content=page_content, _external=True)
+    test_url = test_url.replace('localhost.localdomain', 'cdio')
+    test_url = test_url.replace('localhost', 'cdio')
+
+    res = client.post(
+        url_for("ui.ui_views.form_quick_watch_add"),
+        data={"url": test_url, "tags": '', 'edit_and_watch_submit_button': 'Edit > Watch'},
+        follow_redirects=True
+    )
+    assert b"Watch added in Paused state, saving will unpause" in res.data
+
+    uuid = next(iter(live_server.app.config['DATASTORE'].data['watching']))
+    res = client.post(
+        url_for("ui.ui_edit.edit_page", uuid=uuid, unpause_on_save=1),
+        data={
+            "url": test_url,
+            "tags": "",
+            'fetch_backend': "html_webdriver",
+            "time_between_check_use_default": "y",
+        },
+        follow_redirects=True
+    )
+    assert b"unpaused" in res.data
+    wait_for_all_checks(client)
+
+    with open(os.path.join(datastore_path, uuid, 'elements.deflate'), 'rb') as f:
+        xpath_data = json.loads(zlib.decompress(f.read()).decode('utf-8'))
+
+    xpaths = [str(sel.get('xpath')) for sel in xpath_data['size_pos']]
+    assert xpaths, "Elements were scraped"
+
+    for xpath in xpaths:
+        assert '<' not in xpath, f"No markup from the page in the selector: {xpath}"
+        assert '>' not in xpath, f"No markup from the page in the selector: {xpath}"
+
+    # The two divs are still scraped, just addressed by their position instead
+    assert any(x.startswith('/html/body/div') for x in xpaths), f"Duplicate-id elements still have a selector: {xpaths}"
+    # A well behaved id is untouched
+    assert '#unique' in xpaths, f"Unique id still uses the id selector: {xpaths}"
+
+    client.get(
+        url_for("ui.form_delete", uuid="all"),
+        follow_redirects=True
+    )


### PR DESCRIPTION
### What

The Visual Selector displays the selector of the element under the mouse, and `static/js/visual-selector.js:256` assigned that string with `innerHTML`. The string can contain markup from the scraped page, because `content_fetchers/res/xpath_element_scraper.js:16` builds it as `'//*[@id="' + n.id + '"]'` from the page's raw `id` attribute. An `id` such as `dupe"><img src=x onerror=...>` therefore becomes real DOM nodes in the edit page instead of being shown as the selector it is.

### Why

Two gates are missing on the way to that display. `findUpTag()` runs `CSS.escape()` on the id, but it returns `null` when the id is not unique on the page (`xpath_element_scraper.js:62`, `:65`), and the caller then falls back to `getxpath()` (`:151-160`), which interpolates the id verbatim. That is also the only branch that can emit an invalid selector: a double quote cannot be expressed inside a double-quoted xpath literal, so the resulting `//*[@id="a"b"]` never matches anything either way. At the display end, sibling code in this repo routes untrusted strings through `.text()` rather than `innerHTML`, for example `static/js/watch-overview.js:454` (`$('<span>').text(line).html()`) and `static/js/realtime.js:217` (`.html("&nbsp;").text(data.status)`).

### How

`xpath_element_scraper.js` takes the `//*[@id="..."]` shortcut only for ids without `"`, `<` or `>` and builds the positional path (`/html/body/div[1]`) for the rest, so those elements stay selectable and are addressed by position instead. `visual-selector.js` sets `textContent` on the selector display, which also covers element data already stored in `elements.deflate` from earlier versions.

Left unchanged on purpose: the stored `elements.deflate` payload and the `visual_selector_data` endpoint (the display-end fix covers files written by earlier versions), the `include_filters` branch at `xpath_element_scraper.js:203` (operator input, not page content), and `browser-steps.js`, which puts the same selectors into input values with `.val()`.

### Testing

Added `test_visual_selector_xpath_carries_no_page_markup` to `tests/visualselector/test_fetch_data.py`, the file the playwright and pyppeteer CI jobs already run. It serves a page with the same id on two elements, fetches it with `html_webdriver`, and asserts the stored selectors carry no markup while both divs keep a selector and a unique id still uses the `#id` form. On the unpatched tree it fails with `//*[@id="dupe"><img src=x onerror=console.log(1)>"]`; with the change the file passes 5/5 against a `sockpuppetbrowser` container.

Also checked by hand against a running instance watching such a page: the stored selectors become `/html/body/div[1]` and `/html/body/div[2]`, hovering shows the selector as literal text with no child elements, and `#unique-benign` and `/html/body/h1` display as before. `tests/test_security.py` passes 17/17.

`ruff check` on the touched test file reports the same 6 pre-existing findings as on `master`, no new ones. The full suite was not run, only those two test files.

### References

GHSA-8m69-92q9-qcxx (reported privately, unpublished at time of writing)