### PR TITLE
Use Patchright for browser automation in place of Playwright

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,id=pip,sharing=locked,target=/tmp/pip-cache \
   --target=/dependencies \
   -r /requirements.txt
 
-# Playwright is an alternative to Selenium
+# Patchright provides the Playwright API without detectable Runtime.enable calls.
 # Excluded this package from requirements.txt to prevent arm/v6 and arm/v7 builds from failing
 # https://github.com/dgtlmoon/changedetection.io/pull/1067 also musl/alpine (not supported)
 RUN --mount=type=cache,id=pip,sharing=locked,target=/tmp/pip-cache \
@@ -52,8 +52,8 @@ RUN --mount=type=cache,id=pip,sharing=locked,target=/tmp/pip-cache \
   --prefer-binary \
   --cache-dir=/tmp/pip-cache \
   --target=/dependencies \
-  playwright~=1.56.0 \
-  || echo "WARN: Failed to install Playwright. The application can still run, but the Playwright option will be disabled."
+  patchright~=1.56.0 \
+  || echo "WARN: Failed to install Patchright. The application can still run, but the Playwright option will be disabled."
 
 # OpenCV is optional for fast image comparison (pixelmatch is the fallback)
 # Skip on arm/v7 and arm/v8 where builds take weeks - excluded from requirements.txt
@@ -148,5 +148,4 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Default command (can be overridden in docker-compose.yml)
 CMD ["python", "./changedetection.py", "-d", "/datastore"]
-
 

--- a/changedetectionio/blueprint/browser_steps/__init__.py
+++ b/changedetectionio/blueprint/browser_steps/__init__.py
@@ -140,7 +140,7 @@ async def acquire_browser_for_fetcher(fetcher_name, proxy=None, keepalive_ms=Non
     Playwright/sockpuppetbrowser driver. Returns (browser, playwright_context).
     """
     from changedetectionio import content_fetchers
-    from playwright.async_api import async_playwright
+    from patchright.async_api import async_playwright
 
     logger.debug(f"acquire_browser_for_fetcher: requested fetcher='{fetcher_name}', proxy={'yes' if proxy else 'no'}, keepalive_ms={keepalive_ms}")
 
@@ -242,7 +242,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
     async def start_browsersteps_session(watch_uuid):
         from changedetectionio.browser_steps import browser_steps
         import time
-        from playwright.async_api import async_playwright
+        from patchright.async_api import async_playwright
 
         keepalive_seconds = int(os.getenv('BROWSERSTEPS_MINUTES_KEEPALIVE', 10)) * 60
         keepalive_ms = ((keepalive_seconds + 3) * 1000)
@@ -439,5 +439,4 @@ def construct_blueprint(datastore: ChangeDetectionStore):
         return response
 
     return browser_steps_blueprint
-
 

--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -196,7 +196,7 @@ class steppable_browser_interface():
         await self.page.click(selector=selector, timeout=self.action_timeout + 20 * 1000, delay=randint(200, 500))
 
     async def action_click_element_if_exists(self, selector, value):
-        import playwright._impl._errors as _api_types
+        import patchright._impl._errors as _api_types
         logger.debug("Clicking element if exists")
         if not selector or not len(selector.strip()):
             return
@@ -514,4 +514,3 @@ class browsersteps_live_ui(steppable_browser_interface):
             pass
             
         return (screenshot, xpath_data)
-

--- a/changedetectionio/content_fetchers/base.py
+++ b/changedetectionio/content_fetchers/base.py
@@ -190,7 +190,7 @@ class Fetcher():
 
     async def iterate_browser_steps(self, start_url=None):
         from changedetectionio.browser_steps.browser_steps import steppable_browser_interface, browser_steps_get_valid_steps
-        from playwright._impl._errors import TimeoutError, Error
+        from patchright._impl._errors import TimeoutError, Error
         from changedetectionio.jinja2_custom import render as jinja_render
         step_n = 0
 

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -262,8 +262,8 @@ class fetcher(Fetcher):
                   watch_uuid=None,
                   ):
 
-        from playwright.async_api import async_playwright
-        import playwright._impl._errors
+        from patchright.async_api import async_playwright
+        import patchright._impl._errors
         import time
         self.delete_browser_steps_screenshots()
         self.watch_uuid = watch_uuid  # Store for use in screenshot_step
@@ -320,7 +320,7 @@ class fetcher(Fetcher):
             try:
                 if self.webdriver_js_execute_code is not None and len(self.webdriver_js_execute_code):
                     await browsersteps_interface.action_execute_js(value=self.webdriver_js_execute_code, selector=None)
-            except playwright._impl._errors.TimeoutError as e:
+            except patchright._impl._errors.TimeoutError as e:
                 await context.close()
                 await browser.close()
                 # This can be ok, we will try to grab what we could retrieve
@@ -469,6 +469,3 @@ class PlaywrightFetcherPlugin:
 
 # Create module-level instance for plugin registration
 playwright_plugin = PlaywrightFetcherPlugin()
-
-
-

--- a/changedetectionio/worker.py
+++ b/changedetectionio/worker.py
@@ -325,7 +325,7 @@ async def async_update_worker(worker_id, q, notification_q, app, datastore, exec
                         continue
 
                     error_step = e.step_n
-                    from playwright._impl._errors import TimeoutError, Error
+                    from patchright._impl._errors import TimeoutError, Error
 
                     # Generally enough info for TimeoutError (couldnt locate the element after default seconds)
                     err_text = f"Browser step at position {error_step} could not run, check the watch, add a delay if necessary, view Browser Steps to see screenshot at that step."


### PR DESCRIPTION
# What does this change?

  This replaces the Playwright Python package with Patchright (https://github.com/Kaliiiiiiiiii-Vinyzu/patchright) while retaining the existing Playwright-compatible API, configuration, and
  user-facing names.

  The change updates:

  - The container dependency from playwright to patchright.
  - Browser automation imports throughout changedetection.io.
  - Internal exception imports and type references.
  - Worker checks that determine whether browser automation is available.

  ## Why?

  Playwright enables CDP domains such as Runtime.enable. These calls leave observable browser state that bot-detection systems can use to identify an automated browser, which can be easily tested using tools like bot-detector.rebrowser.net.

  Patchright provides a Playwright-compatible API while avoiding these detectable CDP behaviors. This makes browser-based change detection behave more like an ordinary browser and improves
  compatibility with sites that otherwise block or alter content for automated clients.

  ## Compatibility

  Existing settings such as PLAYWRIGHT_DRIVER_URL remain unchanged. The Playwright fetcher name and UI terminology are also retained, so existing configurations do not need to be migrated.

  Patchright tracks the Playwright API, but it is a separate dependency. Future Playwright version updates may therefore require a matching Patchright release.

  ## Testing

  - Built the changedetection.io container with Patchright.
  - Confirmed that browser fetching and browser steps continue to work.
  - Confirmed operation through the remote PLAYWRIGHT_DRIVER_URL.
  - Verified with bot-detector.rebrowser.net: the runtimeEnableLeak check no longer reports automation when changedetection.io connects through its configured browser endpoint.
  - Tested against the existing self-hosted changedetection.io deployment on Chrome Stable.