### PR TITLE
fix: honour LOGGER_LEVEL on werkzeug HTTP access logs

### DIFF
--- a/changedetectionio/__init__.py
+++ b/changedetectionio/__init__.py
@@ -4,6 +4,7 @@
 # Semver means never use .01, or 00. Should be .1.
 __version__ = '0.55.8'
 
+from changedetectionio.stdlib_log_level import apply_stdlib_logger_level
 from changedetectionio.strtobool import strtobool
 from json.decoder import JSONDecodeError
 
@@ -359,6 +360,10 @@ def main():
     # Set both parent and child loggers since pyppeteer hardcodes DEBUG level
     logging.getLogger('pyppeteer.connection').setLevel(logging.WARNING)
     logging.getLogger('pyppeteer.connection.Connection').setLevel(logging.WARNING)
+
+    # Werkzeug access lines go through logging.getLogger('werkzeug') at INFO.
+    # LOGGER_LEVEL / -l only configured loguru, so ERROR still printed every GET (#4263).
+    apply_stdlib_logger_level(logger_level)
 
     # isnt there some @thingy to attach to each route to tell it, that this route needs a datastore
     app_config = {

--- a/changedetectionio/stdlib_log_level.py
+++ b/changedetectionio/stdlib_log_level.py
@@ -1,0 +1,30 @@
+# Map LOGGER_LEVEL / -l (loguru names) onto the stdlib logging package.
+# loguru and logging are independent; werkzeug's access logger only reads the latter.
+
+import logging
+
+# loguru SUCCESS is 25. Stdlib has no TRACE; map it to DEBUG so access lines still show.
+_LOGURU_TO_STDLIB = {
+    'TRACE': logging.DEBUG,
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'SUCCESS': 25,
+    'WARNING': logging.WARNING,
+    'WARN': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL,
+}
+
+
+def stdlib_level_from_logger_level(level):
+    if isinstance(level, int):
+        return level
+    name = str(level).upper()
+    try:
+        return _LOGURU_TO_STDLIB[name]
+    except KeyError:
+        raise ValueError(f'Unknown logger level: {level}')
+
+
+def apply_stdlib_logger_level(level):
+    logging.getLogger('werkzeug').setLevel(stdlib_level_from_logger_level(level))

--- a/changedetectionio/tests/unit/test_werkzeug_logger_level.py
+++ b/changedetectionio/tests/unit/test_werkzeug_logger_level.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# run from dir above changedetectionio/ dir
+# python3 -m unittest changedetectionio.tests.unit.test_werkzeug_logger_level
+
+"""LOGGER_LEVEL / -l must also control werkzeug's HTTP access logger.
+
+loguru and the stdlib logging package are independent. Werkzeug's dev server
+emits access lines through logging.getLogger('werkzeug') at INFO, so setting
+LOGGER_LEVEL=ERROR currently still prints every GET (issue #4263).
+"""
+
+import logging
+import unittest
+
+from changedetectionio.stdlib_log_level import (
+    apply_stdlib_logger_level,
+    stdlib_level_from_logger_level,
+)
+
+
+class TestStdlibLevelFromLoggerLevel(unittest.TestCase):
+    def test_named_levels(self):
+        self.assertEqual(stdlib_level_from_logger_level('ERROR'), logging.ERROR)
+        self.assertEqual(stdlib_level_from_logger_level('error'), logging.ERROR)
+        self.assertEqual(stdlib_level_from_logger_level('WARNING'), logging.WARNING)
+        self.assertEqual(stdlib_level_from_logger_level('WARN'), logging.WARNING)
+        self.assertEqual(stdlib_level_from_logger_level('INFO'), logging.INFO)
+        self.assertEqual(stdlib_level_from_logger_level('DEBUG'), logging.DEBUG)
+        self.assertEqual(stdlib_level_from_logger_level('CRITICAL'), logging.CRITICAL)
+
+    def test_success_is_quieter_than_info(self):
+        # loguru SUCCESS is 25. Access lines are INFO (20), so SUCCESS must hide them.
+        self.assertGreater(stdlib_level_from_logger_level('SUCCESS'), logging.INFO)
+
+    def test_trace_still_allows_info_access_lines(self):
+        self.assertLessEqual(stdlib_level_from_logger_level('TRACE'), logging.INFO)
+
+    def test_numeric_levels_pass_through(self):
+        self.assertEqual(stdlib_level_from_logger_level(40), 40)
+        self.assertEqual(stdlib_level_from_logger_level(25), 25)
+
+
+class TestApplyStdlibLoggerLevel(unittest.TestCase):
+    def setUp(self):
+        self.werkzeug_log = logging.getLogger('werkzeug')
+        self._previous_level = self.werkzeug_log.level
+        # Werkzeug sets INFO on first use when the logger is still NOTSET.
+        self.werkzeug_log.setLevel(logging.INFO)
+
+    def tearDown(self):
+        self.werkzeug_log.setLevel(self._previous_level)
+
+    def test_error_suppresses_werkzeug_info_access_lines(self):
+        apply_stdlib_logger_level('ERROR')
+        self.assertFalse(self.werkzeug_log.isEnabledFor(logging.INFO))
+        self.assertTrue(self.werkzeug_log.isEnabledFor(logging.ERROR))
+
+    def test_info_keeps_werkzeug_access_lines(self):
+        apply_stdlib_logger_level('INFO')
+        self.assertTrue(self.werkzeug_log.isEnabledFor(logging.INFO))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

With `LOGGER_LEVEL=ERROR` (or `-l ERROR`), the Werkzeug dev server still prints every HTTP request:

```
127.0.0.1 - - [17/Jul/2026 07:37:19] "GET / HTTP/1.1" 200 -
```

`LOGGER_LEVEL` only configures loguru. Werkzeug emits access lines through `logging.getLogger('werkzeug')` at INFO, and the two systems are independent.

Fixes #4263.

## How

Same pattern already used for `pyppeteer.connection`: after loguru is configured, the same level is applied to the stdlib `werkzeug` logger. Loguru names (`TRACE`, `SUCCESS`, `WARN`, ...) are mapped to stdlib levels. `SUCCESS` (25) hides INFO (20) access lines.

## Tests

```
python -m unittest changedetectionio.tests.unit.test_werkzeug_logger_level -v
```

6 tests, 0 failures. Without this change they fail on the werkzeug level assertion; with it they pass.

Not verified: live server start with `LOGGER_LEVEL=ERROR` and real HTTP requests.
