### PR TITLE
Make browser viewport configurable

### DIFF
--- a/changedetectionio/browser_steps/browser_steps.py
+++ b/changedetectionio/browser_steps/browser_steps.py
@@ -368,6 +368,10 @@ class browsersteps_live_ui(steppable_browser_interface):
         self.context = await self.playwright_browser.new_context(
             accept_downloads=False,  # Should never be needed
             bypass_csp=True,  # This is needed to enable JavaScript execution on GitHub and others
+            viewport={
+                "width": int(os.getenv('PLAYWRIGHT_VIEWPORT_WIDTH', '1920')),
+                "height": int(os.getenv('PLAYWRIGHT_VIEWPORT_HEIGHT', '1024')),
+            },
             extra_http_headers=self.headers,
             ignore_https_errors=True,
             proxy=proxy,
@@ -514,4 +518,3 @@ class browsersteps_live_ui(steppable_browser_interface):
             pass
             
         return (screenshot, xpath_data)
-

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -285,6 +285,10 @@ class fetcher(Fetcher):
             context = await browser.new_context(
                 accept_downloads=False,  # Should never be needed
                 bypass_csp=True,  # This is needed to enable JavaScript execution on GitHub and others
+                viewport={
+                    "width": int(os.getenv('PLAYWRIGHT_VIEWPORT_WIDTH', '1920')),
+                    "height": int(os.getenv('PLAYWRIGHT_VIEWPORT_HEIGHT', '1024')),
+                },
                 extra_http_headers=request_headers,
                 ignore_https_errors=True,
                 proxy=self.proxy,
@@ -469,6 +473,5 @@ class PlaywrightFetcherPlugin:
 
 # Create module-level instance for plugin registration
 playwright_plugin = PlaywrightFetcherPlugin()
-
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
   #       Uncomment below and the "sockpuppetbrowser" to use a real Chrome browser (It uses the "playwright" protocol)
   #      - PLAYWRIGHT_DRIVER_URL=ws://browser-sockpuppet-chrome:3000
   #
+  #       Browser context viewport dimensions. Defaults are shown below.
+  #      - PLAYWRIGHT_VIEWPORT_WIDTH=1920
+  #      - PLAYWRIGHT_VIEWPORT_HEIGHT=1024
+  #
   #
   #       Alternative WebDriver/selenium URL, do not use "'s or 's! (old, deprecated, does not support screenshots very well, Can't handle custom headers etc)
   #      - WEBDRIVER_URL=http://browser-selenium-chrome:4444/wd/hub
@@ -158,4 +162,3 @@ services:
 
 volumes:
   changedetection-data:
-


### PR DESCRIPTION
## Summary

  Playwright creates browser contexts with a recognizable default viewport of 1280×720. Bot-detection tools can use these dimensions as an automation signal, as demonstrated by bot-detector.rebrowser.net (https://bot-detector.rebrowser.net/).

  This change replaces that default with a more typical desktop viewport of 1920×1024 and makes both dimensions configurable.

  ## The change

  - Defaults the browser viewport to 1920×1024.
  - Adds the following environment variables:
      - PLAYWRIGHT_VIEWPORT_WIDTH
      - PLAYWRIGHT_VIEWPORT_HEIGHT

  - Documents both variables in docker-compose.yml.
  - Applies the configured viewport to normal browser fetching and interactive Browser Steps.

  ## Motivation

  Using Playwright’s default viewport provides an avoidable signal that the browser is being automated. A more typical desktop viewport makes the browser context resemble an ordinary browser
  while allowing operators to select dimensions appropriate for their deployment.

  ## Potential regressions

  Changing the default viewport can affect responsive page layouts, screenshots, visual selectors, and extracted content. Existing installations that depend on the previous 1280×720 dimensions
  can retain them with:

```
  environment:
    - PLAYWRIGHT_VIEWPORT_WIDTH=1280
    - PLAYWRIGHT_VIEWPORT_HEIGHT=720
```
  ## Testing

  Tested with changedetection.io, Patchright (https://github.com/dgtlmoon/changedetection.io/pull/4327), and sockpuppetbrowser in headful mode against bot-detector.rebrowser.net
  (https://bot-detector.rebrowser.net/).

  The default viewport detection no longer triggers. Normal browser fetching and Browser Steps continued to work in the tested deployment.
 
 