### PR TITLE
fix(llm): support Gemini flash-lite & reasoning models, strip extra_body on 400 retry

### DIFF
--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -6,6 +6,7 @@ and makes the call easy to mock in tests.
 
 import logging
 import os
+
 from loguru import logger
 
 # Default output token cap for JSON-returning calls (intent eval, preview, setup).
@@ -24,6 +25,9 @@ DEFAULT_TIMEOUT = int(os.getenv('LLM_TIMEOUT', 300))
 # longer deadline (Hermes-style, 30 min). Overridable via LLM_LOCAL_TIMEOUT; see
 # evaluator.resolve_llm_timeout() for how the endpoint is classified.
 DEFAULT_LOCAL_TIMEOUT = int(os.getenv('LLM_LOCAL_TIMEOUT', 1800))
+# Models and reasoning architectures that reject explicit sampling parameters (temperature/top_p)
+_NO_TEMPERATURE_MODEL_KEYWORDS = ('flash-lite', 'thinking-exp', 'o1', 'o3', 'o4')
+
 DEFAULT_RETRIES = 3
 
 
@@ -63,10 +67,16 @@ def _install_litellm_debug():
     logger.info("LLM client: litellm debug logging routed through loguru")
 
 
-def completion(model: str, messages: list, api_key: str = None,
-               api_base: str = None, timeout: int = DEFAULT_TIMEOUT,
-               max_tokens: int = None, extra_body: dict = None,
-               debug: bool = False) -> tuple[str, int, int, int]:
+def completion(  # noqa: C901
+    model: str,
+    messages: list,
+    api_key: str = None,
+    api_base: str = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_tokens: int = None,
+    extra_body: dict = None,
+    debug: bool = False,
+) -> tuple[str, int, int, int]:
     """
     Call the LLM and return (response_text, total_tokens, input_tokens, output_tokens).
     Retries up to DEFAULT_RETRIES times on timeout or connection errors.
@@ -79,7 +89,7 @@ def completion(model: str, messages: list, api_key: str = None,
     try:
         import litellm
     except ImportError:
-        raise RuntimeError("litellm is not installed. Add it to requirements.txt.")
+        raise RuntimeError("litellm is not installed. Add it to requirements.txt.") from None
 
     if debug:
         _install_litellm_debug()
@@ -90,9 +100,12 @@ def completion(model: str, messages: list, api_key: str = None,
         'model': model,
         'messages': messages,
         'timeout': _timeout,
-        'temperature': 0,
         'max_tokens': max_tokens if max_tokens is not None else _MAX_COMPLETION_TOKENS,
     }
+    _m_lower = (model or '').lower()
+    if not any(k in _m_lower for k in _NO_TEMPERATURE_MODEL_KEYWORDS):
+        kwargs['temperature'] = 0
+
     if api_key:
         kwargs['api_key'] = api_key
     if api_base:
@@ -122,9 +135,9 @@ def completion(model: str, messages: list, api_key: str = None,
         attempt += 1
         try:
             response = litellm.completion(**kwargs)
-            choice   = response.choices[0]
-            message  = choice.message
-            finish   = getattr(choice, 'finish_reason', None)
+            choice = response.choices[0]
+            message = choice.message
+            finish = getattr(choice, 'finish_reason', None)
 
             text = message.content or ''
 
@@ -133,7 +146,9 @@ def completion(model: str, messages: list, api_key: str = None,
                 parts = getattr(message, 'parts', None)
                 if parts:
                     text = ''.join(getattr(p, 'text', '') or '' for p in parts).strip()
-                    logger.debug(f"LLM client: extracted text from message.parts ({len(parts)} parts) model={model!r}")
+                    logger.debug(
+                        f"LLM client: extracted text from message.parts ({len(parts)} parts) model={model!r}"
+                    )
 
             if finish == 'length':
                 logger.warning(
@@ -149,9 +164,13 @@ def completion(model: str, messages: list, api_key: str = None,
                 )
 
             usage = getattr(response, 'usage', None)
-            input_tokens  = int(getattr(usage, 'prompt_tokens',     0) or 0) if usage else 0
+            input_tokens = int(getattr(usage, 'prompt_tokens', 0) or 0) if usage else 0
             output_tokens = int(getattr(usage, 'completion_tokens', 0) or 0) if usage else 0
-            total_tokens  = int(getattr(usage, 'total_tokens',      0) or 0) if usage else (input_tokens + output_tokens)
+            total_tokens = (
+                int(getattr(usage, 'total_tokens', 0) or 0)
+                if usage
+                else (input_tokens + output_tokens)
+            )
             logger.debug(
                 f"LLM client: model={model!r} finish={finish!r} "
                 f"tokens={total_tokens} (in={input_tokens} out={output_tokens}) "
@@ -181,21 +200,37 @@ def completion(model: str, messages: list, api_key: str = None,
             raise
 
         except litellm.BadRequestError as e:
-            # If the provider rejected an unsupported sampling param (and we haven't
-            # already stripped them), drop them and retry once. attempt-=1 keeps this
-            # off the timeout-retry budget; _stripped_sampling prevents a loop.
-            msg = str(e).lower()
-            if (not _stripped_sampling
-                    and any(p in kwargs for p in _sampling_params)
-                    and any(p in msg for p in _sampling_params)):
+            # If the provider rejected an unsupported sampling param or extra_body
+            # (e.g. Gemini INVALID_ARGUMENT on thinkingConfig or temperature), drop
+            # them and retry once.
+            if not _stripped_sampling:
                 dropped = [p for p in _sampling_params if kwargs.pop(p, None) is not None]
-                _stripped_sampling = True
-                attempt -= 1
-                logger.warning(
-                    f"LLM client: model={model!r} rejected sampling params {dropped} "
-                    f"({e}); retrying without them"
-                )
-                continue
+                extra_body = kwargs.get('extra_body')
+                if isinstance(extra_body, dict):
+                    gen_cfg = extra_body.get('generationConfig')
+                    if (
+                        isinstance(gen_cfg, dict)
+                        and gen_cfg.pop('thinkingConfig', None) is not None
+                    ):
+                        dropped.append('thinkingConfig')
+                        if not gen_cfg:
+                            extra_body.pop('generationConfig', None)
+                        if not extra_body:
+                            kwargs.pop('extra_body', None)
+                    elif 'thinkingConfig' in extra_body:
+                        extra_body.pop('thinkingConfig', None)
+                        dropped.append('thinkingConfig')
+                        if not extra_body:
+                            kwargs.pop('extra_body', None)
+
+                if dropped:
+                    _stripped_sampling = True
+                    attempt -= 1
+                    logger.warning(
+                        f"LLM client: model={model!r} rejected request ({e}); "
+                        f"stripped {dropped} and retrying once"
+                    )
+                    continue
             logger.warning(f"LLM call failed: model={model!r} error={e}")
             raise
 

--- a/changedetectionio/llm/evaluator.py
+++ b/changedetectionio/llm/evaluator.py
@@ -97,6 +97,8 @@ def _thinking_extra_body(model: str, budget: int) -> dict | None:
     """
     if not model.startswith('gemini/'):
         return None
+    if 'flash-lite' in model.lower():
+        return None
     try:
         import litellm
         if not litellm.get_model_info(model).get('supports_reasoning'):

--- a/changedetectionio/tests/unit/test_llm_client_gemini.py
+++ b/changedetectionio/tests/unit/test_llm_client_gemini.py
@@ -1,0 +1,117 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from changedetectionio.llm import client as m
+from changedetectionio.llm import evaluator as ev
+
+
+class TestGeminiFlashLiteClientHandling(unittest.TestCase):
+    def _mock_success_response(
+        self, text="test response", total_tokens=50, input_tokens=30, output_tokens=20
+    ):
+        mock_resp = MagicMock()
+        mock_resp.choices = [
+            MagicMock(message=MagicMock(content=text, parts=None), finish_reason="stop")
+        ]
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = total_tokens
+        mock_usage.prompt_tokens = input_tokens
+        mock_usage.completion_tokens = output_tokens
+        mock_resp.usage = mock_usage
+        return mock_resp
+
+    def _bad_request(self, message="Request contains an invalid argument."):
+        import litellm
+
+        return litellm.BadRequestError(
+            message=message,
+            model="gemini/gemini-2.0-flash-lite",
+            llm_provider="gemini",
+            response=MagicMock(status_code=400),
+        )
+
+    def test_flash_lite_model_omits_temperature_initially(self):
+        mock_resp = self._mock_success_response()
+        with patch("litellm.completion", return_value=mock_resp) as mock_call:
+            text, total_tok, in_tok, out_tok = m.completion(
+                model="gemini/gemini-2.0-flash-lite",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            self.assertEqual(text, "test response")
+            self.assertEqual(total_tok, 50)
+            self.assertEqual(in_tok, 30)
+            self.assertEqual(out_tok, 20)
+
+        kwargs = mock_call.call_args.kwargs
+        self.assertNotIn("temperature", kwargs)
+
+    def test_standard_model_includes_temperature_zero(self):
+        mock_resp = self._mock_success_response()
+        with patch("litellm.completion", return_value=mock_resp) as mock_call:
+            m.completion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        kwargs = mock_call.call_args.kwargs
+        self.assertEqual(kwargs.get("temperature"), 0)
+
+    def test_bad_request_strips_temperature_and_extra_body_and_retries(self):
+        exc = self._bad_request()
+        mock_resp = self._mock_success_response()
+        with patch("litellm.completion", side_effect=[exc, mock_resp]) as mock_call:
+            text, total_tok, in_tok, out_tok = m.completion(
+                model="gemini/gemini-2.5-flash",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_body={"generationConfig": {"thinkingConfig": {"thinkingBudget": 0}}},
+            )
+            self.assertEqual(text, "test response")
+            self.assertEqual(mock_call.call_count, 2)
+
+            first_call_kwargs = mock_call.call_args_list[0].kwargs
+            second_call_kwargs = mock_call.call_args_list[1].kwargs
+
+            self.assertIn("temperature", first_call_kwargs)
+            self.assertIn("extra_body", first_call_kwargs)
+            self.assertNotIn("temperature", second_call_kwargs)
+            self.assertNotIn("extra_body", second_call_kwargs)
+
+    def test_does_not_infinite_loop_when_nothing_left_to_strip(self):
+        exc = self._bad_request("another 400 error")
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(type(exc)):
+                m.completion(
+                    model="gemini/gemini-2.0-flash-lite",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        self.assertEqual(mock_call.call_count, 1)
+
+    def test_only_retries_once_on_persistent_400(self):
+        exc1 = self._bad_request("first 400")
+        exc2 = self._bad_request("second 400")
+        with patch("litellm.completion", side_effect=[exc1, exc2]) as mock_call:
+            with self.assertRaises(type(exc2)):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hi"}],
+                    extra_body={"generationConfig": {"thinkingConfig": {"thinkingBudget": 0}}},
+                )
+        self.assertEqual(mock_call.call_count, 2)
+
+
+class TestThinkingExtraBodyFlashLite(unittest.TestCase):
+    def test_flash_lite_model_gets_no_thinking_config(self):
+        self.assertIsNone(ev._thinking_extra_body("gemini/gemini-2.0-flash-lite", budget=0))
+        self.assertIsNone(ev._thinking_extra_body("gemini/gemini-3.5-flash-lite", budget=0))
+
+    def test_non_gemini_model_gets_no_thinking_config(self):
+        self.assertIsNone(ev._thinking_extra_body("gpt-4o-mini", budget=100))
+
+    @patch("litellm.get_model_info")
+    def test_gemini_supporting_reasoning_gets_thinking_config(self, mock_info):
+        mock_info.return_value = {"supports_reasoning": True}
+        result = ev._thinking_extra_body("gemini/gemini-2.5-flash", budget=512)
+        self.assertEqual(result, {"generationConfig": {"thinkingConfig": {"thinkingBudget": 512}}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Omit temperature=0 on initial request for flash-lite and reasoning models
- Omit thinkingConfig in _thinking_extra_body for flash-lite models
- Defined `_NO_TEMPERATURE_MODEL_KEYWORDS` constant to centrally manage reasoning and flash-lite models that reject explicit temperature settings.
- Unconditionally strip rejected sampling params and extra_body thinkingConfig on BadRequestError (handling Gemini 400 INVALID_ARGUMENT without named details)
- Add comprehensive unit tests in test_llm_client_gemini.py