### PR TITLE
fix: sanitize lone unicode surrogates before filtering JSON

### DIFF
--- a/changedetectionio/html_tools.py
+++ b/changedetectionio/html_tools.py
@@ -406,9 +406,44 @@ def extract_element(find='title', html_content=''):
 
     return element_text
 
+# Any surrogate still present after json.loads() is a lone one - the decoder already folds
+# well-formed pairs (😀 -> a single emoji character) before we see them. Lone ones
+# come from escapes like \uD800 in the source document, which travel as plain ASCII and so
+# pass straight through the fetched-content sanitizer in processors/base.py.
+_LONE_SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
+
+def _has_lone_surrogate(value):
+    if isinstance(value, str):
+        return bool(_LONE_SURROGATE_RE.search(value))
+    if isinstance(value, dict):
+        return any(_has_lone_surrogate(k) or _has_lone_surrogate(v) for k, v in value.items())
+    if isinstance(value, list):
+        return any(_has_lone_surrogate(v) for v in value)
+    return False
+
+def _sanitize_lone_surrogates(value):
+    if isinstance(value, str):
+        return _LONE_SURROGATE_RE.sub('\ufffd', value)
+    if isinstance(value, dict):
+        return {_sanitize_lone_surrogates(k): _sanitize_lone_surrogates(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_lone_surrogates(v) for v in value]
+    return value
+
 #
 def _parse_json(json_data, json_filter):
     from jsonpath_ng.ext import parse
+
+    # Replace lone surrogates with U+FFFD, matching what processors/base.py already does for
+    # fetched content. Two separate failures otherwise, neither of which is confined to the
+    # offending value: jq re-serializes the whole document for its own C parser, which rejects
+    # a lone high surrogate, so every jq:/jqraw: filter on the page errors even when it points
+    # at an unrelated field; and on the json: path the surrogate reaches the caller intact and
+    # raises UnicodeEncodeError later in checksums and history writes.
+    # See: https://github.com/dgtlmoon/changedetection.io/issues/4273
+    if _has_lone_surrogate(json_data):
+        logger.warning("Lone unicode surrogate(s) in JSON document, replacing with U+FFFD before filtering")
+        json_data = _sanitize_lone_surrogates(json_data)
 
     if json_filter.startswith("json:"):
         jsonpath_expression = parse(json_filter.replace('json:', ''))

--- a/changedetectionio/tests/test_jsonpath_jq_selector.py
+++ b/changedetectionio/tests/test_jsonpath_jq_selector.py
@@ -121,6 +121,44 @@ and it can also be repeated
             html_tools.extract_json_as_string('COMPLETE GIBBERISH, NO JSON!', "jqraw:.id")
 
 
+def test_lone_surrogate_escapes_do_not_break_filters():
+    """A \\uD800-style escape in the watched JSON must not take the whole document down.
+
+    jq re-serializes the document for its own C parser, which rejects a lone high surrogate,
+    so every jq:/jqraw: filter on the page used to error even when pointing at an unrelated
+    field. On the json: path the surrogate instead reached the caller intact and blew up later
+    in checksums and history writes. Valid pairs must keep working untouched.
+    See: https://github.com/dgtlmoon/changedetection.io/issues/4273
+    """
+    from .. import html_tools
+
+    BS = chr(92)  # build the escapes at runtime so no quoting layer eats them
+    lone_high = '{"title": "Example ' + BS + 'uD800", "other": "untouched"}'
+    lone_low = '{"title": "Example ' + BS + 'uDC00", "other": "untouched"}'
+    valid_pair = '{"title": "smile ' + BS + 'uD83D' + BS + 'uDE00", "other": "untouched"}'
+
+    filters = ["json:$.%s", "jq:.%s", "jqraw:.%s"] if jq_support else ["json:$.%s"]
+
+    for content in (lone_high, lone_low):
+        for f in filters:
+            # An unrelated field must still be reachable
+            text = html_tools.extract_json_as_string(content, f % "other")
+            assert "untouched" in text
+
+            # And the offending field itself resolves, with the surrogate replaced
+            text = html_tools.extract_json_as_string(content, f % "title")
+            assert "Example" in text
+            assert not any(0xD800 <= ord(c) <= 0xDFFF for c in text)
+            # Whatever comes back has to survive the downstream checksum/history write
+            text.encode('utf-8')
+
+    # A well-formed surrogate pair is a normal emoji and must be preserved as-is
+    for f in filters:
+        text = html_tools.extract_json_as_string(valid_pair, f % "title")
+        assert '\U0001F600' in text
+        text.encode('utf-8')
+
+
 def test_unittest_inline_extract_body():
     content = """
     <html>


### PR DESCRIPTION
## Summary

Closes #4273.

- Replace lone unicode surrogates with U+FFFD in the decoded JSON document before any filter runs.
- Add a regression test covering `json:`, `jq:` and `jqraw:` against lone high, lone low, and valid surrogate pairs.

## Root cause

`_parse_json()` receives a document that `json.loads()` has already decoded, and hands it straight to the filter. An escape such as `\uD800` in the source is 6 plain ASCII characters on the wire, so it passes untouched through the fetched-content sanitizer in `processors/base.py:298` (added for #3952) and only becomes a real lone surrogate at `json.loads`. Two separate failures follow, and neither is confined to the field holding the bad value:

- **`jq:` / `jqraw:`** — the `jq` binding re-serializes the whole document for jq's C parser, which rejects a lone high surrogate. Every jq filter on the page then errors with `parse error: Invalid \uXXXX\uXXXX surrogate pair escape`, even one pointing at an unrelated field. This is the failure reported in the issue.
- **`json:`** — the filter appears to succeed, but returns a string still containing the lone surrogate, which raises `UnicodeEncodeError` downstream at `processors/text_json_diff/processor.py:413` (`hashlib.md5(text.encode('utf-8'))`) and at the history write in `model/Watch.py:704`.

Measured before the change (Linux container, HEAD `aac6fcfa`, jq 1.11):

```
lone high surrogate    json:$.other   -> OK   '"untouched"'
lone high surrogate    jq:.other      -> ValueError: parse error: Invalid \uXXXX\uXXXX surrogate pair escape
lone high surrogate    json:$.title   -> OK, but .encode('utf-8') then raises UnicodeEncodeError
lone low surrogate     jq:.title      -> OK   'Example �'   (jq already replaces this one itself)
valid escape pair      jq:.title      -> OK   'smile 😀'
```

Note the asymmetry: jq only rejects a lone *high* surrogate, and silently replaces a lone *low* one with U+FFFD. The fix makes both paths behave the same way jq already treats the low case.

## The fix

One guard at the top of `_parse_json()`, which is the single choke point for all three call sites (`extract_json_as_string` for clean JSON and for JSONP, plus `extract_json_blob_from_html`) and for all three filter families.

U+FFFD was chosen to match what `processors/base.py` already does for fetched content (`errors='replace'`) and what jq already does for lone low surrogates. A `logger.warning` is emitted when a document is actually sanitized — the issue notes the current failure is silent, and a user seeing U+FFFD in their output should be able to find out why.

The common case stays allocation-free: `_has_lone_surrogate()` only scans, and the document is rebuilt solely when a surrogate is present. Any surrogate surviving `json.loads` is necessarily a lone one, since the decoder folds well-formed pairs into a single character — so a valid `😀` emoji is untouched, which the test asserts.

## Testing

`tests/test_jsonpath_jq_selector.py::test_lone_surrogate_escapes_do_not_break_filters` fails on master and passes with this change. It follows the file's existing `jq_support` convention, so it degrades to the `json:` path where jq is unavailable (Windows).

Run in a Linux container against this branch:

- `tests/test_jsonpath_jq_selector.py` — 19 passed
- `tests/unit/ tests/llm/` — 340 passed
- `tests/test_encoding.py tests/restock/ tests/test_extract_regex.py` — 16 passed, 1 failed

The single failure is `tests/restock/test_restock.py::test_restock_detection`, which fails identically on unmodified master in the same environment, so it is unrelated to this change.
