### PR TITLE
Fix levenshtein_ratio_recent_history comparing snapshot to timestamp key

### DIFF
--- a/changedetectionio/conditions/plugins/levenshtein_plugin.py
+++ b/changedetectionio/conditions/plugins/levenshtein_plugin.py
@@ -27,7 +27,12 @@ def levenshtein_ratio_recent_history(watch, incoming_text=None):
         # Needs atleast one snapshot
         elif len(k) >= 1: # Should be atleast one snapshot to compare against
             a = watch.get_history_snapshot(timestamp=k[-1]) # Latest saved snapshot
-            b = incoming_text if incoming_text else k[-2]
+            if incoming_text:
+                b = incoming_text
+            elif len(k) >= 2:
+                # No incoming text (e.g. filters matched nothing this cycle) - fall back to
+                # comparing against the previous saved snapshot, same as the incoming_text is None branch
+                b = watch.get_history_snapshot(timestamp=k[-2])
 
         if a and b:
             distance_value = distance(a, b)

--- a/changedetectionio/tests/unit/test_levenshtein_plugin.py
+++ b/changedetectionio/tests/unit/test_levenshtein_plugin.py
@@ -1,0 +1,114 @@
+from changedetectionio.conditions.plugins.levenshtein_plugin import levenshtein_ratio_recent_history
+from changedetectionio.store import ChangeDetectionStore
+import shutil
+import tempfile
+import time
+import unittest
+import uuid
+
+
+class TestLevenshteinRatioRecentHistory(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory for the test datastore
+        self.test_datastore_path = tempfile.mkdtemp()
+
+        # Initialize ChangeDetectionStore with our test path and no default watches
+        self.store = ChangeDetectionStore(
+            datastore_path=self.test_datastore_path,
+            include_default_watches=False
+        )
+
+        # Add a test watch
+        watch_url = "https://example.com"
+        self.watch_uuid = self.store.add_watch(url=watch_url)
+        self.watch = self.store.data['watching'][self.watch_uuid]
+
+        # Two prior snapshots, deliberately very similar to each other so that a
+        # correct comparison yields a high ratio, and an incorrect one (comparing
+        # against a raw timestamp string) yields a near-zero ratio.
+        self.first_content = "The quick brown fox jumps over the lazy dog near the riverbank at dawn."
+        self.second_content = "The quick brown fox jumps over the lazy dog near the riverbank at dusk."
+
+        timestamp1 = int(time.time())
+        self.watch.save_history_blob(contents=self.first_content,
+                                      timestamp=timestamp1,
+                                      snapshot_id=str(uuid.uuid4()))
+
+        timestamp2 = timestamp1 + 60
+        self.watch.save_history_blob(contents=self.second_content,
+                                      timestamp=timestamp2,
+                                      snapshot_id=str(uuid.uuid4()))
+
+        self.assertEqual(len(self.watch.history), 2)
+
+    def tearDown(self):
+        self.store.stop_thread = True
+        time.sleep(0.5)
+        shutil.rmtree(self.test_datastore_path)
+
+    def test_empty_incoming_text_compares_against_previous_snapshot(self):
+        """
+        Regression test: when incoming_text == "" (e.g. a filter matched nothing
+        this cycle), the function must fall back to comparing the latest saved
+        snapshot against the *previous saved snapshot's text*, not against a raw
+        history timestamp key/string.
+        """
+        result = levenshtein_ratio_recent_history(self.watch, incoming_text="")
+
+        self.assertIsInstance(result, dict)
+
+        # The two snapshots differ by one word ("dawn" vs "dusk"), so a correct
+        # comparison should show high similarity.
+        self.assertGreater(result['percent_similar'], 90)
+
+        # Sanity check against directly comparing the two known snapshot contents.
+        from Levenshtein import ratio
+        expected_ratio = ratio(self.second_content, self.first_content)
+        self.assertAlmostEqual(result['ratio'], expected_ratio, places=6)
+
+    def test_incoming_text_none_still_compares_last_two_snapshots(self):
+        # Existing behaviour (used by ui_edit_stats_extras) should be unaffected
+        result = levenshtein_ratio_recent_history(self.watch)
+        self.assertIsInstance(result, dict)
+        self.assertGreater(result['percent_similar'], 90)
+
+    def test_incoming_text_provided_is_used_directly(self):
+        # When there IS incoming text, it should be compared directly against
+        # the latest saved snapshot, not the history.
+        incoming = "Something completely different that shares almost nothing."
+        result = levenshtein_ratio_recent_history(self.watch, incoming_text=incoming)
+        self.assertIsInstance(result, dict)
+
+        from Levenshtein import ratio
+        expected_ratio = ratio(self.second_content, incoming)
+        self.assertAlmostEqual(result['ratio'], expected_ratio, places=6)
+
+    def test_single_snapshot_with_empty_incoming_text_does_not_crash(self):
+        # With only one snapshot in history, there's nothing to fall back to -
+        # this should not raise, and should not produce a bogus comparison.
+        single_snapshot_store_path = tempfile.mkdtemp()
+        try:
+            store = ChangeDetectionStore(
+                datastore_path=single_snapshot_store_path,
+                include_default_watches=False
+            )
+            watch_uuid = store.add_watch(url="https://example.org")
+            watch = store.data['watching'][watch_uuid]
+            watch.save_history_blob(contents="Only one snapshot here",
+                                     timestamp=int(time.time()),
+                                     snapshot_id=str(uuid.uuid4()))
+            self.assertEqual(len(watch.history), 1)
+
+            result = levenshtein_ratio_recent_history(watch, incoming_text="")
+            # No second snapshot to compare against, so we expect no result
+            # rather than a misleading ratio against a timestamp string.
+            self.assertEqual(result, '')
+
+            store.stop_thread = True
+            time.sleep(0.5)
+        finally:
+            shutil.rmtree(single_snapshot_store_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes a bug in `levenshtein_ratio_recent_history()` where an empty `incoming_text` (a normal, non-error outcome when a CSS/xpath filter matches nothing on a given check cycle) caused the function to compare the latest snapshot against a raw history **timestamp key** instead of the previous snapshot's **text**.

This value feeds `res['levenshtein_ratio']` / `levenshtein_similarity`, which is exactly what a Levenshtein condition reads to decide whether to fire a notification. The bug is silent — no exception, no distinguishing log line — so an affected condition just makes its pass/fail decision from a near-meaningless score (typically ~0% similarity) instead of the real one.

## Root cause

```python
elif len(k) >= 1:
    a = watch.get_history_snapshot(timestamp=k[-1])   # latest saved snapshot, correct
    b = incoming_text if incoming_text else k[-2]      # k[-2] is a dict KEY (timestamp), not a snapshot
```

`k[-2]` is a timestamp string from `watch.history.keys()`, not resolved through `watch.get_history_snapshot()`. Since `""` is falsy in Python, this branch is reachable on any ordinary check with empty filtered text — not just an edge case.

Introduced in `5fd8200f` (#3161), which added the `else k[-2]` fallback for the single-snapshot case but forgot to wrap it in `watch.get_history_snapshot()`, unlike `a` and the `incoming_text is None` branch just above it.

## Fix

```python
elif len(k) >= 1:
    a = watch.get_history_snapshot(timestamp=k[-1])
    if incoming_text:
        b = incoming_text
    elif len(k) >= 2:
        b = watch.get_history_snapshot(timestamp=k[-2])
```

- Empty `incoming_text` now resolves the previous snapshot through `get_history_snapshot()`, consistent with the `incoming_text is None` branch.
- Added an explicit `len(k) >= 2` guard: for a watch with only one snapshot, there's no previous snapshot to fall back to, so `b` stays `None` and the function returns `''` instead of comparing a snapshot to a timestamp string or to itself.

## Repro (before fix)

```python
from Levenshtein import ratio

history = {
    "1000000000": "The quick brown fox jumps over the lazy dog near the riverbank at dawn.",
    "1000000100": "The quick brown fox jumps over the lazy dog near the riverbank at dusk.",
}
k = list(history.keys())
a = history[k[-1]]
b = "" if False else k[-2]        # incoming_text="" -> falls to the buggy branch
print(round(ratio(a, b) * 100, 2))                 # 0.0  <- what the condition actually read
print(round(ratio(a, history[k[-2]]) * 100, 2))    # 95.77 <- what it should have read
```

## Testing

Added `changedetectionio/tests/unit/test_levenshtein_plugin.py` with real watch/store objects (no mocks):

- `test_empty_incoming_text_compares_against_previous_snapshot` — the regression test; confirmed this **fails** against the pre-fix code (~0% similarity) and **passes** against the fix (~96%).
- `test_incoming_text_none_still_compares_last_two_snapshots` — confirms the existing `ui_edit_stats_extras` path is unaffected.
- `test_incoming_text_provided_is_used_directly` — confirms normal (non-empty) `incoming_text` still compares directly.
- `test_single_snapshot_with_empty_incoming_text_does_not_crash` — confirms the new guard handles the single-snapshot case cleanly.

fixes #4287