### PR TITLE
fix: Browser Steps picker cannot select a <select> nested in a <div>

### DIFF
--- a/changedetectionio/static/js/browser-steps.js
+++ b/changedetectionio/static/js/browser-steps.js
@@ -161,7 +161,7 @@ $(document).ready(function () {
             // Find the best one
             if (possible_elements.length) {
                 possible_elements.forEach(function (item, index) {
-                  if (["a", "input", "textarea", "button"].includes(item['tagName'])) {
+                  if (["a", "input", "select", "textarea", "button"].includes(item['tagName'])) {
                       current_selected_i = item;
                   }
                 });


### PR DESCRIPTION
The Browser Steps element picker resolves an overlapping click to the smallest element, tie-broken by DOM order, falling back to a short priority list of tag names. That list is missing `select`, so a `<select>` wrapped in a similarly sized `<div>` loses to the div (scraped first, since it is the parent). The picker then highlights the div and defaults the step to "Click element". The `process_selected()` branch for a select (which fills in "select by option text") already exists, it just never gets reached because the select never becomes the selected element.

Fix: add `select` to the priority list.

## Reproduction
1. Add a watch on a page with a `<select>` inside a `<div>` sized close to or a little larger than the select.
2. Edit the watch, set the fetch method to the browser/Playwright fetcher, save.
3. Open Browser Steps, click "Click here to Start".
4. Hover the select. Before: the highlight and Selector target the wrapping div and the operation defaults to "Click element". After: they target the select and the operation defaults to "select by option text".

## Testing
Verified on a live changedetection.io plus sockpuppetbrowser stack (stock `dgtlmoon/changedetection.io:latest`, only this line changed), driving the real Browser Steps endpoints so the real scraper produced the element list, then running the real `browser-steps.js` resolution against it.

Scraper output for the test page (the div and select overlap at the same position):

```
#wrap                width 162 height 32 left 40 top 119 tagName div
SELECT[name="pick"]  width 160 height 30 left 40 top 119 tagName select
```

Resolution at a point inside the select:

```
before: selected div    -> "Click element",         selector #wrap
after:  selected select -> "select by option text",  selector SELECT[name="pick"]
```

Note: on a pixel-for-pixel size tie between the div and the select, both old and new code land on the select for an unrelated reason (the scraper's area sort reorders the exact tie), so the case this targets is the realistic one, a wrapping div slightly larger than its select.

Fixes #3440.
