### PR TITLE
Set Cache-Control: no-store on dynamic responses by default

### DIFF
--- a/changedetectionio/flask_app.py
+++ b/changedetectionio/flask_app.py
@@ -160,6 +160,18 @@ csrf = CSRFProtect()
 csrf.init_app(app)
 notification_debug_log=[]
 
+@app.after_request
+def add_no_cache_headers(response):
+    # Dynamic/authenticated pages (forms with CSRF tokens, watch data, settings, etc.) must
+    # never be cached by an intermediate CDN or reverse proxy — a cached copy would serve a
+    # stale CSRF token (breaking form submissions) or, worse, leak one session's page to another
+    # since most edge caches key purely on URL and ignore cookies.
+    # Routes that explicitly set their own Cache-Control (static assets, screenshots, favicons)
+    # are left untouched.
+    if 'Cache-Control' not in response.headers:
+        response.headers['Cache-Control'] = 'no-store, private'
+    return response
+
 # Locale for correct presentation of prices etc
 default_locale = locale.getdefaultlocale()
 logger.info(f"System locale default is {default_locale}")


### PR DESCRIPTION
## Summary
- Adds an `after_request` hook that sets `Cache-Control: no-store, private` on any response that doesn't already set its own `Cache-Control` header.
- Routes that already set their own cache headers (static assets, screenshots, favicons, plugin static files) are untouched, since the hook only fills in the header when it's missing.

## Motivation
Ran into this via a Cloudflare Worker acting as a reverse proxy in front of a self-hosted instance. The worker has an opt-in per-host GET cache, keyed only by URL (not by cookie). Since changedetection.io's dynamic pages (e.g. `/settings`) send no `Cache-Control` header today, enabling that cache option caused the edge to serve a stale cached copy of `/settings` — including its embedded `csrf_token` — resulting in a persistent "The CSRF tokens do not match." error on save, reproducible even from a fresh incognito session, because the token in the cached HTML no longer matched the live session.

Disabling caching on the Worker fixed it, confirming the root cause. Since the cache key in that scenario ignores cookies entirely, the same misconfiguration could in principle serve one session's authenticated page to a different visitor — not just a CSRF nuisance but a potential cross-session content leak.

This isn't a bug in this app's session/CSRF handling itself — it's that nothing tells an intermediary (CDN, reverse proxy, browser) that these pages are per-session and must not be cached. Sending an explicit `Cache-Control: no-store` by default closes that gap for anyone running behind a caching proxy/CDN, without needing extra configuration on their end.

## Test plan
- [x] `python -m py_compile changedetectionio/flask_app.py`
- [ ] Existing test suite (couldn't run locally in this environment — missing deps)
- [ ] Manual: confirm `/settings`, `/`, and other dynamic pages now include `Cache-Control: no-store, private`, while static asset routes (`/static/...`, favicons, screenshots) keep their existing explicit cache headers unchanged