### PR TITLE
fix(restock): show Price badge when restock detection is off

### DIFF
--- a/changedetectionio/blueprint/watchlist/__init__.py
+++ b/changedetectionio/blueprint/watchlist/__init__.py
@@ -13,7 +13,7 @@ from changedetectionio.auth_decorator import login_optionally_required
 # Shared filtering — the single source of truth, also used by the ui blueprint's
 # bulk actions so a filtered view and the actions taken on it always agree.
 from changedetectionio.blueprint.watchlist import filters as wl_filters
-from changedetectionio.blueprint.watchlist.row_context import watch_row_context
+from changedetectionio.blueprint.watchlist.row_context import watch_row_context, processor_badge_texts_for_watches
 
 def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMetaData):
     watchlist_blueprint = Blueprint('watchlist', __name__, template_folder="templates")
@@ -113,9 +113,12 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
 
         # Everything the row markup itself needs comes from here, shared with the Socket.IO
         # row push so a live-updated row can't drift from the server-rendered one.
+        processor_badge_texts = processors.get_processor_badge_texts()
         row_ctx = watch_row_context(datastore,
                                     active_tag_uuid=active_tag_uuid,
-                                    queued_uuids=update_q.get_queued_uuids())
+                                    queued_uuids=update_q.get_queued_uuids(),
+                                    processor_badge_texts_by_watch=processor_badge_texts_for_watches(
+                                        datastore, sorted_watches, processor_badge_texts))
 
         output = render_template(
             "watch-overview.html",
@@ -143,7 +146,7 @@ def construct_blueprint(datastore: ChangeDetectionStore, update_q, queuedWatchMe
             now_time_server=round(time.time()),
             pagination=pagination,
             processor_badge_css=processors.get_processor_badge_css(),
-            processor_badge_texts=processors.get_processor_badge_texts(),
+            processor_badge_texts=processor_badge_texts,
             queue_size=update_q.qsize(),
             # Active view filters (tag/processor/q/unread/...) so links (e.g. column sorting)
             # can re-apply them and not drop the operator's current filtered view.

--- a/changedetectionio/blueprint/watchlist/row_context.py
+++ b/changedetectionio/blueprint/watchlist/row_context.py
@@ -13,7 +13,60 @@ already available in any render and is deliberately NOT listed.
 from changedetectionio import processors
 
 
-def watch_row_context(datastore, active_tag_uuid=None, queued_uuids=None):
+class _LazyProcessorBadgeTexts:
+    """Resolve restock badge text only for rows the template renders."""
+
+    def __init__(self, datastore, watches, processor_badge_texts):
+        self._datastore = datastore
+        self._processor_badge_texts = processor_badge_texts
+        self._restock_watches = {
+            watch.get('uuid'): watch
+            for watch in watches
+            if watch.get('processor') == 'restock_diff'
+        }
+        self._cache = {}
+
+    def get(self, watch_uuid, default=None):
+        watch = self._restock_watches.get(watch_uuid)
+        if watch is None:
+            return default
+
+        if watch_uuid not in self._cache:
+            from changedetectionio.processors.restock_diff.processor import get_restock_settings
+
+            badge_text = self._processor_badge_texts.get('restock_diff', default)
+            if get_restock_settings(self._datastore, watch).get('in_stock_processing') == 'off':
+                # ``Price`` is already part of the extracted catalog (the row's price
+                # column uses it); call the package's locale-aware gettext here without
+                # creating a second extractor location for the same msgid.
+                from flask_babel import gettext as _translate
+                badge_text = _translate('Price')
+            self._cache[watch_uuid] = badge_text
+
+        return self._cache[watch_uuid]
+
+    def __getitem__(self, watch_uuid):
+        watch = self._restock_watches.get(watch_uuid)
+        if watch is None:
+            raise KeyError(watch_uuid)
+        return self.get(watch_uuid)
+
+
+def processor_badge_texts_for_watches(datastore, watches, processor_badge_texts):
+    """Return lazily resolved badge text for watches in a rendered list.
+
+    Most processor badges are fixed by processor type. Restock watches are the
+    exception: when availability detection is disabled, the watch only tracks
+    price changes and should be labelled accordingly. The effective settings
+    include tag overrides, so use the same resolver as the restock processor.
+    Resolution is lazy because pagination renders only a subset of ``watches``;
+    reading config files for rows outside the current page would waste I/O.
+    """
+    return _LazyProcessorBadgeTexts(datastore, watches, processor_badge_texts)
+
+
+def watch_row_context(datastore, active_tag_uuid=None, queued_uuids=None,
+                      processor_badge_texts_by_watch=None):
     """Context for one (or many) watch list rows.
 
     active_tag_uuid matters: the row's Edit/Recheck links carry the tag so the operator lands
@@ -22,6 +75,9 @@ def watch_row_context(datastore, active_tag_uuid=None, queued_uuids=None):
 
     queued_uuids is accepted so a caller rendering many rows can fetch the queue once instead
     of per row; omit it and the live queue is read for you.
+
+    processor_badge_texts_by_watch allows a list page to provide the effective
+    per-watch badge label without making the row template read configuration files.
     """
     if queued_uuids is None:
         # Local import: flask_app imports blueprints, so a module-level import would cycle.
@@ -37,6 +93,7 @@ def watch_row_context(datastore, active_tag_uuid=None, queued_uuids=None):
         'datastore': datastore,
         'has_proxies': datastore.proxy_list,
         'processor_descriptions': processors.get_processor_descriptions(),
+        'processor_badge_texts_by_watch': processor_badge_texts_by_watch or {},
         'queued_uuids': queued_uuids,
         'system_default_fetcher': datastore.data['settings']['application'].get('fetch_backend'),
         'ui_settings': datastore.data['settings']['application']['ui'],

--- a/changedetectionio/blueprint/watchlist/templates/watch-overview-single-row.html
+++ b/changedetectionio/blueprint/watchlist/templates/watch-overview-single-row.html
@@ -65,8 +65,9 @@
                         </div>
                     {%  endif %}
                         <div class="watch-text-info">
-                            {%- if watch['processor'] and watch['processor'] in processor_badge_texts -%}
-                                <a href="{{ url_for('watchlist.index', tag=active_tag_uuid, processor=watch['processor']) }}" class="processor-badge processor-badge-{{ watch['processor'] }}{{ ' active' if active_processor == watch['processor'] else '' }}" title="{{ processor_descriptions.get(watch['processor'], watch['processor']) }}">{{ processor_badge_texts[watch['processor']] }}</a>
+                            {%- set processor_badge_text = (processor_badge_texts_by_watch|default({})).get(watch.uuid, processor_badge_texts.get(watch['processor'])) -%}
+                            {%- if watch['processor'] and processor_badge_text -%}
+                                <a href="{{ url_for('watchlist.index', tag=active_tag_uuid, processor=watch['processor']) }}" class="processor-badge processor-badge-{{ watch['processor'] }}{{ ' active' if active_processor == watch['processor'] else '' }}" title="{{ processor_descriptions.get(watch['processor'], watch['processor']) }}">{{ processor_badge_text }}</a>
                             {%- endif -%}
                             <span class="watch-title">
                                 {% if system_use_url_watchlist or watch.get('use_page_title_in_list') %}

--- a/changedetectionio/processors/base.py
+++ b/changedetectionio/processors/base.py
@@ -320,26 +320,25 @@ class difference_detection_processor():
 
         return filepath
 
-    def get_extra_watch_config(self, filename):
-        """
-        Read processor-specific JSON config file from watch data directory.
+    @classmethod
+    def get_extra_watch_config_for_watch(cls, datastore, watch_uuid, filename):
+        """Read a processor config file without constructing a processor instance.
 
-        Args:
-            filename: Name of JSON file (e.g., "visual_ssim_score.json")
-
-        Returns:
-            dict: Parsed JSON data, or empty dict if file doesn't exist
+        The watch-list and API need to inspect processor settings too, but creating a
+        processor for each rendered row would also copy the watch and load checksum state.
+        Keep the file/path handling here so those callers use the same safe reader as the
+        worker.
         """
         import json
         import os
 
-        watch = self.datastore.data['watching'].get(self.watch_uuid)
-        data_dir = watch.data_dir
+        watch = datastore.data['watching'].get(watch_uuid)
+        data_dir = getattr(watch, 'data_dir', None) if watch else None
 
         if not data_dir:
             return {}
 
-        filepath = self._resolve_watch_config_path(data_dir, filename)
+        filepath = cls._resolve_watch_config_path(data_dir, filename)
         if not filepath:
             return {}
 
@@ -349,9 +348,13 @@ class difference_detection_processor():
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (json.JSONDecodeError, IOError, UnicodeError) as e:
             logger.warning(f"Failed to read extra watch config {filename}: {e}")
             return {}
+
+    def get_extra_watch_config(self, filename):
+        """Read processor-specific JSON config for this processor's watch."""
+        return self.get_extra_watch_config_for_watch(self.datastore, self.watch_uuid, filename)
 
     def update_extra_watch_config(self, filename, data, merge=True):
         """

--- a/changedetectionio/processors/restock_diff/processor.py
+++ b/changedetectionio/processors/restock_diff/processor.py
@@ -17,6 +17,37 @@ del _  # Remove marker function
 processor_weight = 1
 list_badge_text = "Restock"  # _()
 
+DEFAULT_RESTOCK_SETTINGS = {
+    'follow_price_changes': True,
+    'in_stock_processing': 'in_stock_only',
+}
+
+
+def get_restock_settings(datastore, watch, log_tag_override=False):
+    """Return the effective restock settings for a watch.
+
+    Restock settings live in the watch's processor config file. A tag with
+    ``overrides_watch`` takes precedence, matching the resolution used while
+    processing a watch. The file reader is shared with other processor callers.
+    """
+    restock_settings = DEFAULT_RESTOCK_SETTINGS.copy()
+    config_data = difference_detection_processor.get_extra_watch_config_for_watch(
+        datastore, watch.get('uuid'), 'restock_diff.json')
+    config_settings = config_data.get('restock_diff') if isinstance(config_data, dict) else None
+    if isinstance(config_settings, dict) and config_settings:
+        restock_settings = config_settings
+
+    tags = datastore.data['settings']['application'].get('tags', {}) or {}
+    for tag_uuid in watch.get('tags') or []:
+        tag = tags.get(tag_uuid, {})
+        if isinstance(tag, dict) and tag.get('overrides_watch'):
+            if log_tag_override:
+                logger.info(f"Watch {watch.get('uuid')} - Tag '{tag.get('title')}' selected for restock settings override")
+            tag_settings = tag.get('processor_config_restock_diff')
+            return tag_settings if isinstance(tag_settings, dict) else {}
+
+    return restock_settings
+
 class UnableToExtractRestockData(Exception):
     def __init__(self, status_code):
         # Set this so we can use it in other parts of the app
@@ -463,19 +494,7 @@ class perform_site_check(difference_detection_processor):
 
         # Which restock settings to compare against?
         # Settings are stored in restock_diff.json (migrated from watch.json by update_30).
-        _extra_config = self.get_extra_watch_config('restock_diff.json')
-        restock_settings = _extra_config.get('restock_diff') or {
-            'follow_price_changes': True,
-            'in_stock_processing': 'in_stock_only',
-        }
-
-        # See if any tags have 'activate for individual watches in this tag/group?' enabled and use the first we find
-        for tag_uuid in watch.get('tags'):
-            tag = self.datastore.data['settings']['application']['tags'].get(tag_uuid, {})
-            if tag.get('overrides_watch'):
-                restock_settings = tag.get('processor_config_restock_diff') or {}
-                logger.info(f"Watch {watch.get('uuid')} - Tag '{tag.get('title')}' selected for restock settings override")
-                break
+        restock_settings = get_restock_settings(self.datastore, watch, log_tag_override=True)
 
 
         itemprop_availability = {}

--- a/changedetectionio/tests/test_restock_itemprop.py
+++ b/changedetectionio/tests/test_restock_itemprop.py
@@ -76,6 +76,47 @@ def test_restock_itemprop_basic(client, live_server, measure_memory_usage, datas
 
         delete_all_watches(client)
 
+
+def test_restock_badge_uses_price_when_availability_detection_is_off(
+        client, live_server, measure_memory_usage, datastore_path):
+    """The watch-list badge should describe price-only restock watches accurately."""
+    delete_all_watches(client)
+    try:
+        set_original_response(props_markup=instock_props[0], price="121.95", datastore_path=datastore_path)
+        test_url = url_for('test_endpoint', _external=True)
+
+        client.post(
+            url_for("ui.ui_views.form_quick_watch_add"),
+            data={"url": test_url, "tags": "", "processor": "restock_diff"},
+            follow_redirects=True,
+        )
+        wait_for_all_checks(client)
+
+        res = client.get(url_for("watchlist.index"))
+        assert b'class="processor-badge processor-badge-restock_diff' in res.data
+        assert b'>Restock</a>' in res.data
+
+        res = client.post(
+            url_for("ui.ui_edit.edit_page", uuid="first"),
+            data={
+                "processor_config_restock_diff-in_stock_processing": "off",
+                "processor_config_restock_diff-follow_price_changes": "y",
+                "url": test_url,
+                "tags": "",
+                "headers": "",
+                "fetch_backend": "html_requests",
+                "time_between_check_use_default": "y",
+            },
+            follow_redirects=True,
+        )
+        assert b"Updated watch." in res.data
+
+        res = client.get(url_for("watchlist.index"))
+        assert b'>Price</a>' in res.data
+        assert b'>Restock</a>' not in res.data
+    finally:
+        delete_all_watches(client)
+
 def test_itemprop_price_change(client, live_server, measure_memory_usage, datastore_path):
     
 


### PR DESCRIPTION
## Summary

Show a `Price` badge when availability detection is disabled, using the effective watch settings and explicit tag overrides. The watch list and processor share the same settings resolver, and badge settings are loaded only for rendered rows.

The badge stays in the new Mode column after merging upstream `9c4c95dd`. The integration regression also checks that there is exactly one badge and that it appears in that column.

Closes #4190.

## Testing

- Reproduced the regression with the upstream-only row template: the price-only watch still showed `Restock`.
- macOS Python 3.13 and Linux Python 3.11: the complete restock integration file, resolved-config API test, and processor-config path tests passed (20 tests, plus 12 subtests on each platform).
- Ruff checks: `E9,F63,F7,F82,INT`; `git diff --check` for the PR diff.
- Source SHA256 verification before and after Linux validation.

Integration tests used local Flask fixtures; Linux containers had external networking disabled. The full application suite and browser automation were not run.
