### PR TITLE
deps: update litellm dependency cap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ tzdata
 pluggy ~= 1.6
 
 # LLM intent-based change evaluation (multi-provider via litellm)
-litellm>=1.40.0,<1.83.1  # 1.83.1–1.83.14 exact-pin jsonschema==4.23.0, conflicting with openapi-spec-validator's >=4.24.0 floor; re-evaluate when litellm fixes this
+litellm>=1.40.0  # Uncapped: litellm now uses jsonschema<5.0,>=4.0.0, resolving earlier openapi-spec-validator conflict
 # Used today for LLMSettings (model/LLMSettings.py); transitively pulled by litellm but pinned explicitly
 # so the validation/typing layer doesn't disappear if litellm drops it.
 pydantic>=2.0,<3.0


### PR DESCRIPTION
Remove the <1.83.1 upper bound on litellm now that recent releases specify jsonschema<5.0,>=4.0.0, eliminating the conflict with openapi-spec-validator (>=4.24.0).