### PR TITLE
Add OrcaRouter as a named LLM provider

### DIFF
--- a/changedetectionio/blueprint/settings/llm.py
+++ b/changedetectionio/blueprint/settings/llm.py
@@ -92,10 +92,12 @@ def construct_llm_blueprint(datastore: ChangeDetectionStore):
                 )}), 400
 
         _PREFIXES = {'gemini': 'gemini/', 'ollama': 'ollama/', 'openrouter': 'openrouter/',
-                     'openai_compatible': 'openai/'}
+                     'openai_compatible': 'openai/', 'orcarouter': 'orcarouter/'}
         # vLLM / LM Studio / llama.cpp speak OpenAI's wire format — route through litellm's
         # 'openai' provider but keep the UI-level name distinct from cloud OpenAI.
-        _LITELLM_PROVIDER = {'openai_compatible': 'openai'}
+        # OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible model-routing
+        # gateway too, so it also reuses litellm's 'openai' provider against api.orcarouter.ai.
+        _LITELLM_PROVIDER = {'openai_compatible': 'openai', 'orcarouter': 'openai'}
         prefix = _PREFIXES.get(provider, '')
         litellm_provider = _LITELLM_PROVIDER.get(provider, provider)
 

--- a/changedetectionio/blueprint/settings/templates/settings_llm_tab.html
+++ b/changedetectionio/blueprint/settings/templates/settings_llm_tab.html
@@ -121,6 +121,7 @@
         <option value="openai">OpenAI</option>
         <option value="openai_compatible">{{ _('OpenAI-compatible (vLLM, LM Studio, llama.cpp)') }}</option>
         <option value="openrouter">OpenRouter (200+ models)</option>
+        <option value="orcarouter">OrcaRouter</option>
     </select>
   </div>
 
@@ -441,8 +442,9 @@
 
 <script>
 (function () {
-  const LIVE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'ollama', 'openai_compatible', 'openrouter'];
-  const BASE_DEFAULTS  = { ollama: 'http://localhost:11434' };
+  const LIVE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'ollama', 'openai_compatible', 'openrouter', 'orcarouter'];
+  const BASE_DEFAULTS  = { ollama: 'http://localhost:11434',
+                           orcarouter: 'https://api.orcarouter.ai/v1' };
   const KEY_HINTS = {
     openai:             '{{ _("platform.openai.com → API keys") }}',
     anthropic:          '{{ _("console.anthropic.com → API keys") }}',
@@ -450,6 +452,7 @@
     ollama:             '{{ _("No API key needed for local Ollama") }}',
     openai_compatible:  '{{ _("Bearer token for your self-hosted server (vLLM, LM Studio, etc.)") }}',
     openrouter:         '{{ _("openrouter.ai → Keys") }}',
+    orcarouter:         '{{ _("orcarouter.ai → API keys") }}',
   };
 
   window.llmDisclaimerToggle = function (cb) {
@@ -471,7 +474,9 @@
     const needsBase = provider === 'ollama' || provider === 'openai_compatible';
     baseGroup.style.display = needsBase ? '' : 'none';
     if (BASE_DEFAULTS[provider] !== undefined) {
-      if (!baseField.value) baseField.value = BASE_DEFAULTS[provider];
+      // OrcaRouter always targets its gateway endpoint — refresh it when switching
+      // providers so a stale Ollama/vLLM base can't leak into the request.
+      if (!baseField.value || provider === 'orcarouter') baseField.value = BASE_DEFAULTS[provider];
     }
 
     // Persist the dropdown selection so the backend can branch on provider kind
@@ -608,6 +613,7 @@
     if (m.startsWith('gemini/'))       guessed = 'gemini';
     else if (m.startsWith('ollama/'))  guessed = 'ollama';
     else if (m.startsWith('openrouter/')) guessed = 'openrouter';
+    else if (m.startsWith('orcarouter/')) guessed = 'orcarouter';
     else if (m.startsWith('openai/')) {
       // openai/<model> + custom api_base = self-hosted OpenAI-compatible (vLLM etc.)
       const baseField = document.querySelector('[name="llm-api_base"]');

--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -86,6 +86,16 @@ def completion(model: str, messages: list, api_key: str = None,
 
     _timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
 
+    # OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible model-routing
+    # gateway: the /models dropdown stores ids as 'orcarouter/<router-id>' where the
+    # router id is itself provider-prefixed (openai/gpt-4o, anthropic/claude-…).
+    # litellm keys the provider off the first path segment, so a bare 'orcarouter/…'
+    # has no litellm provider. Rewrite to 'openai/<router-id>' — litellm strips the
+    # leading 'openai/' it recognises itself and sends the full router id on the
+    # wire to api.orcarouter.ai.
+    if model.startswith('orcarouter/'):
+        model = 'openai/' + model[len('orcarouter/'):]
+
     kwargs = {
         'model': model,
         'messages': messages,

--- a/changedetectionio/tests/llm/test_client.py
+++ b/changedetectionio/tests/llm/test_client.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Tests for changedetectionio.llm.client.completion() and the OrcaRouter
+(named OpenAI-compatible routing gateway) model handling.
+
+OrcaRouter model ids are stored as 'orcarouter/<router-id>' where the router id is
+itself provider-prefixed (openai/gpt-4o, anthropic/claude-…). litellm keys the
+provider off the first path segment, so client.completion() rewrites
+'orcarouter/<id>' to 'openai/<id>' before the litellm call — litellm then strips the
+leading 'openai/' it recognised itself and sends the full router id on the wire.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from changedetectionio.llm.client import completion
+
+
+def _fake_response(text='pong'):
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=1, total_tokens=4)
+    message = SimpleNamespace(content=text, parts=None)
+    choice = SimpleNamespace(message=message, finish_reason='stop')
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+@pytest.mark.parametrize(
+    'stored_model,expected_litellm_model',
+    [
+        ('orcarouter/openai/gpt-4o', 'openai/openai/gpt-4o'),
+        ('orcarouter/anthropic/claude-sonnet-4.6', 'openai/anthropic/claude-sonnet-4.6'),
+        ('orcarouter/auto', 'openai/auto'),
+        ('orcarouter/openai/o3', 'openai/openai/o3'),
+    ],
+)
+def test_completion_rewrites_orcarouter_model(stored_model, expected_litellm_model):
+    """OrcaRouter ids must be rewritten to the openai provider so litellm can
+    route them, keeping api_base/api_key intact for the gateway."""
+    with patch('litellm.completion', return_value=_fake_response()) as mock_llm:
+        text, total_tokens, in_tokens, out_tokens = completion(
+            model=stored_model,
+            messages=[{'role': 'user', 'content': 'hi'}],
+            api_key='sk-orca-test',
+            api_base='https://api.orcarouter.ai/v1',
+        )
+
+    kwargs = mock_llm.call_args.kwargs
+    assert kwargs['model'] == expected_litellm_model
+    assert kwargs['api_base'] == 'https://api.orcarouter.ai/v1'
+    assert kwargs['api_key'] == 'sk-orca-test'
+
+    assert text == 'pong'
+    assert (total_tokens, in_tokens, out_tokens) == (4, 3, 1)
+
+
+def test_completion_leaves_non_orcarouter_models_unchanged():
+    """Providers litellm already understands must not be touched."""
+    with patch('litellm.completion', return_value=_fake_response()) as mock_llm:
+        completion(
+            model='openai/gpt-4o',
+            messages=[{'role': 'user', 'content': 'hi'}],
+            api_key='sk-test',
+        )
+
+    assert mock_llm.call_args.kwargs['model'] == 'openai/gpt-4o'
+
+
+def test_llm_models_endpoint_orcarouter(client, live_server, datastore_path, monkeypatch):
+    """GET /settings/llm/models?provider=orcarouter must list the gateway's router
+    ids under the orcarouter/ prefix, routed through litellm's openai provider
+    against the OrcaRouter api_base."""
+    import litellm
+
+    calls = {}
+
+    def fake_get_valid_models(**kwargs):
+        calls.update(kwargs)
+        return ['openai/gpt-4o', 'anthropic/claude-sonnet-4.6']
+
+    monkeypatch.setattr(litellm, 'get_valid_models', fake_get_valid_models)
+
+    res = client.get(
+        __import__('flask').url_for('settings.llm.llm_get_models'),
+        query_string={
+            'provider': 'orcarouter',
+            'api_base': 'https://api.orcarouter.ai/v1',
+            'api_key': 'sk-orca-test',
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body['error'] is None
+    assert body['models'] == [
+        'orcarouter/anthropic/claude-sonnet-4.6',
+        'orcarouter/openai/gpt-4o',
+    ]
+    # Routed through litellm's openai provider (OpenAI wire format) to the gateway.
+    assert calls['custom_llm_provider'] == 'openai'
+    assert calls['api_base'] == 'https://api.orcarouter.ai/v1'
+    assert calls['api_key'] == 'sk-orca-test'

--- a/changedetectionio/translations/messages.pot
+++ b/changedetectionio/translations/messages.pot
@@ -1226,6 +1226,10 @@ msgid "openrouter.ai → Keys"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings_llm_tab.html
+msgid "orcarouter.ai → API keys"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings_llm_tab.html
 msgid "Select a provider first."
 msgstr ""
 


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `changedetectionio/blueprint/settings/llm.py`: registers `orcarouter` in the provider-prefix and litellm-provider maps, so "Load available models" lists the gateway's router ids.
- `changedetectionio/llm/client.py`: rewrites `orcarouter/<id>` model strings to `openai/<id>` at the litellm boundary — the gateway speaks the OpenAI wire format and litellm keys the provider off the first path segment.
- `changedetectionio/blueprint/settings/templates/settings_llm_tab.html`: adds the OrcaRouter option to the provider dropdown, with the gateway base URL (`https://api.orcarouter.ai/v1`) and a key hint.
- `changedetectionio/translations/messages.pot`: adds the new key-hint string for translators.
- `changedetectionio/tests/llm/test_client.py`: tests for the model rewrite and the `/settings/llm/models` endpoint.

## Why a dedicated provider rather than the OpenAI-compatible escape hatch

This mirrors how the existing OpenRouter provider is wired in this repo, so the model picker, config reference and docs stay consistent for users. OrcaRouter is an OpenAI-compatible gateway, but its model ids are already provider-prefixed router ids (`openai/gpt-4o`, `anthropic/claude-sonnet-4.6`, `orcarouter/auto`), so a named provider keeps those ids intact end-to-end.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In Settings → AI / LLM → Provider, pick **OrcaRouter** and paste the key.
3. Click "Load available models" and pick a router id such as `openai/gpt-4o`, `anthropic/claude-sonnet-4.6` or `orcarouter/auto`.

The full catalog is at https://www.orcarouter.ai/models.

## Verification

- Unit tests: `pytest changedetectionio/tests/llm/test_client.py` (all passed)
- Live API: L3 live test against `https://api.orcarouter.ai/v1` with a real key (`/v1/models` + a test completion)
- Ran locally: `.venv/Scripts/python.exe -m pytest ...`
