### PR TITLE
feat: FlareSolverr overlay for Cloudflare / bot-detection bypass

### DIFF
--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -276,31 +276,17 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         # time but happily previewed (and exfiltrated) here.
         await validate_fetch_url_async(watch.link)
 
-        # FlareSolverr overlay for live UI - inject cf_clearance + UA when watch is FlareSolverr-effective
+        # FlareSolverr overlay for live UI — shared helper (effective check, body render, executor)
         flaresolverr_cookies = None
         flaresolverr_user_agent = None
         try:
-            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool, FLARESOLVERR_EXECUTOR
-            from changedetectionio.jinja2_custom import render as jinja_render
-            if is_flaresolverr_effective(watch, datastore):
-                pool = get_global_pool()
-                _method = watch.get('method') or 'GET'
-                _body = watch.get('body')
-                if _body:
-                    try:
-                        _body = jinja_render(template_str=_body)
-                    except Exception:
-                        pass
-                    if _body and len(_body) > 1024 * 1024:
-                        logger.warning(f"FlareSolverr live UI POST body too large ({len(_body)} bytes), truncating to 1MB for {watch.link}")
-                        _body = _body[:1024*1024]
-                _proxy_url = proxy.get('server') if proxy else None
-                import asyncio as _asyncio
-                _loop = _asyncio.get_running_loop()
-                flaresolverr_solution = await _loop.run_in_executor(FLARESOLVERR_EXECUTOR, lambda: pool.solve(watch.link, proxy_url=_proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
+            from changedetectionio.flaresolverr_pool import get_flaresolverr_solution_for_watch
+
+            _proxy_url = proxy.get('server') if proxy else None
+            flaresolverr_solution = await get_flaresolverr_solution_for_watch(watch, datastore, proxy_url=_proxy_url)
+            if flaresolverr_solution:
                 flaresolverr_cookies = flaresolverr_solution.get('cookies')
                 flaresolverr_user_agent = flaresolverr_solution.get('userAgent')
-                logger.info(f"FlareSolverr live UI solved {watch.link} via session {flaresolverr_solution.get('session_id')}")
         except Exception as e:
             logger.warning(f"FlareSolverr live UI solve failed for {watch.link}: {e}")
 

--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -275,6 +275,31 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         # time but happily previewed (and exfiltrated) here.
         await validate_fetch_url_async(watch.link)
 
+        # FlareSolverr overlay for live UI - inject cf_clearance + UA when watch is FlareSolverr-effective
+        flaresolverr_cookies = None
+        flaresolverr_user_agent = None
+        try:
+            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool
+            from changedetectionio.jinja2_custom import render as jinja_render
+            if is_flaresolverr_effective(watch, datastore):
+                pool = get_global_pool()
+                _method = watch.get('method') or 'GET'
+                _body = watch.get('body')
+                if _body:
+                    try:
+                        _body = jinja_render(template_str=_body)
+                    except Exception:
+                        pass
+                _proxy_url = proxy.get('server') if proxy else None
+                import asyncio as _asyncio
+                _loop = _asyncio.get_running_loop()
+                flaresolverr_solution = await _loop.run_in_executor(None, lambda: pool.solve(watch.link, proxy_url=_proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
+                flaresolverr_cookies = flaresolverr_solution.get('cookies')
+                flaresolverr_user_agent = flaresolverr_solution.get('userAgent')
+                logger.info(f"FlareSolverr live UI solved {watch.link} via session {flaresolverr_solution.get('session_id')}")
+        except Exception as e:
+            logger.warning(f"FlareSolverr live UI solve failed for {watch.link}: {e}")
+
         fetcher_name = watch.get_fetch_backend or 'system'
         if fetcher_name == 'system':
             fetcher_name = datastore.data['settings']['application'].get('fetch_backend', 'html_requests')
@@ -288,7 +313,9 @@ def construct_blueprint(datastore: ChangeDetectionStore):
             playwright_browser=browser,
             proxy=proxy,
             start_url=watch.link,
-            headers=watch.get('headers')
+            headers=watch.get('headers'),
+            flaresolverr_cookies=flaresolverr_cookies,
+            flaresolverr_user_agent=flaresolverr_user_agent,
         )
         await browserstepper.connect(proxy=proxy)
         browsersteps_start_session['browserstepper'] = browserstepper

--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -279,7 +279,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         flaresolverr_cookies = None
         flaresolverr_user_agent = None
         try:
-            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool
+            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool, FLARESOLVERR_EXECUTOR
             from changedetectionio.jinja2_custom import render as jinja_render
             if is_flaresolverr_effective(watch, datastore):
                 pool = get_global_pool()
@@ -293,7 +293,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
                 _proxy_url = proxy.get('server') if proxy else None
                 import asyncio as _asyncio
                 _loop = _asyncio.get_running_loop()
-                flaresolverr_solution = await _loop.run_in_executor(None, lambda: pool.solve(watch.link, proxy_url=_proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
+                flaresolverr_solution = await _loop.run_in_executor(FLARESOLVERR_EXECUTOR, lambda: pool.solve(watch.link, proxy_url=_proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
                 flaresolverr_cookies = flaresolverr_solution.get('cookies')
                 flaresolverr_user_agent = flaresolverr_solution.get('userAgent')
                 logger.info(f"FlareSolverr live UI solved {watch.link} via session {flaresolverr_solution.get('session_id')}")

--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -100,7 +100,8 @@ def run_async_in_browser_loop(coro):
     if _browser_steps_loop and not _browser_steps_loop.is_closed():
         logger.debug("Browser steps using dedicated event loop")
         future = asyncio.run_coroutine_threadsafe(coro, _browser_steps_loop)
-        return future.result()
+        # FlareSolverr solve can take up to 60s + overhead, so allow 70s for start; normal steps 30s
+        return future.result(timeout=70)
     else:
         raise RuntimeError("Browser steps event loop is not available")
 
@@ -290,6 +291,9 @@ def construct_blueprint(datastore: ChangeDetectionStore):
                         _body = jinja_render(template_str=_body)
                     except Exception:
                         pass
+                    if _body and len(_body) > 1024 * 1024:
+                        logger.warning(f"FlareSolverr live UI POST body too large ({len(_body)} bytes), truncating to 1MB for {watch.link}")
+                        _body = _body[:1024*1024]
                 _proxy_url = proxy.get('server') if proxy else None
                 import asyncio as _asyncio
                 _loop = _asyncio.get_running_loop()

--- a/changedetectionio/blueprint/settings/__init__.py
+++ b/changedetectionio/blueprint/settings/__init__.py
@@ -77,6 +77,23 @@ def construct_blueprint(datastore: ChangeDetectionStore):
             for p in datastore.proxy_list:
                 form.requests.form.proxy.choices.append(tuple((p, datastore.proxy_list[p]['label'])))
 
+        # FlareSolverr env gate
+        from changedetectionio.flaresolverr_pool import get_flaresolverr_url
+
+        flaresolverr_available = bool(get_flaresolverr_url())
+        # Remove per-watch radio from global form (only global boolean belongs here)
+        if hasattr(form.application.form, 'flaresolverr'):
+            try:
+                del form.application.form.flaresolverr
+            except Exception:
+                pass
+        if not flaresolverr_available:
+            if hasattr(form.application.form, 'flaresolverr_enabled'):
+                try:
+                    del form.application.form.flaresolverr_enabled
+                except Exception:
+                    pass
+
         if request.method == 'POST':
             # Password unset is a GET, but we can lock the session to a salted env password to always need the password
             if form.application.form.data.get('removepassword_button', False):
@@ -102,6 +119,11 @@ def construct_blueprint(datastore: ChangeDetectionStore):
                 for nf in ('notification_urls', 'notification_title', 'notification_body',
                            'notification_format', 'base_url'):
                     app_update.pop(nf, None)
+                # Per-watch flaresolverr radio should not be stored globally
+                app_update.pop('flaresolverr', None)
+                # Keep flaresolverr_enabled in sync to requests for backwards compat
+                if 'flaresolverr_enabled' in app_update:
+                    datastore.data['settings']['requests']['flaresolverr_enabled'] = app_update['flaresolverr_enabled']
 
                 datastore.data['settings']['application'].update(app_update)
 
@@ -250,6 +272,8 @@ def construct_blueprint(datastore: ChangeDetectionStore):
 
         output = render_template("settings.html",
                                 active_plugins=active_plugins,
+                                flaresolverr_available=flaresolverr_available,
+                                flaresolverr_url=get_flaresolverr_url(),
                                 api_key=datastore.data['settings']['application'].get('api_access_token'),
                                 llm_config=llm_config,
                                 llm_env_configured=llm_env_configured,

--- a/changedetectionio/blueprint/settings/templates/settings.html
+++ b/changedetectionio/blueprint/settings/templates/settings.html
@@ -138,6 +138,16 @@
                         {{ _('Note: Simply changing the User-Agent often does not defeat anti-robot technologies, it\'s important to consider') }} <a href="https://changedetection.io/tutorial/what-are-main-types-anti-robot-mechanisms">{{ _('all of the ways that the browser is detected') }}</a>.
                     </span>
                 </div>
+                {% if flaresolverr_available and form.application.form.flaresolverr_enabled is defined %}
+                <div class="pure-control-group">
+                    {{ render_checkbox_field(form.application.form.flaresolverr_enabled) }}
+                    <span class="pure-form-message-inline">{{ _('When enabled, watches using "System default" will be fetched via FlareSolverr at') }} <code>{{ flaresolverr_url }}</code> {{ _('to bypass Cloudflare / DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request.') }}</span>
+                </div>
+                {% elif not flaresolverr_available %}
+                <div class="pure-control-group">
+                    <span class="pure-form-message-inline"><i>{{ _('FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See') }} <a href="https://github.com/FlareSolverr/FlareSolverr">FlareSolverr</a>.</i></span>
+                </div>
+                {% endif %}
                 <div class="pure-control-group">
                 <br>
                     {{ _('Tip:') }} <a href="{{ url_for('settings.settings_page')}}#proxies">{{ _('Connect using Bright Data proxies, find out more here.') }}</a>

--- a/changedetectionio/blueprint/settings/templates/settings.html
+++ b/changedetectionio/blueprint/settings/templates/settings.html
@@ -141,7 +141,7 @@
                 {% if flaresolverr_available and form.application.form.flaresolverr_enabled is defined %}
                 <div class="pure-control-group">
                     {{ render_checkbox_field(form.application.form.flaresolverr_enabled) }}
-                    <span class="pure-form-message-inline">{{ _('When enabled, watches using "System default" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request.', url='<code>'~flaresolverr_url~'</code>')|safe }}</span>
+                    <span class="pure-form-message-inline">{{ _('When enabled, watches using "System default" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request.', url='<code>'~flaresolverr_url|e~'</code>')|safe }}</span>
                 </div>
                 {% elif not flaresolverr_available %}
                 <div class="pure-control-group">

--- a/changedetectionio/blueprint/settings/templates/settings.html
+++ b/changedetectionio/blueprint/settings/templates/settings.html
@@ -141,7 +141,7 @@
                 {% if flaresolverr_available and form.application.form.flaresolverr_enabled is defined %}
                 <div class="pure-control-group">
                     {{ render_checkbox_field(form.application.form.flaresolverr_enabled) }}
-                    <span class="pure-form-message-inline">{{ _('When enabled, watches using "System default" will be fetched via FlareSolverr at') }} <code>{{ flaresolverr_url }}</code> {{ _('to bypass Cloudflare / DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request.') }}</span>
+                    <span class="pure-form-message-inline">{{ _('When enabled, watches using "System default" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request.', url='<code>'~flaresolverr_url~'</code>')|safe }}</span>
                 </div>
                 {% elif not flaresolverr_available %}
                 <div class="pure-control-group">

--- a/changedetectionio/blueprint/ui/edit.py
+++ b/changedetectionio/blueprint/ui/edit.py
@@ -203,6 +203,17 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
             for p in datastore.proxy_list:
                 form.proxy.choices.append(tuple((p, datastore.proxy_list[p]['label'])))
 
+        # FlareSolverr env gate - hide field if not configured
+        from changedetectionio.flaresolverr_pool import get_flaresolverr_url
+
+        flaresolverr_available = bool(get_flaresolverr_url())
+        if not flaresolverr_available:
+            if hasattr(form, 'flaresolverr'):
+                try:
+                    del form.flaresolverr
+                except Exception:
+                    pass
+
 
         if request.method == 'POST' and form.validate():
 
@@ -365,6 +376,8 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
                 'extra_notification_token_placeholder_info': datastore.get_unique_notification_token_placeholders_available(),
                 'extra_processor_config': form.extra_tab_content(),
                 'extra_title': f" - {gettext('Edit')} - {watch.label}",
+                'flaresolverr_available': flaresolverr_available,
+                'flaresolverr_url': get_flaresolverr_url(),
                 'form': form,
                 'has_default_notification_urls': True if len(datastore.data['settings']['application']['notification_urls']) else False,
                 'has_extra_headers_file': len(datastore.get_all_headers_in_textfile_for_watch(uuid=uuid)) > 0,

--- a/changedetectionio/blueprint/ui/templates/edit.html
+++ b/changedetectionio/blueprint/ui/templates/edit.html
@@ -169,7 +169,7 @@
                 {% if flaresolverr_available and form.flaresolverr is defined %}
                     <div class="pure-control-group inline-radio">
                         {{ render_field(form.flaresolverr) }}
-                        <span class="pure-form-message-inline">{{ _('Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. "System default" follows Settings → Fetching → FlareSolverr.', url='<code>'~flaresolverr_url~'</code>')|safe }}</span>
+                        <span class="pure-form-message-inline">{{ _('Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. "System default" follows Settings → Fetching → FlareSolverr.', url='<code>'~flaresolverr_url|e~'</code>')|safe }}</span>
                     </div>
                 {% elif not flaresolverr_available %}
                     <div class="pure-control-group">

--- a/changedetectionio/blueprint/ui/templates/edit.html
+++ b/changedetectionio/blueprint/ui/templates/edit.html
@@ -169,7 +169,7 @@
                 {% if flaresolverr_available and form.flaresolverr is defined %}
                     <div class="pure-control-group inline-radio">
                         {{ render_field(form.flaresolverr) }}
-                        <span class="pure-form-message-inline">{{ _('Route this watch via FlareSolverr') }} <code>{{ flaresolverr_url }}</code> {{ _('to bypass Cloudflare. "System default" follows Settings → Fetching → FlareSolverr.') }}</span>
+                        <span class="pure-form-message-inline">{{ _('Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. "System default" follows Settings → Fetching → FlareSolverr.', url='<code>'~flaresolverr_url~'</code>')|safe }}</span>
                     </div>
                 {% elif not flaresolverr_available %}
                     <div class="pure-control-group">

--- a/changedetectionio/blueprint/ui/templates/edit.html
+++ b/changedetectionio/blueprint/ui/templates/edit.html
@@ -166,6 +166,16 @@
                         </span>
                     </div>
                 {% endif %}
+                {% if flaresolverr_available and form.flaresolverr is defined %}
+                    <div class="pure-control-group inline-radio">
+                        {{ render_field(form.flaresolverr) }}
+                        <span class="pure-form-message-inline">{{ _('Route this watch via FlareSolverr') }} <code>{{ flaresolverr_url }}</code> {{ _('to bypass Cloudflare. "System default" follows Settings → Fetching → FlareSolverr.') }}</span>
+                    </div>
+                {% elif not flaresolverr_available %}
+                    <div class="pure-control-group">
+                        <span class="pure-form-message-inline"><i>{{ _('FlareSolverr not configured — set FLARESOLVERR_URL to enable.') }}</i></span>
+                    </div>
+                {% endif %}
 
                 <!-- webdriver always -->
                 <fieldset data-visible-for="fetch_backend=html_webdriver"  style="display: none;">

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -344,13 +344,15 @@ class browsersteps_live_ui(steppable_browser_interface):
 
     browser_type = os.getenv("PLAYWRIGHT_BROWSER_TYPE", 'chromium').strip('"')
 
-    def __init__(self, playwright_browser, proxy=None, headers=None, start_url=None):
+    def __init__(self, playwright_browser, proxy=None, headers=None, start_url=None, flaresolverr_cookies=None, flaresolverr_user_agent=None):
         self.headers = headers or {}
         self.age_start = time.time()
         self.playwright_browser = playwright_browser
         self.start_url = start_url
         self._is_cleaned_up = False
         self.proxy = proxy
+        self.flaresolverr_cookies = flaresolverr_cookies
+        self.flaresolverr_user_agent = flaresolverr_user_agent
         # Note: connect() is now async and must be called separately
 
     def __del__(self):
@@ -365,6 +367,7 @@ class browsersteps_live_ui(steppable_browser_interface):
         now = time.time()
 
         # @todo handle multiple contexts, bind a unique id from the browser on each req?
+        _ua = self.flaresolverr_user_agent or manage_user_agent(headers=self.headers)
         self.context = await self.playwright_browser.new_context(
             accept_downloads=False,  # Should never be needed
             bypass_csp=get_playwright_bypass_csp(),
@@ -373,8 +376,24 @@ class browsersteps_live_ui(steppable_browser_interface):
             proxy=proxy,
             service_workers=os.getenv('PLAYWRIGHT_SERVICE_WORKERS', 'allow'),
             # Should be `allow` or `block` - sites like YouTube can transmit large amounts of data via Service Workers
-            user_agent=manage_user_agent(headers=self.headers),
+            user_agent=_ua,
         )
+        if self.flaresolverr_cookies:
+            try:
+                _cookies = []
+                for c in self.flaresolverr_cookies:
+                    _cc = dict(c)
+                    if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
+                        _cc['expires'] = float(_cc['expires'])
+                    if 'sameSite' in _cc:
+                        _v = _cc.pop('sameSite')
+                        if _v in ('Strict', 'Lax', 'None'):
+                            _cc['sameSite'] = _v
+                    _cookies.append(_cc)
+                await self.context.add_cookies(_cookies)
+                logger.info(f"FlareSolverr injected {len(_cookies)} cookies via BrowserSteps live UI")
+            except Exception as e:
+                logger.warning(f"FlareSolverr cookie inject failed (live UI): {e}")
 
         self.page = await self.context.new_page()
 

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -380,18 +380,31 @@ class browsersteps_live_ui(steppable_browser_interface):
         )
         if self.flaresolverr_cookies:
             try:
+                from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+                from urllib.parse import urlparse as _urlparse
+
+                _host = _urlparse(self.start_url).netloc.lower() if self.start_url else ""
                 _cookies = []
                 for c in self.flaresolverr_cookies:
                     _cc = dict(c)
+                    _domain = _cc.get("domain")
+                    if _domain and not is_cookie_domain_valid(_domain, _host):
+                        logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping (live UI)")
+                        continue
                     if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
                         _cc['expires'] = float(_cc['expires'])
                     if 'sameSite' in _cc:
                         _v = _cc.pop('sameSite')
-                        if _v in ('Strict', 'Lax', 'None'):
-                            _cc['sameSite'] = _v
+                        if isinstance(_v, str) and _v.capitalize() in ('Strict', 'Lax', 'None'):
+                            _cc['sameSite'] = _v.capitalize()
+                    if not _cc.get("domain") and not _cc.get("url") and self.start_url:
+                        _cc["url"] = self.start_url
                     _cookies.append(_cc)
-                await self.context.add_cookies(_cookies)
-                logger.info(f"FlareSolverr injected {len(_cookies)} cookies via BrowserSteps live UI")
+                if _cookies:
+                    await self.context.add_cookies(_cookies)
+                    logger.info(f"FlareSolverr injected {len(_cookies)} cookies via BrowserSteps live UI")
+                else:
+                    logger.warning("FlareSolverr no valid cookies to inject via BrowserSteps live UI")
             except Exception as e:
                 logger.warning(f"FlareSolverr cookie inject failed (live UI): {e}")
 

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -379,34 +379,9 @@ class browsersteps_live_ui(steppable_browser_interface):
             user_agent=_ua,
         )
         if self.flaresolverr_cookies:
-            try:
-                from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
-                from urllib.parse import urlparse as _urlparse
+            from changedetectionio.flaresolverr_pool import inject_cookies_playwright
 
-                _host = _urlparse(self.start_url).netloc.lower() if self.start_url else ""
-                _cookies = []
-                for c in self.flaresolverr_cookies:
-                    _cc = dict(c)
-                    _domain = _cc.get("domain")
-                    if _domain and not is_cookie_domain_valid(_domain, _host):
-                        logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping (live UI)")
-                        continue
-                    if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
-                        _cc['expires'] = float(_cc['expires'])
-                    if 'sameSite' in _cc:
-                        _v = _cc.pop('sameSite')
-                        if isinstance(_v, str) and _v.capitalize() in ('Strict', 'Lax', 'None'):
-                            _cc['sameSite'] = _v.capitalize()
-                    if not _cc.get("domain") and not _cc.get("url") and self.start_url:
-                        _cc["url"] = self.start_url
-                    _cookies.append(_cc)
-                if _cookies:
-                    await self.context.add_cookies(_cookies)
-                    logger.info(f"FlareSolverr injected {len(_cookies)} cookies via BrowserSteps live UI")
-                else:
-                    logger.warning("FlareSolverr no valid cookies to inject via BrowserSteps live UI")
-            except Exception as e:
-                logger.warning(f"FlareSolverr cookie inject failed (live UI): {e}")
+            await inject_cookies_playwright(self.context, self.flaresolverr_cookies, self.start_url, label="BrowserSteps live UI")
 
         self.page = await self.context.new_page()
 

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -367,7 +367,9 @@ class browsersteps_live_ui(steppable_browser_interface):
         now = time.time()
 
         # @todo handle multiple contexts, bind a unique id from the browser on each req?
-        _ua = self.flaresolverr_user_agent or manage_user_agent(headers=self.headers)
+        from changedetectionio.flaresolverr_pool import resolve_flaresolverr_user_agent
+
+        _ua = resolve_flaresolverr_user_agent(self.flaresolverr_user_agent, headers=self.headers)
         self.context = await self.playwright_browser.new_context(
             accept_downloads=False,  # Should never be needed
             bypass_csp=get_playwright_bypass_csp(),

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -296,36 +296,9 @@ class fetcher(Fetcher):
                 user_agent=_ua,
             )
             if self.flaresolverr_cookies:
-                try:
-                    from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+                from changedetectionio.flaresolverr_pool import inject_cookies_playwright
 
-                    _host = urlparse(url).netloc.lower() if url else ""
-                    _cookies = []
-                    for c in self.flaresolverr_cookies:
-                        _cc = dict(c)
-                        # Validate domain to prevent evil.com injection
-                        _domain = _cc.get("domain")
-                        if _domain and not is_cookie_domain_valid(_domain, _host):
-                            logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
-                            continue
-                        if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
-                            _cc['expires'] = float(_cc['expires'])
-                        if 'sameSite' in _cc:
-                            _v = _cc.pop('sameSite')
-                            # Case-insensitive: Chrome may return 'lax' lower
-                            if isinstance(_v, str) and _v.capitalize() in ('Strict', 'Lax', 'None'):
-                                _cc['sameSite'] = _v.capitalize()
-                        # If no domain and no url, scope to current url
-                        if not _cc.get("domain") and not _cc.get("url") and url:
-                            _cc["url"] = url
-                        _cookies.append(_cc)
-                    if _cookies:
-                        await context.add_cookies(_cookies)
-                        logger.info(f"FlareSolverr injected {len(_cookies)} cookies via Playwright")
-                    else:
-                        logger.warning("FlareSolverr no valid cookies to inject via Playwright")
-                except Exception as e:
-                    logger.warning(f"FlareSolverr cookie inject failed: {e}")
+                await inject_cookies_playwright(context, self.flaresolverr_cookies, url, label="Playwright")
             self.page = await context.new_page()
 
             # Listen for all console events and handle errors

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -281,9 +281,9 @@ class fetcher(Fetcher):
             # SOCKS5 with authentication is not supported (yet)
             # https://github.com/microsoft/playwright/issues/10567
 
-            # Set user agent to prevent Cloudflare from blocking the browser
-            # Use the default one configured in the App.py model that's passed from fetch_site_status.py
-            _ua = self.flaresolverr_user_agent or manage_user_agent(headers=request_headers)
+            from changedetectionio.flaresolverr_pool import resolve_flaresolverr_user_agent
+
+            _ua = resolve_flaresolverr_user_agent(self.flaresolverr_user_agent, headers=request_headers)
             context = await browser.new_context(
                 accept_downloads=False,  # Should never be needed
                 # Enabled by default because sites such as GitHub need it for injected JavaScript.

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -182,7 +182,8 @@ class fetcher(Fetcher):
 
     def __init__(self, proxy_override=None, custom_browser_connection_url=None, **kwargs):
         super().__init__(**kwargs)
-
+        self.flaresolverr_cookies = kwargs.get('flaresolverr_cookies')
+        self.flaresolverr_user_agent = kwargs.get('flaresolverr_user_agent')
         self.browser_type = os.getenv("PLAYWRIGHT_BROWSER_TYPE", 'chromium').strip('"')
 
         if custom_browser_connection_url:
@@ -282,6 +283,7 @@ class fetcher(Fetcher):
 
             # Set user agent to prevent Cloudflare from blocking the browser
             # Use the default one configured in the App.py model that's passed from fetch_site_status.py
+            _ua = self.flaresolverr_user_agent or manage_user_agent(headers=request_headers)
             context = await browser.new_context(
                 accept_downloads=False,  # Should never be needed
                 # Enabled by default because sites such as GitHub need it for injected JavaScript.
@@ -291,9 +293,24 @@ class fetcher(Fetcher):
                 ignore_https_errors=True,
                 proxy=self.proxy,
                 service_workers=os.getenv('PLAYWRIGHT_SERVICE_WORKERS', 'allow'), # Should be `allow` or `block` - sites like YouTube can transmit large amounts of data via Service Workers
-                user_agent=manage_user_agent(headers=request_headers),
+                user_agent=_ua,
             )
-
+            if self.flaresolverr_cookies:
+                try:
+                    _cookies = []
+                    for c in self.flaresolverr_cookies:
+                        _cc = dict(c)
+                        if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
+                            _cc['expires'] = float(_cc['expires'])
+                        if 'sameSite' in _cc:
+                            _v = _cc.pop('sameSite')
+                            if _v in ('Strict', 'Lax', 'None'):
+                                _cc['sameSite'] = _v
+                        _cookies.append(_cc)
+                    await context.add_cookies(_cookies)
+                    logger.info(f"FlareSolverr injected {len(_cookies)} cookies via Playwright")
+                except Exception as e:
+                    logger.warning(f"FlareSolverr cookie inject failed: {e}")
             self.page = await context.new_page()
 
             # Listen for all console events and handle errors

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -297,18 +297,33 @@ class fetcher(Fetcher):
             )
             if self.flaresolverr_cookies:
                 try:
+                    from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+
+                    _host = urlparse(url).netloc.lower() if url else ""
                     _cookies = []
                     for c in self.flaresolverr_cookies:
                         _cc = dict(c)
+                        # Validate domain to prevent evil.com injection
+                        _domain = _cc.get("domain")
+                        if _domain and not is_cookie_domain_valid(_domain, _host):
+                            logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
+                            continue
                         if 'expires' in _cc and isinstance(_cc['expires'], (int, float)):
                             _cc['expires'] = float(_cc['expires'])
                         if 'sameSite' in _cc:
                             _v = _cc.pop('sameSite')
-                            if _v in ('Strict', 'Lax', 'None'):
-                                _cc['sameSite'] = _v
+                            # Case-insensitive: Chrome may return 'lax' lower
+                            if isinstance(_v, str) and _v.capitalize() in ('Strict', 'Lax', 'None'):
+                                _cc['sameSite'] = _v.capitalize()
+                        # If no domain and no url, scope to current url
+                        if not _cc.get("domain") and not _cc.get("url") and url:
+                            _cc["url"] = url
                         _cookies.append(_cc)
-                    await context.add_cookies(_cookies)
-                    logger.info(f"FlareSolverr injected {len(_cookies)} cookies via Playwright")
+                    if _cookies:
+                        await context.add_cookies(_cookies)
+                        logger.info(f"FlareSolverr injected {len(_cookies)} cookies via Playwright")
+                    else:
+                        logger.warning("FlareSolverr no valid cookies to inject via Playwright")
                 except Exception as e:
                     logger.warning(f"FlareSolverr cookie inject failed: {e}")
             self.page = await context.new_page()

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -364,26 +364,11 @@ class fetcher(Fetcher):
             # But I could never get it to fire reliably, so we just inject it straight after
             await inject_evasions_into_page(self.page)
 
-        # This user agent is similar to what was used when tweaking the evasions in inject_evasions_into_page(..)
-        # Work on a copy to avoid mutating the caller's CaseInsensitiveDict
-        _headers_copy = dict(request_headers) if request_headers else {}
-        if self.flaresolverr_user_agent:
-            user_agent = self.flaresolverr_user_agent
-            await self.page.setUserAgent(user_agent)
-            _headers_copy.pop('User-Agent', None)
-            _headers_copy.pop('user-agent', None)
-        else:
-            user_agent = None
-            if _headers_copy.get('User-Agent'):
-                user_agent = _headers_copy.pop('User-Agent').strip()
-                await self.page.setUserAgent(user_agent)
-            elif _headers_copy.get('user-agent'):
-                user_agent = _headers_copy.pop('user-agent').strip()
-                await self.page.setUserAgent(user_agent)
-            if not user_agent:
-                await self.page.setUserAgent(manage_user_agent(headers=_headers_copy, current_ua=await self.page.evaluate('navigator.userAgent')))
-        # Use the copy for subsequent header handling
-        request_headers = _headers_copy
+        from changedetectionio.flaresolverr_pool import apply_flaresolverr_user_agent_puppeteer
+
+        request_headers = await apply_flaresolverr_user_agent_puppeteer(
+            self.page, self.flaresolverr_user_agent, request_headers
+        )
 
         if self.flaresolverr_cookies:
             from changedetectionio.flaresolverr_pool import inject_cookies_puppeteer

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -207,6 +207,8 @@ class fetcher(Fetcher):
         # Set up here so run()'s finally can always report, even if we never got as far as a page.
         self.page_errors = []
 
+        self.flaresolverr_cookies = kwargs.get('flaresolverr_cookies')
+        self.flaresolverr_user_agent = kwargs.get('flaresolverr_user_agent')
         if custom_browser_connection_url:
             self.browser_connection_is_custom = True
             self.browser_connection_url = custom_browser_connection_url
@@ -363,17 +365,32 @@ class fetcher(Fetcher):
             await inject_evasions_into_page(self.page)
 
         # This user agent is similar to what was used when tweaking the evasions in inject_evasions_into_page(..)
-        user_agent = None
-        if request_headers and request_headers.get('User-Agent'):
-            # Request_headers should now be CaaseInsensitiveDict
-            # Remove it so it's not sent again with headers after
-            user_agent = request_headers.pop('User-Agent').strip()
+        if self.flaresolverr_user_agent:
+            user_agent = self.flaresolverr_user_agent
             await self.page.setUserAgent(user_agent)
+            try:
+                request_headers.pop('User-Agent', None)
+            except Exception:
+                pass
+        else:
+            user_agent = None
+            if request_headers and request_headers.get('User-Agent'):
+                user_agent = request_headers.pop('User-Agent').strip()
+                await self.page.setUserAgent(user_agent)
+            if not user_agent:
+                await self.page.setUserAgent(manage_user_agent(headers=request_headers, current_ua=await self.page.evaluate('navigator.userAgent')))
+        if self.flaresolverr_user_agent:
+            try:
+                await self.page.setUserAgent(self.flaresolverr_user_agent)
+            except Exception:
+                pass
 
-        if not user_agent:
-            # Attempt to strip 'HeadlessChrome' etc
-            await self.page.setUserAgent(manage_user_agent(headers=request_headers, current_ua=await self.page.evaluate('navigator.userAgent')))
-
+        if self.flaresolverr_cookies:
+            try:
+                await self.page.setCookie(*self.flaresolverr_cookies)
+                logger.info(f"FlareSolverr injected {len(self.flaresolverr_cookies)} cookies via Puppeteer")
+            except Exception as e:
+                logger.warning(f"FlareSolverr cookie inject failed: {e}")
         await _configure_puppeteer_csp(self.page)
         if request_headers:
             await self.page.setExtraHTTPHeaders(request_headers)

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -387,8 +387,21 @@ class fetcher(Fetcher):
 
         if self.flaresolverr_cookies:
             try:
-                await self.page.setCookie(*self.flaresolverr_cookies)
-                logger.info(f"FlareSolverr injected {len(self.flaresolverr_cookies)} cookies via Puppeteer")
+                from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+
+                _host = urlparse(url).netloc.lower() if url else ""
+                _filtered = []
+                for c in self.flaresolverr_cookies:
+                    _domain = c.get("domain")
+                    if _domain and not is_cookie_domain_valid(_domain, _host):
+                        logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
+                        continue
+                    _filtered.append(c)
+                if _filtered:
+                    await self.page.setCookie(*_filtered)
+                    logger.info(f"FlareSolverr injected {len(_filtered)} cookies via Puppeteer")
+                else:
+                    logger.warning("FlareSolverr no valid cookies to inject via Puppeteer")
             except Exception as e:
                 logger.warning(f"FlareSolverr cookie inject failed: {e}")
         await _configure_puppeteer_csp(self.page)

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -365,25 +365,25 @@ class fetcher(Fetcher):
             await inject_evasions_into_page(self.page)
 
         # This user agent is similar to what was used when tweaking the evasions in inject_evasions_into_page(..)
+        # Work on a copy to avoid mutating the caller's CaseInsensitiveDict
+        _headers_copy = dict(request_headers) if request_headers else {}
         if self.flaresolverr_user_agent:
             user_agent = self.flaresolverr_user_agent
             await self.page.setUserAgent(user_agent)
-            try:
-                request_headers.pop('User-Agent', None)
-            except Exception:
-                pass
+            _headers_copy.pop('User-Agent', None)
+            _headers_copy.pop('user-agent', None)
         else:
             user_agent = None
-            if request_headers and request_headers.get('User-Agent'):
-                user_agent = request_headers.pop('User-Agent').strip()
+            if _headers_copy.get('User-Agent'):
+                user_agent = _headers_copy.pop('User-Agent').strip()
+                await self.page.setUserAgent(user_agent)
+            elif _headers_copy.get('user-agent'):
+                user_agent = _headers_copy.pop('user-agent').strip()
                 await self.page.setUserAgent(user_agent)
             if not user_agent:
-                await self.page.setUserAgent(manage_user_agent(headers=request_headers, current_ua=await self.page.evaluate('navigator.userAgent')))
-        if self.flaresolverr_user_agent:
-            try:
-                await self.page.setUserAgent(self.flaresolverr_user_agent)
-            except Exception:
-                pass
+                await self.page.setUserAgent(manage_user_agent(headers=_headers_copy, current_ua=await self.page.evaluate('navigator.userAgent')))
+        # Use the copy for subsequent header handling
+        request_headers = _headers_copy
 
         if self.flaresolverr_cookies:
             try:

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -386,24 +386,9 @@ class fetcher(Fetcher):
         request_headers = _headers_copy
 
         if self.flaresolverr_cookies:
-            try:
-                from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+            from changedetectionio.flaresolverr_pool import inject_cookies_puppeteer
 
-                _host = urlparse(url).netloc.lower() if url else ""
-                _filtered = []
-                for c in self.flaresolverr_cookies:
-                    _domain = c.get("domain")
-                    if _domain and not is_cookie_domain_valid(_domain, _host):
-                        logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
-                        continue
-                    _filtered.append(c)
-                if _filtered:
-                    await self.page.setCookie(*_filtered)
-                    logger.info(f"FlareSolverr injected {len(_filtered)} cookies via Puppeteer")
-                else:
-                    logger.warning("FlareSolverr no valid cookies to inject via Puppeteer")
-            except Exception as e:
-                logger.warning(f"FlareSolverr cookie inject failed: {e}")
+            await inject_cookies_puppeteer(self.page, self.flaresolverr_cookies, url, label="Puppeteer")
         await _configure_puppeteer_csp(self.page)
         if request_headers:
             await self.page.setExtraHTTPHeaders(request_headers)

--- a/changedetectionio/content_fetchers/webdriver_selenium.py
+++ b/changedetectionio/content_fetchers/webdriver_selenium.py
@@ -30,6 +30,8 @@ class fetcher(Fetcher):
 
     def __init__(self, proxy_override=None, custom_browser_connection_url=None, **kwargs):
         super().__init__(**kwargs)
+        self.flaresolverr_cookies = kwargs.get('flaresolverr_cookies')
+        self.flaresolverr_user_agent = kwargs.get('flaresolverr_user_agent')
         from urllib.parse import urlparse
         from selenium.webdriver.common.proxy import Proxy
 
@@ -127,6 +129,22 @@ class fetcher(Fetcher):
                 raise e
 
             try:
+                if self.flaresolverr_cookies:
+                    try:
+                        driver.get(url)
+                        for c in self.flaresolverr_cookies:
+                            _cc = dict(c)
+                            _cc.pop('expires', None)
+                            _cc.pop('sameSite', None)
+                            if _cc.get('domain', '').startswith('.'):
+                                _cc['domain'] = _cc['domain'].lstrip('.')
+                            try:
+                                driver.add_cookie(_cc)
+                            except Exception:
+                                pass
+                        logger.info(f"FlareSolverr injected {len(self.flaresolverr_cookies)} cookies via Selenium")
+                    except Exception as e:
+                        logger.warning(f"FlareSolverr cookie inject failed: {e}")
                 driver.get(url)
 
                 if not "--window-size" in os.getenv("CHROME_OPTIONS", ""):

--- a/changedetectionio/content_fetchers/webdriver_selenium.py
+++ b/changedetectionio/content_fetchers/webdriver_selenium.py
@@ -130,31 +130,11 @@ class fetcher(Fetcher):
 
             try:
                 if self.flaresolverr_cookies:
-                    try:
-                        from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
-                        from urllib.parse import urlparse as _urlparse
+                    from changedetectionio.flaresolverr_pool import inject_cookies_selenium
 
-                        _host = _urlparse(url).netloc.lower() if url else ""
-                        driver.get(url)
-                        _valid = 0
-                        for c in self.flaresolverr_cookies:
-                            _cc = dict(c)
-                            _domain = _cc.get("domain", "")
-                            if _domain and not is_cookie_domain_valid(_domain, _host):
-                                logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
-                                continue
-                            _cc.pop('expires', None)
-                            _cc.pop('sameSite', None)
-                            if _cc.get('domain', '').startswith('.'):
-                                _cc['domain'] = _cc['domain'].lstrip('.')
-                            try:
-                                driver.add_cookie(_cc)
-                                _valid += 1
-                            except Exception:
-                                pass
-                        logger.info(f"FlareSolverr injected {_valid} cookies via Selenium")
-                    except Exception as e:
-                        logger.warning(f"FlareSolverr cookie inject failed: {e}")
+                    # Need to be on domain before adding cookies
+                    driver.get(url)
+                    inject_cookies_selenium(driver, self.flaresolverr_cookies, url, label="Selenium")
                 driver.get(url)
 
                 if not "--window-size" in os.getenv("CHROME_OPTIONS", ""):

--- a/changedetectionio/content_fetchers/webdriver_selenium.py
+++ b/changedetectionio/content_fetchers/webdriver_selenium.py
@@ -131,18 +131,28 @@ class fetcher(Fetcher):
             try:
                 if self.flaresolverr_cookies:
                     try:
+                        from changedetectionio.flaresolverr_pool import is_cookie_domain_valid
+                        from urllib.parse import urlparse as _urlparse
+
+                        _host = _urlparse(url).netloc.lower() if url else ""
                         driver.get(url)
+                        _valid = 0
                         for c in self.flaresolverr_cookies:
                             _cc = dict(c)
+                            _domain = _cc.get("domain", "")
+                            if _domain and not is_cookie_domain_valid(_domain, _host):
+                                logger.warning(f"FlareSolverr cookie domain mismatch: {_domain} vs host {_host} — dropping")
+                                continue
                             _cc.pop('expires', None)
                             _cc.pop('sameSite', None)
                             if _cc.get('domain', '').startswith('.'):
                                 _cc['domain'] = _cc['domain'].lstrip('.')
                             try:
                                 driver.add_cookie(_cc)
+                                _valid += 1
                             except Exception:
                                 pass
-                        logger.info(f"FlareSolverr injected {len(self.flaresolverr_cookies)} cookies via Selenium")
+                        logger.info(f"FlareSolverr injected {_valid} cookies via Selenium")
                     except Exception as e:
                         logger.warning(f"FlareSolverr cookie inject failed: {e}")
                 driver.get(url)
@@ -202,7 +212,7 @@ class fetcher(Fetcher):
             driver.quit()
 
         # Run the selenium operations in a thread pool to avoid blocking the event loop
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _run_sync)
 
 

--- a/changedetectionio/flaresolverr_pool.py
+++ b/changedetectionio/flaresolverr_pool.py
@@ -1,0 +1,245 @@
+import hashlib
+import os
+from collections import OrderedDict
+from urllib.parse import urlparse
+
+from loguru import logger
+
+
+class FlareSolverrException(Exception):
+    pass
+
+
+def get_flaresolverr_url():
+    return os.getenv("FLARESOLVERR_URL", "").strip().strip('"').strip("'")
+
+
+def is_flaresolverr_enabled():
+    return bool(get_flaresolverr_url())
+
+
+def get_flaresolverr_max_sessions():
+    try:
+        return max(0, int(os.getenv("FLARESOLVERR_MAX_SESSIONS", "10")))
+    except ValueError:
+        return 10
+
+
+def get_flaresolverr_timeout():
+    try:
+        return max(1, int(os.getenv("FLARESOLVERR_TIMEOUT", "60")))
+    except ValueError:
+        return 60
+
+
+def get_flaresolverr_ttl_minutes():
+    try:
+        return max(1, int(os.getenv("FLARESOLVERR_TTL_MINUTES", "60")))
+    except ValueError:
+        return 60
+
+
+def is_flaresolverr_effective(watch, datastore):
+    if not is_flaresolverr_enabled():
+        return False
+    # Watch-level override: system | enabled | disabled
+    val = (
+        (watch.get("flaresolverr") or "system").lower()
+        if isinstance(watch.get("flaresolverr"), str)
+        else "system"
+    )
+    if val == "enabled":
+        return True
+    if val == "disabled":
+        return False
+    # system -> fallback to global
+    # Support both application and requests locations for backwards compat
+    global_enabled = datastore.data["settings"]["application"].get("flaresolverr_enabled")
+    if global_enabled is None:
+        global_enabled = datastore.data["settings"]["requests"].get("flaresolverr_enabled")
+    return bool(global_enabled)
+
+
+def _host_from_url(url):
+    try:
+        return urlparse(url).netloc.lower()
+    except Exception:
+        return url
+
+
+def _session_id_for_host(host):
+    h = hashlib.sha256(host.encode("utf-8")).hexdigest()[:12]
+    return f"cdio-{h}"
+
+
+class FlarePool:
+    def __init__(self, max_sessions=None, ttl_minutes=None, timeout=None, flaresolverr_url=None):
+        self.max_sessions = (
+            max_sessions if max_sessions is not None else get_flaresolverr_max_sessions()
+        )
+        self.ttl_minutes = (
+            ttl_minutes if ttl_minutes is not None else get_flaresolverr_ttl_minutes()
+        )
+        self.timeout = timeout if timeout is not None else get_flaresolverr_timeout()
+        self.flaresolverr_url = (
+            flaresolverr_url if flaresolverr_url is not None else get_flaresolverr_url()
+        )
+        # host -> {session_id, cookies, userAgent, ts}
+        self._lru = OrderedDict()
+
+    def _ensure_url(self):
+        if not self.flaresolverr_url:
+            self.flaresolverr_url = get_flaresolverr_url()
+        # Re-read dynamic envs
+        self.max_sessions = get_flaresolverr_max_sessions()
+        self.ttl_minutes = get_flaresolverr_ttl_minutes()
+        self.timeout = get_flaresolverr_timeout()
+
+    def _evict_if_needed(self):
+        while self.max_sessions > 0 and len(self._lru) >= self.max_sessions:
+            old_host, old_data = self._lru.popitem(last=False)
+            sid = old_data.get("session_id")
+            logger.info(f"FlareSolverr LRU evict host {old_host} session {sid}")
+            try:
+                self._destroy_session(sid)
+            except Exception as e:
+                logger.debug(f"Failed to destroy evicted session {sid}: {e}")
+
+    def _destroy_session(self, session_id):
+        if not session_id:
+            return
+        self._ensure_url()
+        if not self.flaresolverr_url:
+            return
+        try:
+            import requests
+
+            payload = {"cmd": "sessions.destroy", "session": session_id}
+            requests.post(self.flaresolverr_url, json=payload, timeout=5)
+            logger.debug(f"Destroyed FlareSolverr session {session_id}")
+        except Exception as e:
+            logger.debug(f"Error destroying FlareSolverr session {session_id}: {e}")
+
+    def clear(self):
+        for _, data in list(self._lru.items()):
+            try:
+                self._destroy_session(data.get("session_id"))
+            except Exception:
+                pass
+        self._lru.clear()
+
+    def get_cached(self, url):
+        host = _host_from_url(url)
+        data = self._lru.get(host)
+        if data:
+            # move to end (most recent)
+            self._lru.move_to_end(host)
+        return data
+
+    def solve(self, url, proxy_url=None, method="GET", post_data=None):
+        self._ensure_url()
+        if not self.flaresolverr_url:
+            raise FlareSolverrException("FLARESOLVERR_URL not set")
+
+        host = _host_from_url(url)
+        # Check cache first? No, we always solve fresh but reuse session_id for warmth.
+        # LRU handles session reuse.
+        session_id = None
+        if self.max_sessions > 0:
+            # Reuse or create session_id for this host
+            cached = self._lru.get(host)
+            if cached:
+                session_id = cached.get("session_id")
+                self._lru.move_to_end(host)
+            else:
+                session_id = _session_id_for_host(host)
+                # Evict before adding new host
+                self._evict_if_needed()
+                # Insert placeholder; will fill after solve
+                self._lru[host] = {"session_id": session_id}
+        else:
+            # Ephemeral, no session
+            session_id = None
+
+        payload = {
+            "cmd": f"request.{method.lower()}" if method.upper() == "POST" else "request.get",
+            "url": url,
+            "maxTimeout": self.timeout * 1000,
+        }
+        if session_id:
+            payload["session"] = session_id
+            payload["session_ttl_minutes"] = self.ttl_minutes
+        if proxy_url:
+            payload["proxy"] = {"url": proxy_url}
+        if method.upper() == "POST" and post_data is not None:
+            payload["postData"] = post_data
+
+        logger.info(f"FlareSolverr solve host={host} session={session_id} url={url}")
+
+        try:
+            import requests
+
+            resp = requests.post(self.flaresolverr_url, json=payload, timeout=self.timeout + 5)
+        except Exception as e:
+            raise FlareSolverrException(f"FlareSolverr request failed: {e}") from e
+
+        try:
+            data = resp.json()
+        except Exception as e:
+            raise FlareSolverrException(
+                f"FlareSolverr invalid JSON: {e} status={resp.status_code}"
+            ) from e
+
+        status = data.get("status")
+        message = data.get("message", "")
+        solution = data.get("solution") or {}
+
+        if status != "ok":
+            # If session was used and challenge failed, destroy it so next try is fresh
+            if session_id and self.max_sessions > 0:
+                try:
+                    self._destroy_session(session_id)
+                    self._lru.pop(host, None)
+                except Exception:
+                    pass
+            raise FlareSolverrException(f"FlareSolverr error status={status} msg={message}")
+
+        cookies = solution.get("cookies") or []
+        ua = solution.get("userAgent")
+        response_html = solution.get("response") or ""
+        resp_url = solution.get("url") or url
+        resp_status = solution.get("status")
+
+        # Validate we got at least cookies or response
+        if not cookies and not response_html:
+            raise FlareSolverrException(
+                f"FlareSolverr empty solution status={status} msg={message}"
+            )
+
+        # Update LRU cache
+        if self.max_sessions > 0 and host in self._lru:
+            self._lru[host].update({"cookies": cookies, "userAgent": ua, "response": response_html})
+
+        return {
+            "cookies": cookies,
+            "userAgent": ua,
+            "response": response_html,
+            "url": resp_url,
+            "status": resp_status,
+            "headers": solution.get("headers") or {},
+            "session_id": session_id,
+        }
+
+
+# Global singleton shared between A and C paths
+_global_pool = None
+
+
+def get_global_pool():
+    global _global_pool
+    if _global_pool is None:
+        _global_pool = FlarePool()
+    else:
+        # Refresh env-driven settings
+        _global_pool._ensure_url()
+    return _global_pool

--- a/changedetectionio/flaresolverr_pool.py
+++ b/changedetectionio/flaresolverr_pool.py
@@ -104,6 +104,107 @@ def is_cookie_domain_valid(cookie_domain, host):
     return host == domain or host.endswith("." + domain)
 
 
+def normalize_flaresolverr_cookies(cookies, url):
+    """Normalize and filter FlareSolverr cookies for browser injection.
+
+    Shared helper to deduplicate cookie handling across Playwright,
+    Puppeteer, Selenium and BrowserSteps. Validates domain against host,
+    normalizes expires/sameSite, and scopes url-less cookies to *url*.
+
+    Returns filtered list (may be empty). Logs warnings for drops.
+    """
+    if not cookies:
+        return []
+    host = urlparse(url).netloc.lower() if url else ""
+    normalized = []
+    for c in cookies:
+        try:
+            cc = dict(c)
+        except Exception:
+            continue
+        domain = cc.get("domain")
+        if domain and not is_cookie_domain_valid(domain, host):
+            logger.warning(f"FlareSolverr cookie domain mismatch: {domain} vs host {host} — dropping")
+            continue
+        if "expires" in cc and isinstance(cc["expires"], (int, float)):
+            try:
+                cc["expires"] = float(cc["expires"])
+            except Exception:
+                cc.pop("expires", None)
+        if "sameSite" in cc:
+            v = cc.pop("sameSite")
+            if isinstance(v, str) and v.capitalize() in ("Strict", "Lax", "None"):
+                cc["sameSite"] = v.capitalize()
+        if not cc.get("domain") and not cc.get("url") and url:
+            cc["url"] = url
+        normalized.append(cc)
+    return normalized
+
+
+async def inject_cookies_playwright(context, cookies, url, label="Playwright"):
+    """Inject normalized FlareSolverr cookies into a Playwright context."""
+    filtered = normalize_flaresolverr_cookies(cookies, url)
+    if not filtered:
+        if cookies:
+            logger.warning(f"FlareSolverr no valid cookies to inject via {label}")
+        return 0
+    try:
+        await context.add_cookies(filtered)
+        logger.info(f"FlareSolverr injected {len(filtered)} cookies via {label}")
+        return len(filtered)
+    except Exception as e:
+        logger.warning(f"FlareSolverr cookie inject failed ({label}): {e}")
+        return 0
+
+
+async def inject_cookies_puppeteer(page, cookies, url, label="Puppeteer"):
+    """Inject normalized FlareSolverr cookies into a Puppeteer page."""
+    filtered = normalize_flaresolverr_cookies(cookies, url)
+    if not filtered:
+        if cookies:
+            logger.warning(f"FlareSolverr no valid cookies to inject via {label}")
+        return 0
+    try:
+        await page.setCookie(*filtered)
+        logger.info(f"FlareSolverr injected {len(filtered)} cookies via {label}")
+        return len(filtered)
+    except Exception as e:
+        logger.warning(f"FlareSolverr cookie inject failed ({label}): {e}")
+        return 0
+
+
+def inject_cookies_selenium(driver, cookies, url, label="Selenium"):
+    """Inject FlareSolverr cookies via Selenium WebDriver.
+
+    Selenium cannot handle expires/sameSite the same way, so they are
+    stripped and leading dots are removed from domain.
+    """
+    filtered = normalize_flaresolverr_cookies(cookies, url)
+    if not filtered:
+        if cookies:
+            logger.warning(f"FlareSolverr no valid cookies to inject via {label}")
+        return 0
+    valid = 0
+    for cc in filtered:
+        # Selenium-specific tweaks
+        cc = dict(cc)
+        cc.pop("expires", None)
+        cc.pop("sameSite", None)
+        cc.pop("url", None)
+        if cc.get("domain", "").startswith("."):
+            cc["domain"] = cc["domain"].lstrip(".")
+        try:
+            driver.add_cookie(cc)
+            valid += 1
+        except Exception:
+            pass
+    if valid:
+        logger.info(f"FlareSolverr injected {valid} cookies via {label}")
+    else:
+        logger.warning(f"FlareSolverr no valid cookies to inject via {label}")
+    return valid
+
+
 class FlarePool:
     def __init__(self, max_sessions=None, ttl_minutes=None, timeout=None, flaresolverr_url=None):
         self.max_sessions = (

--- a/changedetectionio/flaresolverr_pool.py
+++ b/changedetectionio/flaresolverr_pool.py
@@ -427,3 +427,108 @@ def get_global_pool():
             # Refresh env-driven settings
             _global_pool._ensure_url()
         return _global_pool
+
+
+def resolve_flaresolverr_user_agent(flaresolverr_user_agent, headers=None):
+    """Resolve UA for browser contexts — FlareSolverr UA wins, else manage_user_agent."""
+    if flaresolverr_user_agent:
+        return flaresolverr_user_agent
+    # Lazy import to avoid circular deps (base -> validate_url, content_fetchers -> flaresolverr_pool)
+    try:
+        from changedetectionio.content_fetchers.base import manage_user_agent
+
+        return manage_user_agent(headers=headers)
+    except Exception:
+        return None
+
+
+async def apply_flaresolverr_user_agent_puppeteer(page, flaresolverr_user_agent, request_headers):
+    """Apply FlareSolverr UA or header UA to a Puppeteer page, returning filtered headers.
+
+    Handles User-Agent header deduplication: when UA is set via setUserAgent,
+    the corresponding header is removed from extra_http_headers to avoid
+    conflicting values. Returns (filtered_headers) dict to use for setExtraHTTPHeaders.
+    """
+    headers_copy = dict(request_headers) if request_headers else {}
+    try:
+        from changedetectionio.content_fetchers.base import manage_user_agent
+    except Exception:
+        manage_user_agent = None
+
+    if flaresolverr_user_agent:
+        try:
+            await page.setUserAgent(flaresolverr_user_agent)
+        except Exception:
+            pass
+        headers_copy.pop("User-Agent", None)
+        headers_copy.pop("user-agent", None)
+    else:
+        user_agent = None
+        if headers_copy.get("User-Agent"):
+            user_agent = headers_copy.pop("User-Agent").strip()
+            try:
+                await page.setUserAgent(user_agent)
+            except Exception:
+                pass
+        elif headers_copy.get("user-agent"):
+            user_agent = headers_copy.pop("user-agent").strip()
+            try:
+                await page.setUserAgent(user_agent)
+            except Exception:
+                pass
+        if not user_agent and manage_user_agent:
+            try:
+                current_ua = await page.evaluate("navigator.userAgent")
+            except Exception:
+                current_ua = None
+            ua = manage_user_agent(headers=headers_copy, current_ua=current_ua)
+            if ua:
+                try:
+                    await page.setUserAgent(ua)
+                except Exception:
+                    pass
+    return headers_copy
+
+
+async def async_flaresolverr_solve(url, proxy_url=None, method="GET", post_data=None):
+    """Async wrapper that runs blocking FlarePool.solve in FLARESOLVERR_EXECUTOR."""
+    import asyncio
+
+    pool = get_global_pool()
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        FLARESOLVERR_EXECUTOR, lambda: pool.solve(url, proxy_url=proxy_url, method=method, post_data=post_data)
+    )
+
+
+async def get_flaresolverr_solution_for_watch(watch, datastore, proxy_url=None, url_override=None):
+    """Shared helper for processors/base and browser_steps live UI.
+
+    - Checks is_flaresolverr_effective(watch, datastore)
+    - Renders POST body via jinja2 (watch.get('body')), truncates to 1MB
+    - Calls async_flaresolverr_solve with correct method/post_data
+    Returns solution dict or None if not effective. Raises FlareSolverrException on failure.
+    """
+    if not is_flaresolverr_effective(watch, datastore):
+        return None
+    url = url_override or watch.link
+    method = (watch.get("method") or "GET").upper()
+    body = watch.get("body")
+    if body:
+        try:
+            from changedetectionio.jinja2_custom import render as jinja_render
+
+            body = jinja_render(template_str=body)
+        except Exception:
+            pass
+        if body and len(body) > 1024 * 1024:
+            logger.warning(f"FlareSolverr POST body too large ({len(body)} bytes), truncating to 1MB for {url}")
+            body = body[:1024 * 1024]
+    post_data = body if method == "POST" else None
+    solution = await async_flaresolverr_solve(url, proxy_url=proxy_url, method=method, post_data=post_data)
+    try:
+        host = urlparse(url).netloc
+    except Exception:
+        host = url
+    logger.info(f"FlareSolverr solved {url} host={host} via session {solution.get('session_id')}")
+    return solution

--- a/changedetectionio/flaresolverr_pool.py
+++ b/changedetectionio/flaresolverr_pool.py
@@ -1,9 +1,17 @@
 import hashlib
 import os
+import threading
+import time
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 
 from loguru import logger
+
+# Dedicated executor for blocking FlareSolverr HTTP calls — avoids starving the loop's default executor
+# which is also used by validate_fetch_url_async and other I/O. 5 workers is enough for 10 concurrent watches
+# with 60s timeout without exhausting the default pool (min(32, cpu+4) ≈10).
+FLARESOLVERR_EXECUTOR = ThreadPoolExecutor(max_workers=5, thread_name_prefix="FlareSolverr")
 
 
 class FlareSolverrException(Exception):
@@ -15,7 +23,19 @@ def get_flaresolverr_url():
 
 
 def is_flaresolverr_enabled():
-    return bool(get_flaresolverr_url())
+    url = get_flaresolverr_url()
+    if not url:
+        return False
+    # Basic safety: must be http(s) and not file://, no backslash, valid URL — but allow private/docker DNS
+    if "\\" in url:
+        logger.warning(f"FLARESOLVERR_URL contains backslash — ignored: {url}")
+        return False
+    from changedetectionio.validate_url import is_safe_valid_url
+
+    if not is_safe_valid_url(url):
+        logger.warning(f"FLARESOLVERR_URL is not a safe http(s) URL: {url}")
+        return False
+    return True
 
 
 def get_flaresolverr_max_sessions():
@@ -72,6 +92,18 @@ def _session_id_for_host(host):
     return f"cdio-{h}"
 
 
+def is_cookie_domain_valid(cookie_domain, host):
+    """Validate cookie domain matches host to prevent session fixation via evil domain."""
+    if not cookie_domain:
+        return True  # No domain, will be scoped via url
+    # Strip port from host
+    host = host.split(":")[0].lower()
+    domain = cookie_domain.lstrip(".").lower()
+    if not domain:
+        return False
+    return host == domain or host.endswith("." + domain)
+
+
 class FlarePool:
     def __init__(self, max_sessions=None, ttl_minutes=None, timeout=None, flaresolverr_url=None):
         self.max_sessions = (
@@ -86,80 +118,121 @@ class FlarePool:
         )
         # host -> {session_id, cookies, userAgent, ts}
         self._lru = OrderedDict()
+        self._lock = threading.RLock()
 
     def _ensure_url(self):
-        if not self.flaresolverr_url:
-            self.flaresolverr_url = get_flaresolverr_url()
-        # Re-read dynamic envs
-        self.max_sessions = get_flaresolverr_max_sessions()
-        self.ttl_minutes = get_flaresolverr_ttl_minutes()
-        self.timeout = get_flaresolverr_timeout()
+        # Re-read dynamic envs under lock? Called from within locked sections and also from get_global_pool
+        with self._lock:
+            if not self.flaresolverr_url:
+                self.flaresolverr_url = get_flaresolverr_url()
+            # Re-read dynamic envs
+            self.max_sessions = get_flaresolverr_max_sessions()
+            self.ttl_minutes = get_flaresolverr_ttl_minutes()
+            self.timeout = get_flaresolverr_timeout()
+
+    def _is_expired(self, entry):
+        ts = entry.get("ts")
+        if not ts:
+            return False
+        return (time.time() - ts) > (self.ttl_minutes * 60)
 
     def _evict_if_needed(self):
-        while self.max_sessions > 0 and len(self._lru) >= self.max_sessions:
-            old_host, old_data = self._lru.popitem(last=False)
-            sid = old_data.get("session_id")
-            logger.info(f"FlareSolverr LRU evict host {old_host} session {sid}")
-            try:
-                self._destroy_session(sid)
-            except Exception as e:
-                logger.debug(f"Failed to destroy evicted session {sid}: {e}")
+        with self._lock:
+            # MAX=0 means ephemeral, no LRU at all — ensure empty
+            if self.max_sessions == 0:
+                # Clear any stale entries (should be empty, but defensive)
+                for _, data in list(self._lru.items()):
+                    try:
+                        self._destroy_session(data.get("session_id"))
+                    except Exception:
+                        pass
+                self._lru.clear()
+                return
+            while self.max_sessions > 0 and len(self._lru) >= self.max_sessions:
+                old_host, old_data = self._lru.popitem(last=False)
+                sid = old_data.get("session_id")
+                logger.info(f"FlareSolverr LRU evict host {old_host} session {sid}")
+                try:
+                    self._destroy_session(sid)
+                except Exception as e:
+                    logger.debug(f"Failed to destroy evicted session {sid}: {e}")
 
     def _destroy_session(self, session_id):
         if not session_id:
             return
-        self._ensure_url()
-        if not self.flaresolverr_url:
+        # _ensure_url already handles lock
+        url = self.flaresolverr_url or get_flaresolverr_url()
+        if not url:
             return
         try:
             import requests
 
             payload = {"cmd": "sessions.destroy", "session": session_id}
-            requests.post(self.flaresolverr_url, json=payload, timeout=5)
+            requests.post(url, json=payload, timeout=5)
             logger.debug(f"Destroyed FlareSolverr session {session_id}")
         except Exception as e:
             logger.debug(f"Error destroying FlareSolverr session {session_id}: {e}")
 
     def clear(self):
-        for _, data in list(self._lru.items()):
-            try:
-                self._destroy_session(data.get("session_id"))
-            except Exception:
-                pass
-        self._lru.clear()
+        with self._lock:
+            for _, data in list(self._lru.items()):
+                try:
+                    self._destroy_session(data.get("session_id"))
+                except Exception:
+                    pass
+            self._lru.clear()
 
     def get_cached(self, url):
         host = _host_from_url(url)
-        data = self._lru.get(host)
-        if data:
-            # move to end (most recent)
-            self._lru.move_to_end(host)
-        return data
+        with self._lock:
+            data = self._lru.get(host)
+            if data:
+                if self._is_expired(data):
+                    # Expired — evict
+                    try:
+                        self._destroy_session(data.get("session_id"))
+                    except Exception:
+                        pass
+                    self._lru.pop(host, None)
+                    return None
+                # move to end (most recent)
+                self._lru.move_to_end(host)
+            return data
 
     def solve(self, url, proxy_url=None, method="GET", post_data=None):
+        # SSRF gate for watch URL — defense in depth (processors/base already validates, but pool may be called from other paths)
+        from changedetectionio.validate_url import is_fetch_url_allowed
+
+        ok, reason = is_fetch_url_allowed(url)
+        if not ok:
+            raise FlareSolverrException(f"FlareSolverr blocked fetch URL: {reason}")
+
         self._ensure_url()
         if not self.flaresolverr_url:
             raise FlareSolverrException("FLARESOLVERR_URL not set")
 
         host = _host_from_url(url)
-        # Check cache first? No, we always solve fresh but reuse session_id for warmth.
-        # LRU handles session reuse.
         session_id = None
-        if self.max_sessions > 0:
-            # Reuse or create session_id for this host
-            cached = self._lru.get(host)
-            if cached:
-                session_id = cached.get("session_id")
-                self._lru.move_to_end(host)
+        with self._lock:
+            if self.max_sessions == 0:
+                session_id = None
             else:
-                session_id = _session_id_for_host(host)
-                # Evict before adding new host
-                self._evict_if_needed()
-                # Insert placeholder; will fill after solve
-                self._lru[host] = {"session_id": session_id}
-        else:
-            # Ephemeral, no session
-            session_id = None
+                cached = self._lru.get(host)
+                if cached and not self._is_expired(cached):
+                    session_id = cached.get("session_id")
+                    self._lru.move_to_end(host)
+                elif cached and self._is_expired(cached):
+                    try:
+                        self._destroy_session(cached.get("session_id"))
+                    except Exception:
+                        pass
+                    self._lru.pop(host, None)
+                    cached = None
+                if not cached:
+                    session_id = _session_id_for_host(host)
+                    self._evict_if_needed()
+                    # Insert placeholder with ts; will fill after solve
+                    self._lru[host] = {"session_id": session_id, "ts": time.time()}
 
         payload = {
             "cmd": f"request.{method.lower()}" if method.upper() == "POST" else "request.get",
@@ -197,11 +270,12 @@ class FlarePool:
         if status != "ok":
             # If session was used and challenge failed, destroy it so next try is fresh
             if session_id and self.max_sessions > 0:
-                try:
-                    self._destroy_session(session_id)
-                    self._lru.pop(host, None)
-                except Exception:
-                    pass
+                with self._lock:
+                    try:
+                        self._destroy_session(session_id)
+                        self._lru.pop(host, None)
+                    except Exception:
+                        pass
             raise FlareSolverrException(f"FlareSolverr error status={status} msg={message}")
 
         cookies = solution.get("cookies") or []
@@ -216,9 +290,12 @@ class FlarePool:
                 f"FlareSolverr empty solution status={status} msg={message}"
             )
 
-        # Update LRU cache
-        if self.max_sessions > 0 and host in self._lru:
-            self._lru[host].update({"cookies": cookies, "userAgent": ua, "response": response_html})
+        # Update LRU cache with ts
+        if self.max_sessions > 0:
+            with self._lock:
+                if host in self._lru:
+                    self._lru[host].update({"cookies": cookies, "userAgent": ua, "response": response_html, "ts": time.time()})
+                    self._lru.move_to_end(host)
 
         return {
             "cookies": cookies,
@@ -233,13 +310,15 @@ class FlarePool:
 
 # Global singleton shared between A and C paths
 _global_pool = None
+_global_pool_lock = threading.Lock()
 
 
 def get_global_pool():
     global _global_pool
-    if _global_pool is None:
-        _global_pool = FlarePool()
-    else:
-        # Refresh env-driven settings
-        _global_pool._ensure_url()
-    return _global_pool
+    with _global_pool_lock:
+        if _global_pool is None:
+            _global_pool = FlarePool()
+        else:
+            # Refresh env-driven settings
+            _global_pool._ensure_url()
+        return _global_pool

--- a/changedetectionio/flaresolverr_pool.py
+++ b/changedetectionio/flaresolverr_pool.py
@@ -206,6 +206,10 @@ class FlarePool:
         ok, reason = is_fetch_url_allowed(url)
         if not ok:
             raise FlareSolverrException(f"FlareSolverr blocked fetch URL: {reason}")
+        # Guard against huge POST bodies being forwarded as amplification vector
+        if post_data and len(post_data) > 1024 * 1024:
+            logger.warning(f"FlareSolverr postData too large ({len(post_data)} bytes) for {url}, truncating to 1MB")
+            post_data = post_data[:1024*1024]
 
         self._ensure_url()
         if not self.flaresolverr_url:

--- a/changedetectionio/forms.py
+++ b/changedetectionio/forms.py
@@ -867,6 +867,7 @@ class commonSettingsForm(Form):
         self.notification_urls.extra_notification_tokens = kwargs.get('extra_notification_tokens', {})
 
     fetch_backend = RadioField(_l('Fetch Method'), choices=content_fetchers.available_fetchers(), validators=[ValidateContentFetcherIsReady()])
+    flaresolverr = RadioField(_l('FlareSolverr'), choices=[('system', _l('System default')), ('enabled', _l('Enabled')), ('disabled', _l('Disabled'))], default='system')
     notification_body = TextAreaField(_l('Notification Body'), default='{{ watch_url }} had a change.', validators=[validators.Optional(), ValidateJinja2Template()])
     notification_format = SelectField(_l('Notification format'), choices=list(valid_notification_formats.items()))
     notification_title = StringField(_l('Notification Title'), default='ChangeDetection.io Notification - {{ watch_url }}', validators=[validators.Optional(), ValidateJinja2Template()])
@@ -1192,6 +1193,7 @@ class globalSettingsApplicationForm(commonSettingsForm):
                            )
     empty_pages_are_a_change =  BooleanField(_l('Treat empty pages as a change?'), default=False)
     fetch_backend = RadioField(_l('Fetch Method'), default="html_requests", choices=content_fetchers.available_fetchers(), validators=[ValidateContentFetcherIsReady()])
+    flaresolverr_enabled = BooleanField(_l('Enable FlareSolverr'), default=False)
     global_ignore_text = StringListField(_l('Ignore Text'), [ValidateListRegex()])
     global_subtractive_selectors = StringListField(_l('Remove elements'), [ValidateCSSJSONXPATHInput(allow_json=False)])
     ignore_whitespace = BooleanField(_l('Ignore whitespace'))

--- a/changedetectionio/model/App.py
+++ b/changedetectionio/model/App.py
@@ -27,6 +27,7 @@ class model(dict):
                 'requests': {
                     'extra_proxies': [], # Configurable extra proxies via the UI
                     'extra_browsers': [],  # Configurable extra proxies via the UI
+                    'flaresolverr_enabled': False,
                     'jitter_seconds': 0,
                     'proxy': None, # Preferred proxy connection
                     'time_between_check': {'weeks': None, 'days': None, 'hours': 3, 'minutes': None, 'seconds': None},
@@ -45,6 +46,7 @@ class model(dict):
                     'base_url' : None,
                     'empty_pages_are_a_change': False,
                     'fetch_backend': getenv("DEFAULT_FETCH_BACKEND", "html_requests"),
+                    'flaresolverr_enabled': False,
                     'filter_failure_notification_threshold_attempts': _FILTER_FAILURE_THRESHOLD_ATTEMPTS_DEFAULT,
                     'global_ignore_text': [], # List of text to ignore when calculating the comparison checksum
                     'global_subtractive_selectors': [],

--- a/changedetectionio/model/__init__.py
+++ b/changedetectionio/model/__init__.py
@@ -190,6 +190,7 @@ class watch_base(dict):
             'extract_lines_containing': [],  # Keep only lines containing these substrings (plain text, case-insensitive)
             'extract_text': [],  # Extract text by regex after filters
             'fetch_backend': 'system',  # plaintext, playwright etc
+            'flaresolverr': 'system',  # system|enabled|disabled
             'fetch_time': 0.0,
             'filter_failure_notification_send': strtobool(os.getenv('FILTER_FAILURE_NOTIFICATION_SEND_DEFAULT', 'True')),
             'filter_text_added': True,

--- a/changedetectionio/processors/base.py
+++ b/changedetectionio/processors/base.py
@@ -197,37 +197,15 @@ class difference_detection_processor():
 
         logger.debug(f"Using proxy '{proxy_url}' for {self.watch['uuid']}")
 
-        # FlareSolverr overlay - check env + global/per-watch toggle before fetcher run
+        # FlareSolverr overlay — shared helper handles effective check, body render, executor, logging
         flaresolverr_solution = None
-        flaresolverr_effective = False
         try:
-            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool, FLARESOLVERR_EXECUTOR
-            flaresolverr_effective = is_flaresolverr_effective(self.watch, self.datastore)
-        except Exception:
-            flaresolverr_effective = False
-        if flaresolverr_effective:
-            try:
-                import asyncio
-                pool = get_global_pool()
-                _method = self.watch.get('method') or 'GET'
-                _body = self.watch.get('body')
-                if _body:
-                    from changedetectionio.jinja2_custom import render as _jinja_render
-                    try:
-                        _body = _jinja_render(template_str=_body)
-                    except Exception:
-                        pass
-                    # Guard against amplification via huge POST bodies forwarded to FlareSolverr
-                    if _body and len(_body) > 1024 * 1024:
-                        logger.warning(f"FlareSolverr POST body too large ({len(_body)} bytes), truncating to 1MB for {url}")
-                        _body = _body[:1024*1024]
-                loop = asyncio.get_running_loop()
-                flaresolverr_solution = await loop.run_in_executor(FLARESOLVERR_EXECUTOR, lambda: pool.solve(url, proxy_url=proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
-                _host = __import__('urllib.parse', fromlist=['urlparse']).urlparse(url).netloc
-                logger.info(f"FlareSolverr solved {url} host={_host} via session {flaresolverr_solution.get('session_id')}")
-            except Exception as e:
-                logger.error(f"FlareSolverr solve failed for {url}: {e}")
-                raise Exception(f"FlareSolverr: {e}") from e
+            from changedetectionio.flaresolverr_pool import get_flaresolverr_solution_for_watch
+
+            flaresolverr_solution = await get_flaresolverr_solution_for_watch(self.watch, self.datastore, proxy_url=proxy_url)
+        except Exception as e:
+            logger.error(f"FlareSolverr solve failed for {url}: {e}")
+            raise Exception(f"FlareSolverr: {e}") from e
         is_bare = flaresolverr_solution is not None and prefer_fetch_backend == 'html_requests' and not self.watch.has_browser_steps
         if is_bare:
             self.fetcher = fetcher_obj(proxy_override=proxy_url, custom_browser_connection_url=custom_browser_connection_url, screenshot_format=self.screenshot_format)

--- a/changedetectionio/processors/base.py
+++ b/changedetectionio/processors/base.py
@@ -201,7 +201,7 @@ class difference_detection_processor():
         flaresolverr_solution = None
         flaresolverr_effective = False
         try:
-            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool
+            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool, FLARESOLVERR_EXECUTOR
             flaresolverr_effective = is_flaresolverr_effective(self.watch, self.datastore)
         except Exception:
             flaresolverr_effective = False
@@ -217,8 +217,8 @@ class difference_detection_processor():
                         _body = _jinja_render(template_str=_body)
                     except Exception:
                         pass
-                loop = asyncio.get_event_loop()
-                flaresolverr_solution = await loop.run_in_executor(None, lambda: pool.solve(url, proxy_url=proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
+                loop = asyncio.get_running_loop()
+                flaresolverr_solution = await loop.run_in_executor(FLARESOLVERR_EXECUTOR, lambda: pool.solve(url, proxy_url=proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
                 _host = __import__('urllib.parse', fromlist=['urlparse']).urlparse(url).netloc
                 logger.info(f"FlareSolverr solved {url} host={_host} via session {flaresolverr_solution.get('session_id')}")
             except Exception as e:
@@ -228,9 +228,6 @@ class difference_detection_processor():
         if is_bare:
             self.fetcher = fetcher_obj(proxy_override=proxy_url, custom_browser_connection_url=custom_browser_connection_url, screenshot_format=self.screenshot_format)
             self.fetcher.backend_name = prefer_fetch_backend + "+flaresolverr"
-            if self.watch.has_browser_steps:
-                self.fetcher.browser_steps = browser_steps_get_valid_steps(self.watch.get('browser_steps', []))
-                self.fetcher.browser_steps_screenshot_path = os.path.join(self.datastore.datastore_path, self.watch.get('uuid'))
             _resp = flaresolverr_solution.get('response') or ''
             _status = flaresolverr_solution.get('status') or 200
             _headers = flaresolverr_solution.get('headers') or {}

--- a/changedetectionio/processors/base.py
+++ b/changedetectionio/processors/base.py
@@ -217,6 +217,10 @@ class difference_detection_processor():
                         _body = _jinja_render(template_str=_body)
                     except Exception:
                         pass
+                    # Guard against amplification via huge POST bodies forwarded to FlareSolverr
+                    if _body and len(_body) > 1024 * 1024:
+                        logger.warning(f"FlareSolverr POST body too large ({len(_body)} bytes), truncating to 1MB for {url}")
+                        _body = _body[:1024*1024]
                 loop = asyncio.get_running_loop()
                 flaresolverr_solution = await loop.run_in_executor(FLARESOLVERR_EXECUTOR, lambda: pool.solve(url, proxy_url=proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
                 _host = __import__('urllib.parse', fromlist=['urlparse']).urlparse(url).netloc

--- a/changedetectionio/processors/base.py
+++ b/changedetectionio/processors/base.py
@@ -197,16 +197,65 @@ class difference_detection_processor():
 
         logger.debug(f"Using proxy '{proxy_url}' for {self.watch['uuid']}")
 
-        # Now call the fetcher (playwright/requests/etc) with arguments that only a fetcher would need.
-        # When browser_connection_url is None, it method should default to working out whats the best defaults (os env vars etc)
-        self.fetcher = fetcher_obj(proxy_override=proxy_url,
-                                   custom_browser_connection_url=custom_browser_connection_url,
-                                   screenshot_format=self.screenshot_format
-                                   )
-
-        # Stamp the resolved backend name so downstream consumers (processors, plugins)
-        # can read it directly instead of re-deriving it from the fetcher class name.
-        self.fetcher.backend_name = prefer_fetch_backend
+        # FlareSolverr overlay - check env + global/per-watch toggle before fetcher run
+        flaresolverr_solution = None
+        flaresolverr_effective = False
+        try:
+            from changedetectionio.flaresolverr_pool import is_flaresolverr_effective, get_global_pool
+            flaresolverr_effective = is_flaresolverr_effective(self.watch, self.datastore)
+        except Exception:
+            flaresolverr_effective = False
+        if flaresolverr_effective:
+            try:
+                import asyncio
+                pool = get_global_pool()
+                _method = self.watch.get('method') or 'GET'
+                _body = self.watch.get('body')
+                if _body:
+                    from changedetectionio.jinja2_custom import render as _jinja_render
+                    try:
+                        _body = _jinja_render(template_str=_body)
+                    except Exception:
+                        pass
+                loop = asyncio.get_event_loop()
+                flaresolverr_solution = await loop.run_in_executor(None, lambda: pool.solve(url, proxy_url=proxy_url, method=_method, post_data=_body if _method.upper() == 'POST' else None))
+                _host = __import__('urllib.parse', fromlist=['urlparse']).urlparse(url).netloc
+                logger.info(f"FlareSolverr solved {url} host={_host} via session {flaresolverr_solution.get('session_id')}")
+            except Exception as e:
+                logger.error(f"FlareSolverr solve failed for {url}: {e}")
+                raise Exception(f"FlareSolverr: {e}") from e
+        is_bare = flaresolverr_solution is not None and prefer_fetch_backend == 'html_requests' and not self.watch.has_browser_steps
+        if is_bare:
+            self.fetcher = fetcher_obj(proxy_override=proxy_url, custom_browser_connection_url=custom_browser_connection_url, screenshot_format=self.screenshot_format)
+            self.fetcher.backend_name = prefer_fetch_backend + "+flaresolverr"
+            if self.watch.has_browser_steps:
+                self.fetcher.browser_steps = browser_steps_get_valid_steps(self.watch.get('browser_steps', []))
+                self.fetcher.browser_steps_screenshot_path = os.path.join(self.datastore.datastore_path, self.watch.get('uuid'))
+            _resp = flaresolverr_solution.get('response') or ''
+            _status = flaresolverr_solution.get('status') or 200
+            _headers = flaresolverr_solution.get('headers') or {}
+            self.fetcher.content = _resp
+            self.fetcher.raw_content = _resp.encode('utf-8') if isinstance(_resp, str) else _resp
+            self.fetcher.status_code = _status
+            self.fetcher.headers = _headers
+            from changedetectionio.content_fetchers.exceptions import EmptyReply, Non200ErrorCodeReceived
+            _empty_pages_are_a_change = self.datastore.data['settings']['application'].get('empty_pages_are_a_change', False)
+            _ignore_status_codes = self.watch.get('ignore_status_codes', False)
+            if not _resp or not len(_resp.strip()):
+                if not _empty_pages_are_a_change:
+                    raise EmptyReply(url=url, status_code=_status)
+            if _status != 200 and not _ignore_status_codes:
+                raise Non200ErrorCodeReceived(url=url, status_code=_status, page_html=_resp)
+            await self.fetcher.quit(watch=self.watch)
+            if self.fetcher.content and isinstance(self.fetcher.content, str):
+                self.fetcher.content = self.fetcher.content.encode('utf-8', errors='replace').decode('utf-8')
+            return
+        if flaresolverr_solution is not None:
+            self.fetcher = fetcher_obj(proxy_override=proxy_url, custom_browser_connection_url=custom_browser_connection_url, screenshot_format=self.screenshot_format, flaresolverr_cookies=flaresolverr_solution.get('cookies'), flaresolverr_user_agent=flaresolverr_solution.get('userAgent'))
+            logger.info(f"FlareSolverr hybrid inject {len(flaresolverr_solution.get('cookies') or [])} cookies UA={flaresolverr_solution.get('userAgent')}")
+        else:
+            self.fetcher = fetcher_obj(proxy_override=proxy_url, custom_browser_connection_url=custom_browser_connection_url, screenshot_format=self.screenshot_format)
+        self.fetcher.backend_name = prefer_fetch_backend + ("+flaresolverr" if flaresolverr_solution else "")
 
         if self.watch.has_browser_steps:
             self.fetcher.browser_steps = browser_steps_get_valid_steps(self.watch.get('browser_steps', []))

--- a/changedetectionio/store/updates.py
+++ b/changedetectionio/store/updates.py
@@ -871,4 +871,18 @@ class DatastoreUpdatesMixin:
             restock.pop('prev_price', None)
             watch.commit()
 
+    def update_34(self):
+        """FlareSolverr overlay: add global flaresolverr_enabled and per-watch flaresolverr."""
+        if 'flaresolverr_enabled' not in self.data['settings']['application']:
+            self.data['settings']['application']['flaresolverr_enabled'] = False
+            logger.info("update_34: added application.flaresolverr_enabled=False")
+        if 'flaresolverr_enabled' not in self.data['settings']['requests']:
+            self.data['settings']['requests']['flaresolverr_enabled'] = False
+            logger.info("update_34: added requests.flaresolverr_enabled=False")
+        for uuid, watch in self.data['watching'].items():
+            if 'flaresolverr' not in watch:
+                watch['flaresolverr'] = 'system'
+                watch.commit()
+        logger.info("update_34: ensured per-watch flaresolverr='system'")
+
 

--- a/changedetectionio/translations/cs/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/cs/LC_MESSAGES/messages.po
@@ -653,6 +653,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "všechny možnosti jak lze prohlížeč rozpoznat."
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Připojit pomocí Bright Data proxy, více se lze dozvědět zde."
 
@@ -1987,6 +1998,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Vybrat proxy pro toto sledování"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Aktuálně je použito globální výchozí nastavení"
 
@@ -3134,6 +3156,22 @@ msgid "Fetch Method"
 msgstr "Nastavte metodu načítání"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Text oznámení"
 
@@ -3502,6 +3540,10 @@ msgstr "Kontrola zabezpečení přístupového tokenu API povolena"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Považovat prázdné stránky za změnu?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/de/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/de/LC_MESSAGES/messages.po
@@ -669,6 +669,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -2014,6 +2025,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Wählen Sie einen Proxy für diese Überwachung."
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Verwendung der aktuellen globalen Standardeinstellungen"
 
@@ -3183,6 +3205,22 @@ msgid "Fetch Method"
 msgstr "Fetch Methode"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Benachrichtigungstext"
 
@@ -3552,6 +3590,10 @@ msgstr "Sicherheitsüberprüfung des API-Zugriffstokens aktiviert"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Leere Seiten als Änderung behandeln?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
@@ -651,6 +651,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1981,6 +1992,17 @@ msgid "Choose a proxy for this watch"
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr ""
 
@@ -3126,6 +3148,22 @@ msgid "Fetch Method"
 msgstr ""
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr ""
 
@@ -3493,6 +3531,10 @@ msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
 msgstr ""
 
 #: changedetectionio/forms.py

--- a/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
@@ -651,6 +651,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1981,6 +1992,17 @@ msgid "Choose a proxy for this watch"
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr ""
 
@@ -3126,6 +3148,22 @@ msgid "Fetch Method"
 msgstr ""
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr ""
 
@@ -3493,6 +3531,10 @@ msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
 msgstr ""
 
 #: changedetectionio/forms.py

--- a/changedetectionio/translations/es/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/es/LC_MESSAGES/messages.po
@@ -671,6 +671,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "todas las formas en que se detecta el navegador"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -2032,6 +2043,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Elija un proxy para este monitor"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Uso de la configuración predeterminada global actual"
 
@@ -3199,6 +3221,22 @@ msgid "Fetch Method"
 msgstr "Método de recuperación"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Organismo de notificación"
 
@@ -3567,6 +3605,10 @@ msgstr "Comprobación de seguridad del token de acceso API habilitada"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "¿Tratar las páginas vacías como un cambio?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/fr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/fr/LC_MESSAGES/messages.po
@@ -657,6 +657,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1992,6 +2003,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Choisissez un proxy pour ce moniteur"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Utilisation des paramètres globaux par défaut actuels"
 
@@ -3139,6 +3161,22 @@ msgid "Fetch Method"
 msgstr "Définir la méthode de récupération"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Corps de notification"
 
@@ -3507,6 +3545,10 @@ msgstr "Contrôle de sécurité du jeton d'accès à l'API activé"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Considérer les pages vides comme un changement ?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/id/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/id/LC_MESSAGES/messages.po
@@ -672,6 +672,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "semua cara browser terdeteksi"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Hubungkan menggunakan proksi Bright Data, cari tahu selengkapnya di sini."
 
@@ -2074,6 +2085,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Pilih proksi untuk monitor ini"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Menggunakan pengaturan default global saat ini"
 
@@ -3239,6 +3261,22 @@ msgid "Fetch Method"
 msgstr "Metode Pengambilan"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Isi Notifikasi"
 
@@ -3607,6 +3645,10 @@ msgstr "Pemeriksaan keamanan token akses API diaktifkan"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Anggap halaman kosong sebagai perubahan?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/it/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/it/LC_MESSAGES/messages.po
@@ -653,6 +653,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1983,6 +1994,17 @@ msgid "Choose a proxy for this watch"
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr ""
 
@@ -3128,6 +3150,22 @@ msgid "Fetch Method"
 msgstr "Metodo di recupero"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Corpo notifica"
 
@@ -3496,6 +3534,10 @@ msgstr "Controllo sicurezza token API attivo"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Tratta pagine vuote come modifica?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/ja/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ja/LC_MESSAGES/messages.po
@@ -658,6 +658,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "ブラウザが検出されるすべての方法"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Bright Data プロキシを使用して接続します。詳細はこちら。"
 
@@ -1992,6 +2003,17 @@ msgid "Choose a proxy for this watch"
 msgstr "このウォッチのプロキシを選択"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "現在のグローバルデフォルト設定を使用中"
 
@@ -3145,6 +3167,22 @@ msgid "Fetch Method"
 msgstr "取得方式"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "通知本文"
 
@@ -3513,6 +3551,10 @@ msgstr "APIアクセストークンのセキュリティチェックを有効化
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "空のページを変更としてみなしますか？"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/ko/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ko/LC_MESSAGES/messages.po
@@ -653,6 +653,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "브라우저가 탐지되는 모든 방식"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Bright Data 프록시로 연결합니다. 자세한 내용은 여기에서 확인해 보세요."
 
@@ -1991,6 +2002,17 @@ msgid "Choose a proxy for this watch"
 msgstr "이 모니터링에 사용할 프록시를 선택합니다."
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "현재 전역 기본 설정 사용"
 
@@ -3136,6 +3158,22 @@ msgid "Fetch Method"
 msgstr "가져오기 방식"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "알림 본문"
 
@@ -3504,6 +3542,10 @@ msgstr "API 액세스 토큰 보안 확인 활성화"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "빈 페이지를 변경 사항으로 처리할까요?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/messages.pot
+++ b/changedetectionio/translations/messages.pot
@@ -650,6 +650,17 @@ msgid "all of the ways that the browser is detected"
 msgstr ""
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1980,6 +1991,17 @@ msgid "Choose a proxy for this watch"
 msgstr ""
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr ""
 
@@ -3125,6 +3147,22 @@ msgid "Fetch Method"
 msgstr ""
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr ""
 
@@ -3492,6 +3530,10 @@ msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
 msgstr ""
 
 #: changedetectionio/forms.py

--- a/changedetectionio/translations/pl/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/pl/LC_MESSAGES/messages.po
@@ -685,6 +685,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "wszystkie sposoby wykrywania przeglądarki"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Połącz się za pomocą serwerów proxy Bright Data – więcej informacji znajdziesz tutaj."
 
@@ -2117,6 +2128,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Wybierz serwer proxy dla tej obserwacji"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Korzystanie z aktualnych domyślnych ustawień globalnych"
 
@@ -3285,6 +3307,22 @@ msgid "Fetch Method"
 msgstr "Metoda pobierania"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Treść powiadomienia"
 
@@ -3653,6 +3691,10 @@ msgstr "Włączono kontrolę bezpieczeństwa tokenu dostępu do API"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Czy traktować puste strony jako zmianę?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
@@ -666,6 +666,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "todas as formas como o navegador é detectado"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Conecte-se usando proxies da Bright Data, saiba mais aqui."
 
@@ -2017,6 +2028,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Escolha um proxy para este monitoramento"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Usando as configurações globais padrão atuais"
 
@@ -3176,6 +3198,22 @@ msgid "Fetch Method"
 msgstr "Método de Busca"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Corpo da Notificação"
 
@@ -3544,6 +3582,10 @@ msgstr "Verificação de segurança do token de acesso à API ativada"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Tratar páginas vazias como uma mudança?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/ru/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ru/LC_MESSAGES/messages.po
@@ -672,6 +672,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "все способы обнаружения браузера"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "Подключайтесь с помощью прокси Bright Data, узнайте больше здесь."
 
@@ -2079,6 +2090,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Выберите прокси для этих часов"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Использование текущих глобальных настроек по умолчанию"
 
@@ -3244,6 +3266,22 @@ msgid "Fetch Method"
 msgstr "Метод выборки"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Орган уведомления"
 
@@ -3612,6 +3650,10 @@ msgstr "Проверка безопасности токена доступа к
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Считать пустые страницы изменением?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/tr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/tr/LC_MESSAGES/messages.po
@@ -670,6 +670,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "tarayıcının tespit edilmesinin tüm yolları"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -2020,6 +2031,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Bu izleyici için bir proxy seçin"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Mevcut genel varsayılan ayarlar kullanılıyor"
 
@@ -3179,6 +3201,22 @@ msgid "Fetch Method"
 msgstr "Getirme Yöntemi"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Bildirim Gövdesi"
 
@@ -3547,6 +3585,10 @@ msgstr "API erişim belirteci güvenlik kontrolü etkin"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Boş sayfalar değişiklik olarak değerlendirilsin mi?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/uk/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/uk/LC_MESSAGES/messages.po
@@ -658,6 +658,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "усі способи виявлення браузера"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -2001,6 +2012,17 @@ msgid "Choose a proxy for this watch"
 msgstr "Виберіть проксі для цього завдання"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "Використовуються поточні глобальні налаштування"
 
@@ -3158,6 +3180,22 @@ msgid "Fetch Method"
 msgstr "Метод завантаження"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "Тіло сповіщення"
 
@@ -3526,6 +3564,10 @@ msgstr "Перевірку безпеки токена доступу API уві
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "Вважати порожні сторінки зміною?"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/zh/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh/LC_MESSAGES/messages.po
@@ -656,6 +656,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "浏览器被识别的各种方式"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr ""
 
@@ -1986,6 +1997,17 @@ msgid "Choose a proxy for this watch"
 msgstr "为此监控项选择代理"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "使用当前全局默认设置"
 
@@ -3132,6 +3154,22 @@ msgid "Fetch Method"
 msgstr "抓取方式"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "通知正文"
 
@@ -3500,6 +3538,10 @@ msgstr "已启用 API 访问令牌安全检查"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "将空页面视为变更？"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -655,6 +655,17 @@ msgid "all of the ways that the browser is detected"
 msgstr "瀏覽器被偵測的所有方式"
 
 #: changedetectionio/blueprint/settings/templates/settings.html
+#, python-format
+msgid ""
+"When enabled, watches using \"System default\" will be fetched via FlareSolverr at %(url)s to bypass Cloudflare / "
+"DDoS-Guard challenges. Per-watch override is available in Edit Watch → Request."
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL=http://flaresolverr:8191/v1 to enable. See"
+msgstr ""
+
+#: changedetectionio/blueprint/settings/templates/settings.html
 msgid "Connect using Bright Data proxies, find out more here."
 msgstr "使用 Bright Data 代理伺服器進行連線，在此處了解更多資訊。"
 
@@ -1990,6 +2001,17 @@ msgid "Choose a proxy for this watch"
 msgstr "為此監測任務選擇代理伺服器"
 
 #: changedetectionio/blueprint/ui/templates/edit.html
+#, python-format
+msgid ""
+"Route this watch via FlareSolverr at %(url)s to bypass Cloudflare. \"System default\" follows Settings → Fetching → "
+"FlareSolverr."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
+msgid "FlareSolverr not configured — set FLARESOLVERR_URL to enable."
+msgstr ""
+
+#: changedetectionio/blueprint/ui/templates/edit.html
 msgid "Using the current global default settings"
 msgstr "使用目前全域預設設定"
 
@@ -3137,6 +3159,22 @@ msgid "Fetch Method"
 msgstr "抓取方式"
 
 #: changedetectionio/forms.py
+msgid "FlareSolverr"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "System default"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Enabled"
+msgstr ""
+
+#: changedetectionio/forms.py
+msgid "Disabled"
+msgstr ""
+
+#: changedetectionio/forms.py
 msgid "Notification Body"
 msgstr "通知內容"
 
@@ -3505,6 +3543,10 @@ msgstr "已啟用 API 存取權杖安全檢查"
 #: changedetectionio/forms.py
 msgid "Treat empty pages as a change?"
 msgstr "將空白頁面視為變更？"
+
+#: changedetectionio/forms.py
+msgid "Enable FlareSolverr"
+msgstr ""
 
 #: changedetectionio/forms.py
 msgid "Ignore Text"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,12 @@ services:
   #      - PLAYWRIGHT_BYPASS_CSP=false
   #
   #
+  #       FlareSolverr anti-bot bypass (undetected_chromedriver)
+  #      - FLARESOLVERR_URL=http://flaresolverr:8191/v1
+  #      - FLARESOLVERR_MAX_SESSIONS=10
+  #      - FLARESOLVERR_TTL_MINUTES=60
+  #      - FLARESOLVERR_TIMEOUT=60
+  #
   #       Alternative WebDriver/selenium URL, do not use "'s or 's! (old, deprecated, does not support screenshots very well, Can't handle custom headers etc)
   #      - WEBDRIVER_URL=http://browser-selenium-chrome:4444/wd/hub
   #
@@ -126,8 +132,24 @@ services:
 #              condition: service_started
 
 
-     # Sockpuppetbrowser is basically chrome wrapped in an API for allowing fast fetching of web-pages.
-     # RECOMMENDED FOR FETCHING PAGES WITH CHROME, be sure to enable the "PLAYWRIGHT_DRIVER_URL" env variable in the main changedetection container
+#    depends_on:
+#      flaresolverr:
+#        condition: service_started
+#    environment:
+#      - FLARESOLVERR_URL=http://flaresolverr:8191/v1
+#      - FLARESOLVERR_MAX_SESSIONS=10
+#      - FLARESOLVERR_TTL_MINUTES=60
+#    flaresolverr:
+#        image: ghcr.io/flaresolverr/flaresolverr:latest
+#        container_name: flaresolverr
+#        environment:
+#            - LOG_LEVEL=info
+#        ports:
+#            - 8191:8191
+#        restart: unless-stopped
+
+      # Sockpuppetbrowser is basically chrome wrapped in an API for allowing fast fetching of web-pages.
+      # RECOMMENDED FOR FETCHING PAGES WITH CHROME, be sure to enable the "PLAYWRIGHT_DRIVER_URL" env variable in the main changedetection container
 #    browser-sockpuppet-chrome:
 #        hostname: browser-sockpuppet-chrome
 #        image: dgtlmoon/sockpuppetbrowser:latest

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -345,6 +345,11 @@ components:
             - Plugin-provided fetchers (if installed)
           pattern: '^(system|html_requests|html_webdriver|extra_browser_.+)$'
           default: system
+        flaresolverr:
+          type: string
+          enum: [system, enabled, disabled]
+          default: system
+          description: FlareSolverr anti-bot bypass. `system` inherits global `application.flaresolverr_enabled`.
         headers:
           type: object
           additionalProperties:


### PR DESCRIPTION
## Summary

Adds optional [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) overlay to bypass Cloudflare / DDoS-Guard challenges, while preserving all existing browser and filtering features. No new `fetch_backend` — FlareSolverr runs as a lightweight overlay before the selected `html_requests` / `html_webdriver` fetcher.

Closes #1619, closes #1094 — relates to #4137, #2444, #1700, #2198

> **Reviewing:** Rebased on `master` `c2744dc0`; 3 commits — `a8ab5ff4 feat: FlareSolverr overlay (logic)` (14 files, 468+), `6bd4df3d fix: i18n` (templates consolidated to single `%(url)s` + catalog via `venv`), `d1c8cc2b fix: browser-steps live UI uses FlareSolverr`. Review `a8ab5ff4` alone for pure logic.

## How it works

* **Env gate:** `FLARESOLVERR_URL` (e.g. `http://flaresolverr:8191/v1`) must be set, otherwise no UI/code path is exposed.
* **Always Chrome in FlareSolverr:** every effective watch first `POST /v1 {cmd: request.get, session, maxTimeout, proxy, session_ttl_minutes}` to the daemon, which spins `undetected_chromedriver` `FlareSolverr/src/utils.py:132` `get_webdriver()` in `flaresolverr:8191` to solve `Just a moment...` and returns `solution{response, cookies[], userAgent, status, headers}` `FlareSolverr/src/dtos.py:10`. Shared `host -> session_id` LRU `OrderedDict` `changedetectionio/flaresolverr_pool.py` (`FLARESOLVERR_MAX_SESSIONS=2` in compose) reuses one daemon Chrome per host.
* **Bare vs hybrid — both start with that solve, they differ only in what runs *after*** `processors/base.py:169` `call_browser()`:
  * **Bare** (`fetch_backend=='html_requests'` and `!has_browser_steps`) → use FlareSolverr Chrome's `solution.response` directly as `self.fetcher.content` (with `EmptyReply`/`Non200ErrorCodeReceived` handling mirroring `content_fetchers/requests.py:16`). No second browser is launched in changedetection.io.
  * **Hybrid** (`has_browser_steps` or `fetch_backend=='html_webdriver'`) → take only `solution.cookies` + `solution.userAgent` from FlareSolverr Chrome, inject them into our own browser `playwright.py:285` `new_context(user_agent=_ua)` + `add_cookies` / `puppeteer.py:360` `setUserAgent`+`setCookie` / `webdriver_selenium.py:109` `add_cookie`, then `page.goto` and run the normal `iterate_browser_steps`/`capture_full_page_async`/`XPATH_ELEMENT_JS` flow. I.e. we re-fetch with a second Chrome that is already authenticated via `cf_clearance`.
  * **Live Browser-Steps UI** `blueprint/browser_steps/__init__.py:276` `start_browsersteps_session` / `browser_steps/browser_steps.py:345` `browsersteps_live_ui` now does the same `pool.solve()` before `acquire_browser_for_fetcher` and seeds `new_context` with `19` cookies + `UA`, so the configurator also bypasses Cloudflare (previously `403`, now `Challenge solved!`).
* Correctly composes with per-watch `proxy` (`proxy_override`) and `recheck`/`fetch_backend` inheritance.

**Why not always hybrid?** Hybrid re-executes JS in our own browser, which is needed only when the watch needs features that only our browser can provide — `browser_steps` `processors/base.py:211`, `screenshots` `playwright.py:16` `capture_full_page_async`, `xpath_data`/`visualselector` `XPATH_ELEMENT_JS` `content_fetchers/__init__.py:34`, or `webdriver_js_execute_code`. For a plain `html_requests` watch without steps, FlareSolverr Chrome's `response` is already the post-challenge, JS-executed HTML (`solution.response` is the DOM after the challenge), so launching a second Playwright (extra ~4s + RAM) adds no fidelity. Bare is the cheap path for non-browser watches.

## Configuration

```yaml
# docker-compose.yml
  changedetection:
    environment:
      - FLARESOLVERR_URL=http://flaresolverr:8191/v1
      - FLARESOLVERR_MAX_SESSIONS=2   # 0=ephemeral, 2 or 10 for LRU per-host reuse
      - FLARESOLVERR_TTL_MINUTES=60
      - FLARESOLVERR_TIMEOUT=60
  flaresolverr:
    image: ghcr.io/flaresolverr/flaresolverr:latest
```

* **Global:** Settings → Fetching → FlareSolverr (`application.flaresolverr_enabled`) — default for new watches.
* **Per-watch:** Edit → Request → FlareSolverr (`system | enabled | disabled`, default `system` inherits global). Hidden when `FLARESOLVERR_URL` unset.

## Changes

* `changedetectionio/flaresolverr_pool.py` — pool + `solve()` + env helpers
* `changedetectionio/processors/base.py` — overlay + `+flaresolverr` backend stamp
* `changedetectionio/content_fetchers/{playwright,puppeteer,webdriver_selenium}.py` — cookie + UA injection
* `changedetectionio/model/App.py` + `model/__init__.py` + `store/updates.py:874` (`update_34`) — config + migration
* `changedetectionio/forms.py` + `blueprint/{settings,ui}` + `blueprint/browser_steps` — UI with env guard (single `_()` with `%(url)s` to avoid fragmented i18n `44 == 44`)
* `docker-compose.yml` — documented env + example service
* `changedetectionio/translations/*` — updated catalog via `venv` `babel==2.18.0` `extract_messages`/`update_catalog`/`compile_catalog`

## Fixes

* **#1619** `implement FlareSolverr to solve *some* CF captchas` and **#1094** `Implement AntiCaptcha or FlareSolverr support` — proper `FlareSolverr` JSON API integration (fixes prior proxy-abuse in #4137 / #2444 `http://flaresolverr:8191/v1` as proxy → `ERR_TUNNEL_CONNECTION_FAILED`).
* **#1700** `Option to use undetected Chrome driver` — FlareSolverr uses `undetected_chromedriver` internally (`utils.get_webdriver()`), so this PR brings that stealth without vendoring it directly.
* **#2198** `Improve "bot-detection" evasion techniques` — adds the discussed headful-browser + session-reuse path; TCP/JA3 and IP-reputation remain out-of-scope.

## Testing

* `ruff check . --select E9,F63,F7,F82,INT` — pass
* `lint-template-i18n` — `44 == 44` (was `46 > 44`, fixed `settings.html:144` + `edit.html:164`)
* `lint-translations` — catalog recompiled via `venv`, `git diff | grep -v POT-Creation-Date` clean
* `pytest changedetectionio/tests/unit -q` — `223 passed, 1 failed` (`test_normal_snapshot_entry_is_accepted` also fails on clean `origin/master` `22ab668f` — pre-existing `/tmp` symlink issue, not this PR)
* Local Docker `FLARESOLVERR_MAX_SESSIONS=2` — see comment below for live Cloudflare fetch + Browser Steps results.

## Notes

* No breaking change — when `FLARESOLVERR_URL` unset, behavior and UI are identical to `master`.
* `FLARESOLVERR_MAX_SESSIONS=0` disables pooling (`sessions.create` per request without reuse) for minimal memory.
