### PR TITLE
fix(http): send a single Date header on werkzeug built-in server

### DIFF
--- a/changedetectionio/flask_app.py
+++ b/changedetectionio/flask_app.py
@@ -767,6 +767,18 @@ def changedetection_app(config=None, datastore_o=None):
             else:
                 return login_manager.unauthorized()
 
+    # #4299: werkzeug's send_file() (via make_conditional) injects a Date
+    # header into the WSGI response for conditional/static responses, and the
+    # Werkzeug built-in server (allow_unsafe_werkzeug=True) then writes its own
+    # Date via BaseHTTPRequestHandler.send_response() — emitting the Date
+    # header line twice, which RFC 9110 forbids and nginx rejects ("upstream
+    # sent duplicate header line"). Strip the application-side copy so the
+    # server's single header is what reaches the wire.
+    @app.after_request
+    def strip_duplicate_date_header(response):
+        response.headers.pop("Date", None)
+        return response
+
     watch_api.add_resource(
         WatchHistoryDiff,
         '/api/v1/watch/<uuid_str:uuid>/difference/<string:from_timestamp>/<string:to_timestamp>',

--- a/changedetectionio/tests/test_duplicate_date_header.py
+++ b/changedetectionio/tests/test_duplicate_date_header.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Issue #4299: Duplicate Date HTTP header for static resources.
+
+Static files are served via werkzeug send_from_directory/send_file, whose
+make_conditional() injects a Date header into the WSGI response. When the
+app runs on Werkzeug's built-in server (the default dev/LXC/docker-entrypoint
+path, started through socketio.run(..., allow_unsafe_werkzeug=True)),
+BaseHTTPRequestHandler.send_response() emits its own Date header too — so the
+wire response carries two Date header lines, which nginx rejects with
+"upstream sent duplicate header line" and which RFC 9110 forbids.
+
+This test hits the live server over real HTTP (the Flask test client talks to
+the WSGI app directly and never sees the server-added header), and asserts the
+Date header appears exactly once.
+"""
+
+import http.client
+import re
+import socket
+import time
+from urllib.parse import urlparse
+
+
+def _get_raw_headers(url):
+    """Return the raw response header lines (list of (key, value)) — unlike
+    requests/urllib3, these are not merged, so a duplicated header line is
+    visible as two entries."""
+    parsed = urlparse(url)
+    conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+    try:
+        conn.request('GET', parsed.path)
+        resp = conn.getresponse()
+        resp.read()
+        return resp.status, resp.getheaders()
+    finally:
+        conn.close()
+
+
+def _assert_single_date_header(status, headers, label):
+    assert status == 200, f"{label}: expected 200, got {status}"
+    dates = [value for key, value in headers if key.lower() == 'date']
+    assert len(dates) == 1, (
+        f"{label}: expected exactly 1 Date header, got {len(dates)}: {dates!r} "
+        f"(RFC 9110 forbids a duplicated Date header; nginx logs "
+        f"'upstream sent duplicate header line' and ignores the whole field)"
+    )
+    assert re.match(r'^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT$', dates[0]), (
+        f"{label}: Date header is not a valid IMF-fixdate: {dates[0]!r}"
+    )
+
+
+def test_no_duplicate_date_header_on_static_resources(app, live_server):
+    # Wait for the live server socket to accept connections
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((live_server.host, live_server.port), timeout=1):
+                break
+        except OSError:
+            time.sleep(0.2)
+    else:
+        raise AssertionError("live server did not come up in time")
+
+    # The exact resources named in the issue report
+    for group, filename in [('js', 'jquery-3.6.0.min.js'), ('styles', 'styles.css')]:
+        url = live_server.url(f"/static/{group}/{filename}")
+        status, headers = _get_raw_headers(url)
+        _assert_single_date_header(status, headers, f"static/{group}/{filename}")


### PR DESCRIPTION
## Problem

Responses for static resources (e.g. `/static/js/jquery-3.6.0.min.js`) carry **two** `Date` header lines (issue #4299). RFC 9110 forbids a duplicated `Date` header, and reverse proxies such as nginx log "upstream sent duplicate header line" and drop the field.

## Root cause

The `Date` header is injected twice:

1. **WSGI side**: static files are served through werkzeug `send_from_directory()`/`send_file()`, whose `make_conditional()` adds `Date` to the WSGI response headers when absent.
2. **Server side**: the default production path in this repo runs on werkzeug's built-in server (`socketio.run(app, ..., allow_unsafe_werkzeug=True)` in `changedetectionio/__init__.py`), whose `BaseHTTPRequestHandler.send_response()` writes its own `Date` line, after which the WSGI headers are copied through verbatim — two `Date` lines on the wire.

## Fix

Strip the application-side copy with a single global `after_request` hook in `changedetection_app()`:

```python
@app.after_request
def strip_duplicate_date_header(response):
    response.headers.pop("Date", None)
    return response
```

The server's own header is what reaches the wire. Both of this repo's deployment paths re-add `Date` themselves: werkzeug's built-in server, and gunicorn (verified with gunicorn 26.2.0 — a WSGI response without `Date` still goes out with exactly one). A per-route patch would be insufficient because API conditional responses (Flask-RESTful) go through the same `make_conditional()` path; no monkey-patching of werkzeug.

## Test (1 new, red → green)

`changedetectionio/tests/test_duplicate_date_header.py` — uses pytest-flask's `live_server` fixture (the app is forked into a child process running on the real werkzeug server; the Flask test client talks to WSGI directly and would never see the server-added header) and reads raw headers with `http.client` (requests/urllib3 merge duplicate header lines and would hide the bug). Asserts exactly one `Date` header in valid IMF-fixdate format for the two resources named in the issue.

**Fails before the fix** (`expected exactly 1 Date header, got 2: ['Fri, 04 Sep 2026 ...', 'Fri, 04 Sep 2026 ...']`), passes after.

Regression: local CI-equivalent subset (`tests/unit/ tests/llm/ test_access_control.py test_errorhandling.py`) — identical failure sets before and after (5 environment-only failures, unchanged); ruff clean on the new file; no existing test asserts on the presence of a `Date` header.

Known limitation, stated for review: a third-party WSGI server that never sends `Date` would now produce responses without one — RFC 9110 permits the header to be absent, and both of this repo's official paths (built-in server, gunicorn) always send it.

Fixes #4299
