### PR TITLE
Fix: Gemini 3.x lite models get 400 INVALID_ARGUMENT on every LLM call

### DIFF
--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -6,6 +6,7 @@ and makes the call easy to mock in tests.
 
 import logging
 import os
+import re
 from loguru import logger
 
 # Default output token cap for JSON-returning calls (intent eval, preview, setup).
@@ -25,6 +26,25 @@ DEFAULT_TIMEOUT = int(os.getenv('LLM_TIMEOUT', 300))
 # evaluator.resolve_llm_timeout() for how the endpoint is classified.
 DEFAULT_LOCAL_TIMEOUT = int(os.getenv('LLM_LOCAL_TIMEOUT', 1800))
 DEFAULT_RETRIES = 3
+
+# Matches "gemini-3" with or without a provider prefix (gemini/gemini-3.5-flash-lite,
+# vertex_ai/gemini-3-pro-preview, plain "gemini-3-pro-preview", ...).
+_GEMINI_3_RE = re.compile(r'gemini-3', re.IGNORECASE)
+
+
+def is_gemini_3_family(model: str) -> bool:
+    """True for any Gemini 3.x model.
+
+    Google's Gemini 3.x migration deprecates the `temperature`/`top_p`/`top_k`
+    sampling params and replaces `thinkingConfig.thinkingBudget` with a new
+    `thinking_level` control. Sending the old params gets a bare 400
+    INVALID_ARGUMENT with no `details` field — litellm's model registry lags
+    brand-new releases, so we can't rely on it (or on drop_params) to catch this
+    before the request goes out. Gated on the model name directly so the very
+    first request avoids the error, rather than depending on the retry path
+    below to clean it up after the fact.
+    """
+    return bool(model) and bool(_GEMINI_3_RE.search(model))
 
 
 class _LoguruInterceptHandler(logging.Handler):
@@ -90,9 +110,12 @@ def completion(model: str, messages: list, api_key: str = None,
         'model': model,
         'messages': messages,
         'timeout': _timeout,
-        'temperature': 0,
         'max_tokens': max_tokens if max_tokens is not None else _MAX_COMPLETION_TOKENS,
     }
+    if not is_gemini_3_family(model):
+        # Gemini 3.x rejects 'temperature' outright (see is_gemini_3_family) —
+        # every other provider we support accepts temperature=0 fine.
+        kwargs['temperature'] = 0
     if api_key:
         kwargs['api_key'] = api_key
     if api_base:
@@ -181,21 +204,39 @@ def completion(model: str, messages: list, api_key: str = None,
             raise
 
         except litellm.BadRequestError as e:
-            # If the provider rejected an unsupported sampling param (and we haven't
-            # already stripped them), drop them and retry once. attempt-=1 keeps this
-            # off the timeout-retry budget; _stripped_sampling prevents a loop.
-            msg = str(e).lower()
-            if (not _stripped_sampling
-                    and any(p in kwargs for p in _sampling_params)
-                    and any(p in msg for p in _sampling_params)):
+            # If the provider rejected an unsupported sampling param or reasoning
+            # payload, drop it and retry once. We used to only do this when the
+            # error message *named* the offending field, but not every provider
+            # does that — Google's Gemini 3.x 400 INVALID_ARGUMENT responses
+            # carry no 'details' field and never mention 'temperature' or
+            # 'thinkingConfig' by name. So instead we unconditionally strip
+            # anything we ourselves added on top of the caller's messages
+            # (sampling params, Gemini's generationConfig.thinkingConfig) the
+            # first time a BadRequestError is seen, then retry once.
+            # attempt-=1 keeps this off the timeout-retry budget;
+            # _stripped_sampling prevents looping. If there's nothing of ours
+            # left to strip, `dropped` stays empty and the original error is
+            # raised immediately — this can't mask an unrelated 400 (bad key,
+            # bad model name, oversized input, ...) beyond one wasted retry.
+            if not _stripped_sampling:
                 dropped = [p for p in _sampling_params if kwargs.pop(p, None) is not None]
-                _stripped_sampling = True
-                attempt -= 1
-                logger.warning(
-                    f"LLM client: model={model!r} rejected sampling params {dropped} "
-                    f"({e}); retrying without them"
-                )
-                continue
+                extra_body = kwargs.get('extra_body')
+                if isinstance(extra_body, dict):
+                    gen_cfg = extra_body.get('generationConfig')
+                    if isinstance(gen_cfg, dict) and gen_cfg.pop('thinkingConfig', None) is not None:
+                        dropped.append('thinkingConfig')
+                        if not gen_cfg:
+                            extra_body.pop('generationConfig', None)
+                        if not extra_body:
+                            kwargs.pop('extra_body', None)
+                if dropped:
+                    _stripped_sampling = True
+                    attempt -= 1
+                    logger.warning(
+                        f"LLM client: model={model!r} rejected request ({e}); "
+                        f"stripped {dropped} and retrying once"
+                    )
+                    continue
             logger.warning(f"LLM call failed: model={model!r} error={e}")
             raise
 

--- a/changedetectionio/llm/evaluator.py
+++ b/changedetectionio/llm/evaluator.py
@@ -94,8 +94,16 @@ def _thinking_extra_body(model: str, budget: int) -> dict | None:
     "does this model think?" decision. That picks up new Gemini variants and
     rolling aliases (`gemini-flash-latest`, etc.) as litellm's registry tracks
     them, without us hardcoding model names here.
+
+    Gemini 3.x is a special case: it deprecated `thinkingConfig.thinkingBudget`
+    in favour of a new `thinking_level` control and rejects the old shape with a
+    bare 400 INVALID_ARGUMENT. There's no safe numeric-budget → level mapping to
+    fall back to, so rather than guess we send no thinking config at all and let
+    the model use its own default (see llm_client.is_gemini_3_family).
     """
     if not model.startswith('gemini/'):
+        return None
+    if llm_client.is_gemini_3_family(model):
         return None
     try:
         import litellm
@@ -792,13 +800,14 @@ def evaluate_change(watch, datastore, diff: str, current_snapshot: str = '') -> 
             f"LLM evaluate_change skipped for {watch.get('uuid')}: monthly budget {budget:,} reached "
             f"({used:,} used this month) — passing change through as important"
         )
-        # Fail open: don't suppress notifications when budget is exhausted
-        return {'important': True, 'summary': ''}
+        # Fail open: don't suppress notifications when budget is exhausted.
+        # Not an 'llm_error' — this is a deliberate, expected skip, not a failed call.
+        return {'important': True, 'summary': '', 'llm_error': False, 'llm_skipped': 'budget_exceeded'}
 
     # Check per-watch cumulative budget before making the call
     if not _check_token_budget(watch, cfg):
         # Already over budget — fail open (don't suppress notification)
-        return {'important': True, 'summary': ''}
+        return {'important': True, 'summary': '', 'llm_error': False, 'llm_skipped': 'budget_exceeded'}
 
     url = watch.get('url', '')
     title = watch.get('page_title') or watch.get('title') or ''
@@ -833,9 +842,14 @@ def evaluate_change(watch, datastore, diff: str, current_snapshot: str = '') -> 
         result = parse_eval_response(raw)
     except Exception as e:
         logger.warning(f"LLM evaluation failed for {watch.get('uuid')}: {e}")
-        # On failure: don't suppress the notification — pass through as important
+        # On failure: don't suppress the notification — pass through as important.
+        # 'llm_error' distinguishes this fail-open fallback from a genuine
+        # {'important': True, ...} verdict from the model — without it, a total
+        # LLM outage (wrong model name, provider-side breaking change, etc.) is
+        # silently indistinguishable from working intent-matching that simply
+        # found every change important.
         watch['llm_last_tokens_used'] = 0
-        return {'important': True, 'summary': ''}
+        return {'important': True, 'summary': '', 'llm_error': True}
 
     # Accumulate token usage: per-watch limit and global monthly budget
     _check_token_budget(watch, cfg, tokens)

--- a/changedetectionio/notification/handler.py
+++ b/changedetectionio/notification/handler.py
@@ -381,11 +381,17 @@ def process_notification(n_object: NotificationContextData, datastore):
     if _llm_change_summary and _override_diff:
         n_object['diff'] = _llm_change_summary
 
-    # Lazily populate llm_summary / llm_intent if used in notification template
+    # Lazily populate llm_summary / llm_intent / llm_error if used in notification template
     scan_text = n_object.get('notification_body', '') + n_object.get('notification_title', '')
-    if 'llm_summary' in scan_text or 'llm_intent' in scan_text or 'raw_diff' in scan_text:
+    if 'llm_summary' in scan_text or 'llm_intent' in scan_text or 'llm_error' in scan_text or 'raw_diff' in scan_text:
         n_object['llm_summary'] = _llm_change_summary or (n_object.get('_llm_result') or {}).get('summary', '')
         n_object['llm_intent'] = n_object.get('_llm_intent', '')
+        # True when the last AI Change Intent evaluation fell back to "important"
+        # because the LLM call itself failed (bad model/params, provider outage,
+        # auth error, ...) — not because the model genuinely judged the change
+        # important. Lets a template surface "AI check failed, notified anyway"
+        # instead of silently looking like a normal positive match.
+        n_object['llm_error'] = bool((n_object.get('_llm_result') or {}).get('llm_error'))
 
     # Escape diff/snapshot variables before Jinja renders them into an HTML notification.
     # GHSA-q8xq-qg4x-wphg: inscriptis decodes HTML entities when converting text/html

--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -236,6 +236,8 @@ class NotificationContextData(dict):
             'triggered_text': None,
             'llm_summary': None,     # AI plain-English summary of what changed (requires AI intent to be configured)
             'llm_intent': None,      # The intent that was evaluated (watch-level or inherited from tag)
+            'llm_error': False,      # True when AI Change Intent fell back to "important" because the LLM call itself failed
+
             'uuid': 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',  # Converted to 'watch_uuid' in create_notification_parameters
             'watch_mime_type': None,
             'watch_tag': None,

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -125,6 +125,10 @@
                 <td><code>{{ '{{llm_intent}}' }}</code></td>
                 <td>{{ _('The AI Change Intent that was evaluated.') }}</td>
             </tr>
+            <tr>
+                <td><code>{{ '{{llm_error}}' }}</code></td>
+                <td>{{ _('True when this notification fired because the AI Change Intent call itself failed (bad model/params, provider outage, etc.) rather than a genuine "important" verdict — use to avoid mistaking an AI outage for working filtering.') }}</td>
+            </tr>
             {% endif %}
                 {% if extra_notification_token_placeholder_info %}
                     {% for token in extra_notification_token_placeholder_info %}

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -127,7 +127,7 @@
             </tr>
             <tr>
                 <td><code>{{ '{{llm_error}}' }}</code></td>
-                <td>{{ _('True when this notification fired because the AI Change Intent call itself failed (bad model/params, provider outage, etc.) rather than a genuine "important" verdict — use to avoid mistaking an AI outage for working filtering.') }}</td>
+                <td>True when this notification fired because the AI Change Intent call itself failed, rather than a genuine "important" verdict.</td>
             </tr>
             {% endif %}
                 {% if extra_notification_token_placeholder_info %}

--- a/changedetectionio/tests/unit/test_llm_client.py
+++ b/changedetectionio/tests/unit/test_llm_client.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Unit tests for changedetectionio.llm.client:
+
+  * is_gemini_3_family() correctly identifies Gemini 3.x models with/without
+    a provider prefix, and doesn't false-positive on other Gemini generations.
+  * completion() omits 'temperature' for Gemini 3.x models (which reject it
+    outright) but still sends it for every other model.
+  * The BadRequestError strip-and-retry fallback fires even when the
+    provider's error message doesn't name the offending field (Google's
+    Gemini 3.x 400 INVALID_ARGUMENT responses carry no 'details' field), and
+    strips both sampling params (kwargs) and Gemini's
+    generationConfig.thinkingConfig (extra_body).
+  * The fallback only retries once — a second BadRequestError with nothing
+    left to strip propagates instead of looping.
+
+Run from the tests/ directory:
+    python -m unittest unit/test_llm_client.py
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from changedetectionio.llm import client as m
+
+
+def _mock_success_response(text='{"important": true, "summary": "ok"}'):
+    message = MagicMock()
+    message.content = text
+    message.parts = None
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = 'stop'
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return response
+
+
+class TestIsGemini3Family(unittest.TestCase):
+    def test_gemini_3_with_provider_prefix(self):
+        self.assertTrue(m.is_gemini_3_family('gemini/gemini-3.5-flash-lite'))
+        self.assertTrue(m.is_gemini_3_family('gemini/gemini-3-pro-preview'))
+
+    def test_gemini_3_without_provider_prefix(self):
+        self.assertTrue(m.is_gemini_3_family('gemini-3.5-flash-lite'))
+
+    def test_vertex_ai_prefix(self):
+        self.assertTrue(m.is_gemini_3_family('vertex_ai/gemini-3.5-flash-lite'))
+
+    def test_older_gemini_not_matched(self):
+        self.assertFalse(m.is_gemini_3_family('gemini/gemini-2.5-flash'))
+        self.assertFalse(m.is_gemini_3_family('gemini/gemini-1.5-pro'))
+
+    def test_non_gemini_model_not_matched(self):
+        self.assertFalse(m.is_gemini_3_family('gpt-4o-mini'))
+        self.assertFalse(m.is_gemini_3_family('claude-opus-4-8'))
+
+    def test_empty_or_none(self):
+        self.assertFalse(m.is_gemini_3_family(''))
+        self.assertFalse(m.is_gemini_3_family(None))
+
+
+class TestCompletionTemperatureHandling(unittest.TestCase):
+    """completion() must not send 'temperature' to Gemini 3.x models."""
+
+    def test_temperature_sent_for_non_gemini_3_model(self):
+        with patch('litellm.completion', return_value=_mock_success_response()) as mock_call:
+            m.completion(model='gemini/gemini-2.5-flash', messages=[{'role': 'user', 'content': 'hi'}])
+            self.assertIn('temperature', mock_call.call_args.kwargs)
+            self.assertEqual(mock_call.call_args.kwargs['temperature'], 0)
+
+    def test_temperature_omitted_for_gemini_3_model(self):
+        with patch('litellm.completion', return_value=_mock_success_response()) as mock_call:
+            m.completion(model='gemini/gemini-3.5-flash-lite', messages=[{'role': 'user', 'content': 'hi'}])
+            self.assertNotIn('temperature', mock_call.call_args.kwargs)
+
+
+class TestBadRequestStripAndRetry(unittest.TestCase):
+    """
+    Google's Gemini 3.x 400 INVALID_ARGUMENT responses don't name the
+    offending field, so the fallback must not depend on message-matching —
+    only on there being something of ours left to strip.
+    """
+
+    def _bad_request(self, msg='Request contains an invalid argument.'):
+        import litellm as real_litellm
+        return real_litellm.BadRequestError(msg, llm_provider='gemini', model='gemini/gemini-3.5-flash-lite')
+
+    def test_retries_and_succeeds_after_stripping_thinking_config(self):
+        exc = self._bad_request()
+        success = _mock_success_response()
+        with patch('litellm.completion', side_effect=[exc, success]) as mock_call:
+            text, tokens, *_ = m.completion(
+                model='gemini/gemini-3.5-flash-lite',
+                messages=[{'role': 'user', 'content': 'hi'}],
+                extra_body={'generationConfig': {'thinkingConfig': {'thinkingBudget': 0}}},
+            )
+        self.assertEqual(mock_call.call_count, 2)
+        # The second (retried) call must no longer carry thinkingConfig.
+        second_call_kwargs = mock_call.call_args_list[1].kwargs
+        self.assertNotIn('extra_body', second_call_kwargs)
+        self.assertIn('important', text)
+
+    def test_retries_and_strips_sampling_params_generic_message(self):
+        # No mention of 'temperature' anywhere in the message — this is what
+        # trips up the old message-matching implementation.
+        exc = self._bad_request(msg='Request contains an invalid argument.')
+        success = _mock_success_response()
+        with patch('litellm.completion', side_effect=[exc, success]) as mock_call:
+            m.completion(
+                model='gemini/gemini-2.5-flash',  # not gemini-3, so temperature is set by default
+                messages=[{'role': 'user', 'content': 'hi'}],
+            )
+        self.assertEqual(mock_call.call_count, 2)
+        first_call_kwargs = mock_call.call_args_list[0].kwargs
+        second_call_kwargs = mock_call.call_args_list[1].kwargs
+        self.assertIn('temperature', first_call_kwargs)
+        self.assertNotIn('temperature', second_call_kwargs)
+
+    def test_does_not_loop_when_nothing_left_to_strip(self):
+        # Two BadRequestErrors in a row, no sampling params / extra_body present
+        # at all — nothing to strip, so the second attempt is never made and the
+        # original error propagates rather than retrying forever.
+        exc = self._bad_request('some other, unrelated 400 error')
+        with patch('litellm.completion', side_effect=exc) as mock_call:
+            with self.assertRaises(type(exc)):
+                m.completion(
+                    model='gemini/gemini-3.5-flash-lite',  # temperature already omitted -> nothing to strip
+                    messages=[{'role': 'user', 'content': 'hi'}],
+                )
+        self.assertEqual(mock_call.call_count, 1)
+
+    def test_only_retries_once(self):
+        # If stripping doesn't fix it, the second BadRequestError (now with
+        # nothing left of ours to strip) must propagate, not retry again.
+        exc1 = self._bad_request()
+        exc2 = self._bad_request('still invalid')
+        with patch('litellm.completion', side_effect=[exc1, exc2]) as mock_call:
+            with self.assertRaises(type(exc2)):
+                m.completion(
+                    model='gemini/gemini-2.5-flash',
+                    messages=[{'role': 'user', 'content': 'hi'}],
+                    extra_body={'generationConfig': {'thinkingConfig': {'thinkingBudget': 0}}},
+                )
+        self.assertEqual(mock_call.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/changedetectionio/tests/unit/test_llm_evaluator_gemini3.py
+++ b/changedetectionio/tests/unit/test_llm_evaluator_gemini3.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Unit tests for changedetectionio.llm.evaluator:
+
+  * _thinking_extra_body() sends no generationConfig at all for Gemini 3.x
+    models (thinkingBudget is deprecated there and gets rejected outright),
+    while still sending it for older Gemini generations that support it.
+  * evaluate_change() marks its fail-open {'important': True, ...} fallback
+    with 'llm_error': True when the LLM call itself raised, so a genuine
+    outage (bad model/params, provider error, ...) is distinguishable from a
+    real positive verdict — see the bug report this fixes: a total LLM
+    outage against a Gemini 3.x lite model was silently indistinguishable
+    from working intent-matching.
+
+Run from the tests/ directory:
+    python -m unittest unit/test_llm_evaluator_gemini3.py
+"""
+import unittest
+from unittest.mock import patch
+
+from changedetectionio.llm import evaluator as m
+
+
+class FakeDatastore:
+    def __init__(self, llm_cfg=None):
+        self.data = {
+            'settings': {
+                'application': {
+                    'llm': llm_cfg or {'model': 'gemini/gemini-3.5-flash-lite', 'api_key': 'test-key'},
+                }
+            }
+        }
+        self.commit_calls = 0
+
+    def commit(self):
+        self.commit_calls += 1
+
+
+class TestThinkingExtraBodyGemini3(unittest.TestCase):
+    def test_gemini_3_lite_gets_no_thinking_config(self):
+        self.assertIsNone(m._thinking_extra_body('gemini/gemini-3.5-flash-lite', budget=0))
+
+    def test_gemini_3_pro_gets_no_thinking_config(self):
+        self.assertIsNone(m._thinking_extra_body('gemini/gemini-3-pro-preview', budget=1024))
+
+    def test_non_gemini_model_gets_no_thinking_config(self):
+        self.assertIsNone(m._thinking_extra_body('gpt-4o-mini', budget=1024))
+
+    @patch('litellm.get_model_info')
+    def test_older_gemini_that_supports_reasoning_still_gets_thinking_config(self, mock_info):
+        mock_info.return_value = {'supports_reasoning': True}
+        result = m._thinking_extra_body('gemini/gemini-2.5-flash', budget=512)
+        self.assertEqual(result, {'generationConfig': {'thinkingConfig': {'thinkingBudget': 512}}})
+
+    @patch('litellm.get_model_info')
+    def test_older_gemini_without_reasoning_support_gets_none(self, mock_info):
+        mock_info.return_value = {'supports_reasoning': False}
+        self.assertIsNone(m._thinking_extra_body('gemini/gemini-1.5-flash', budget=512))
+
+
+class TestEvaluateChangeLLMErrorMarker(unittest.TestCase):
+    """A failed LLM call must be distinguishable from a genuine 'important' verdict."""
+
+    def _watch(self, **overrides):
+        watch = {
+            'uuid': 'test-uuid',
+            'llm_intent': 'Notify only on price changes',
+            'tags': [],
+        }
+        watch.update(overrides)
+        return watch
+
+    def test_llm_call_failure_sets_llm_error_true(self):
+        ds = FakeDatastore()
+        watch = self._watch()
+        with patch('changedetectionio.llm.evaluator.llm_client.completion',
+                   side_effect=RuntimeError('simulated 400 INVALID_ARGUMENT')):
+            result = m.evaluate_change(watch, ds, diff='- old price\n+ new price')
+
+        self.assertEqual(result['important'], True)  # fail-open: notification still fires
+        self.assertEqual(result['llm_error'], True)   # ...but is flagged as not a real verdict
+
+    def test_successful_call_has_no_llm_error_flag(self):
+        ds = FakeDatastore()
+        watch = self._watch()
+        with patch('changedetectionio.llm.evaluator.llm_client.completion',
+                   return_value=('{"important": true, "summary": "price changed"}', 42, 30, 12)):
+            result = m.evaluate_change(watch, ds, diff='- old price\n+ new price')
+
+        self.assertEqual(result['important'], True)
+        self.assertNotIn('llm_error', result)
+
+    def test_budget_exceeded_fail_open_is_not_marked_as_error(self):
+        ds = FakeDatastore(llm_cfg={
+            'model': 'gemini/gemini-3.5-flash-lite',
+            'api_key': 'test-key',
+            'token_budget_month': 100,
+            'tokens_this_month': 1000,
+            'tokens_month_key': m._get_month_key(),
+        })
+        watch = self._watch()
+        result = m.evaluate_change(watch, ds, diff='- old price\n+ new price')
+
+        self.assertEqual(result['important'], True)
+        self.assertEqual(result.get('llm_error'), False)
+        self.assertEqual(result.get('llm_skipped'), 'budget_exceeded')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/changedetectionio/worker.py
+++ b/changedetectionio/worker.py
@@ -502,6 +502,16 @@ async def async_update_worker(worker_id, q, notification_q, app, datastore, exec
                                                 f"(intent from {_llm_intent_source}): "
                                                 f"{_llm_result.get('summary', '')[:80]}"
                                             )
+                                        elif _llm_result and _llm_result.get('llm_error'):
+                                            # The 'important: True' verdict above is a fail-open
+                                            # fallback, not a real match — call this out at the
+                                            # point notifications get sent, since it's otherwise
+                                            # indistinguishable from working intent-matching.
+                                            logger.warning(
+                                                f"LLM evaluation failed for {uuid} — notification "
+                                                f"will fire unfiltered (AI Change Intent is not "
+                                                f"actually being applied right now)"
+                                            )
 
                                     # Step 2: AI Change Summary — only compute it when a notification
                                     # is actually going to be sent, because that's the only place


### PR DESCRIPTION
Fixes #4283

## The problem

Gemini 3.x deprecated the `temperature` / `top_p` / `top_k` sampling params and replaced `thinkingConfig.thinkingBudget` with a new `thinking_level` control. changedetection.io sends both unconditionally, so **every** AI Change Summary / AI Change Intent call against a `gemini-3.x` model (e.g. `gemini/gemini-3.5-flash-lite`) fails outright.

<details>
<summary>Error output</summary>

​```
litellm.BadRequestError: GeminiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT"
  }
}
​```

</details>

Google's response carries no `details` field, so the message never names the rejected param — which is why the strip-and-retry fallback from #4241 doesn't catch it: it only retries when the error message *names* `temperature` / `top_p` / `top_k`.

It gets worse: `evaluate_change()` fails open on any exception, returning `{'important': True, 'summary': ''}`. Since `important: true` is also what a genuine positive match looks like, **a total LLM outage is silently indistinguishable from working intent-matching** — notifications keep firing, the LLM Usage tab just stays empty.

## What this fixes

### 1. Stop sending params Gemini 3.x rejects
- `llm/client.py` — new `is_gemini_3_family(model)` helper (name-based, since litellm's model registry lags brand-new releases). `completion()` no longer sends `temperature` for these models.
- `llm/evaluator.py` — `_thinking_extra_body()` sends no `thinkingConfig` at all for Gemini 3.x. There's no safe `thinking_budget` → `thinking_level` mapping to fall back to, so rather than guess, thinking is left at the model's own default.

### 2. Make the retry path actually catch this
- `llm/client.py` — the `BadRequestError` strip-and-retry no longer depends on the error message naming the field. It now unconditionally strips sampling params **and** `extra_body.generationConfig.thinkingConfig` on the first `BadRequestError` and retries once. If there's nothing left of ours to strip, it raises immediately — so this can't loop or mask an unrelated 400 beyond one wasted retry.

### 3. Stop hiding LLM outages behind a passing verdict
- `evaluate_change()` tags its fail-open fallback with `llm_error: True` on a genuine call failure, and `llm_error: False` on a deliberate budget-skip — so the two "not a real verdict" cases aren't confused with each other either.
- `worker.py` logs an explicit warning when a notification fires off an `llm_error` fallback.
- New `{{llm_error}}` notification token, documented in the Settings → Notifications token table, so operators can surface this in their own templates.

## Files changed

| File | Change |
|---|---|
| `llm/client.py` | `is_gemini_3_family()`, conditional `temperature`, message-independent strip-and-retry |
| `llm/evaluator.py` | `_thinking_extra_body()` skips Gemini 3.x; `llm_error` / `llm_skipped` markers on `evaluate_change()` |
| `worker.py` | Warn on `llm_error` fallback at notification time |
| `notification/handler.py` | Populate `llm_error` token lazily (same pattern as `llm_summary` / `llm_intent`) |
| `notification_service.py` | Register `llm_error` as a valid notification placeholder |
| `templates/_common_fields.html` | Document `{{llm_error}}` in the token help table |
| `tests/unit/test_llm_client.py` 🆕 | Gemini-3 detection, temperature omission, strip-and-retry (incl. the generic-message case) |
| `tests/unit/test_llm_evaluator_gemini3.py` 🆕 | `_thinking_extra_body` per Gemini generation, `llm_error` / `llm_skipped` markers |

## Testing

- [x] Unit test reproduces the exact failure shape from the bug report — a generic `"Request contains an invalid argument."` message with no field name — and confirms the retry now fires and succeeds
- [x] Unit test confirms the retry doesn't loop when there's nothing left to strip
- [x] Unit tests confirm `llm_error: True` on failure, `llm_skipped: 'budget_exceeded'` + `llm_error: False` on a budget skip, and no marker at all on a genuine verdict
- [x] Confirmed `gemini/gemini-2.5-flash` (the workaround model from the issue) is unaffected — still receives `temperature` and `thinkingConfig` exactly as before
- [ ] Manual end-to-end test against a real Gemini 3.x API key would be good to confirm before merge — I don't have one handy, happy to test if someone can share a sanitized run