### PR TITLE
  Reduce bot-detection signals created by Playwright browser contexts.

### DIFF
--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -367,7 +367,11 @@ class browsersteps_live_ui(steppable_browser_interface):
         # @todo handle multiple contexts, bind a unique id from the browser on each req?
         self.context = await self.playwright_browser.new_context(
             accept_downloads=False,  # Should never be needed
-            bypass_csp=True,  # This is needed to enable JavaScript execution on GitHub and others
+            bypass_csp=False,
+            viewport={
+                "width": int(os.getenv('PLAYWRIGHT_VIEWPORT_WIDTH', '1920')),
+                "height": int(os.getenv('PLAYWRIGHT_VIEWPORT_HEIGHT', '1024')),
+            },
             extra_http_headers=self.headers,
             ignore_https_errors=True,
             proxy=proxy,
@@ -514,4 +518,3 @@ class browsersteps_live_ui(steppable_browser_interface):
             pass
             
         return (screenshot, xpath_data)
-

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -284,7 +284,11 @@ class fetcher(Fetcher):
             # Use the default one configured in the App.py model that's passed from fetch_site_status.py
             context = await browser.new_context(
                 accept_downloads=False,  # Should never be needed
-                bypass_csp=True,  # This is needed to enable JavaScript execution on GitHub and others
+                bypass_csp=False,
+                viewport={
+                    "width": int(os.getenv('PLAYWRIGHT_VIEWPORT_WIDTH', '1920')),
+                    "height": int(os.getenv('PLAYWRIGHT_VIEWPORT_HEIGHT', '1024')),
+                },
                 extra_http_headers=request_headers,
                 ignore_https_errors=True,
                 proxy=self.proxy,
@@ -469,6 +473,5 @@ class PlaywrightFetcherPlugin:
 
 # Create module-level instance for plugin registration
 playwright_plugin = PlaywrightFetcherPlugin()
-
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
   #       Uncomment below and the "sockpuppetbrowser" to use a real Chrome browser (It uses the "playwright" protocol)
   #      - PLAYWRIGHT_DRIVER_URL=ws://browser-sockpuppet-chrome:3000
   #
+  #       Browser context viewport dimensions. Defaults are shown below.
+  #      - PLAYWRIGHT_VIEWPORT_WIDTH=1920
+  #      - PLAYWRIGHT_VIEWPORT_HEIGHT=1024
+  #
   #
   #       Alternative WebDriver/selenium URL, do not use "'s or 's! (old, deprecated, does not support screenshots very well, Can't handle custom headers etc)
   #      - WEBDRIVER_URL=http://browser-selenium-chrome:4444/wd/hub
@@ -158,4 +162,3 @@ services:
 
 volumes:
   changedetection-data:
-


### PR DESCRIPTION
## Summary

  The existing context enables `bypass_csp=True`, with a comment stating that it is needed for JavaScript execution on GitHub and similar sites. However, bypassing CSP is observable through the Chrome DevTools Protocol and differs from normal browser behavior. Bot-detection tools can use it as an automation signal and they *do*, as witnessed by e.g. https://bot-detector.rebrowser.net , which significantly limits ChangeDetection's abilities in checking websites for changes.  

## Potential regressions

1. Changedetection’s JavaScript actions use Playwright evaluation APIs, which do not generally require the page’s CSP to be disabled. CSP bypass is primarily relevant when injecting resources such as script elements into the page and AFIK this is not supported.
2. The current code comment specifically mentions GitHub (`# This is needed to enable JavaScript execution on GitHub and others`) as the rationale behind enabling `bypass_csp`. This was added in 9d742446, however that commit doesn't explain what was this fixing such that I could test it for regression.  I would argue, however, that a quirk for one particular website does not warrant regressions introduced for potentially countless other pages.

##  The change:

  - Disables CSP bypass.
  - Replaces Playwright’s recognizable 1280×720 default viewport.
  - Defaults the viewport to 1920×1024.
  - Allows viewport dimensions to be configured with:
      - PLAYWRIGHT_VIEWPORT_WIDTH
      - PLAYWRIGHT_VIEWPORT_HEIGHT

  - Applies the settings to normal fetching and interactive browser steps.

  ## Motivation

  The previous settings triggered two checks on bot-detector.rebrowser.net:

  - bypassCsp, because the browser ignored the page’s CSP.
  - viewport, because the context used Playwright’s default dimensions.

  Both provide avoidable signals that the browser is being automated.

  ## Testing

  Tested with changedetection.io, Patchright (https://github.com/dgtlmoon/changedetection.io/pull/4327), and sockpuppetbrowser in headful mode against bot-detector.rebrowser.net. The bypassCsp and default viewport detections no longer trigger. Normal
  browser fetching and browser steps continued to work in the tested deployment.