### PR TITLE
fix(model): add llm period token keys to system-managed non-spec fields

### DIFF
--- a/changedetectionio/model/schema_utils.py
+++ b/changedetectionio/model/schema_utils.py
@@ -29,6 +29,8 @@ SYSTEM_MANAGED_NON_SPEC_FIELDS = frozenset({
     'llm_evaluation_cache',
     'llm_last_tokens_used',
     'llm_tokens_used_cumulative',
+    'llm_tokens_this_period',
+    'llm_tokens_period_key',
 })
 
 

--- a/changedetectionio/tests/unit/test_schema_utils.py
+++ b/changedetectionio/tests/unit/test_schema_utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import unittest
+from changedetectionio.model.schema_utils import SYSTEM_MANAGED_NON_SPEC_FIELDS
+from changedetectionio.api import strip_internal_api_fields
+
+
+class TestSchemaUtils(unittest.TestCase):
+    def test_system_managed_non_spec_fields_contains_all_llm_runtime_state(self):
+        expected = {
+            '_llm_result',
+            '_llm_intent',
+            '_llm_change_summary',
+            'llm_prefilter',
+            'llm_evaluation_cache',
+            'llm_last_tokens_used',
+            'llm_tokens_used_cumulative',
+            'llm_tokens_this_period',
+            'llm_tokens_period_key',
+        }
+        for field in expected:
+            self.assertIn(field, SYSTEM_MANAGED_NON_SPEC_FIELDS, f"{field} should be in SYSTEM_MANAGED_NON_SPEC_FIELDS")
+
+    def test_strip_internal_api_fields(self):
+        data = {
+            'url': 'https://example.com',
+            'title': 'Test Page',
+            '__check_status': 'Checking...',
+            'last_check_status': 200,
+            '_llm_result': {'important': True},
+            '_llm_intent': 'watch for price drops',
+            '_llm_change_summary': 'Price dropped by $5',
+            'llm_prefilter': '#price',
+            'llm_evaluation_cache': {'hash': {}},
+            'llm_last_tokens_used': 150,
+            'llm_tokens_used_cumulative': 1500,
+            'llm_tokens_this_period': 450,
+            'llm_tokens_period_key': '2026-09',
+        }
+        stripped = strip_internal_api_fields(data)
+        self.assertEqual(stripped, {'url': 'https://example.com', 'title': 'Test Page'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem
When `_check_token_budget()` in `changedetectionio/llm/evaluator.py` updates token usage for a watch, it writes:
```python
watch['llm_tokens_this_period'] = ...
watch['llm_tokens_period_key'] = ...
```
While all other internal LLM runtime fields (`_llm_result`, `_llm_intent`, `_llm_change_summary`, `llm_prefilter`, `llm_evaluation_cache`, `llm_last_tokens_used`, `llm_tokens_used_cumulative`) are registered in `SYSTEM_MANAGED_NON_SPEC_FIELDS` in `changedetectionio/model/schema_utils.py`, `llm_tokens_this_period` and `llm_tokens_period_key` were omitted.

This caused two issues:
1. **Unchanged-content skip cache invalidation:** In `model/__init__.py:354`, setting any key not in `SYSTEM_MANAGED_NON_SPEC_FIELDS` marks `watch.__watch_was_edited = True`. This caused `perform_site_check()` to fail the `not watch.was_edited` check on every check, forcing full extraction and diffing even when the page had 0 changes.
2. **Internal field leak across API:** Because `strip_internal_api_fields()` relies on `SYSTEM_MANAGED_NON_SPEC_FIELDS`, these two internal counters were not stripped from API responses, leaking internal runtime state and causing schema validation errors on round-trip PUT requests.

## Solution
1. Added `'llm_tokens_this_period'` and `'llm_tokens_period_key'` to `SYSTEM_MANAGED_NON_SPEC_FIELDS` in `changedetectionio/model/schema_utils.py`.
2. Added unit tests in `changedetectionio/tests/unit/test_schema_utils.py` verifying that all LLM runtime fields are present in `SYSTEM_MANAGED_NON_SPEC_FIELDS` and correctly stripped by `strip_internal_api_fields()`.