### PR TITLE
fix(llm): retry transient errors (ServiceUnavailable, RateLimit, InternalServerError) with backoff in client

### DIFF
--- a/changedetectionio/blueprint/settings/llm.py
+++ b/changedetectionio/blueprint/settings/llm.py
@@ -204,6 +204,7 @@ def construct_llm_blueprint(datastore: ChangeDetectionStore):
                 timeout=resolve_llm_timeout(llm_cfg),
                 max_tokens=apply_local_token_multiplier(200, llm_cfg),
                 debug=get_llm_settings(datastore).debug,
+                retries=0,
             )
             reply = text.strip()
             if not reply:

--- a/changedetectionio/blueprint/ui/diff.py
+++ b/changedetectionio/blueprint/ui/diff.py
@@ -314,7 +314,7 @@ def construct_blueprint(datastore: ChangeDetectionStore):
             }), 429
 
         try:
-            summary = summarise_change(watch, datastore, diff=diff_text, current_snapshot=to_text)
+            summary = summarise_change(watch, datastore, diff=diff_text, current_snapshot=to_text, retries=0)
         except LLMInputTooLargeError as e:
             return jsonify({'summary': None, 'error': str(e)}), 400
         except Exception as e:

--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -6,6 +6,7 @@ and makes the call easy to mock in tests.
 
 import logging
 import os
+import time
 
 from loguru import logger
 
@@ -113,7 +114,13 @@ def completion(  # noqa: C901
     if extra_body:
         kwargs['extra_body'] = extra_body
 
-    _retryable = (litellm.Timeout, litellm.APIConnectionError)
+    _retryable = (
+        litellm.Timeout,
+        litellm.APIConnectionError,
+        litellm.ServiceUnavailableError,
+        litellm.RateLimitError,
+        litellm.InternalServerError,
+    )
 
     # Some models reject sampling params outright: Anthropic Claude Opus 4.7/4.8 and
     # Fable return HTTP 400 for 'temperature', and OpenAI reasoning models (o1/o3/gpt-5)
@@ -188,10 +195,12 @@ def completion(  # noqa: C901
             except Exception:
                 pass
             if attempt < DEFAULT_RETRIES:
+                _backoff = min(2 ** (attempt - 1), 8)
                 logger.warning(
-                    f"LLM call timed out/connection error (attempt {attempt}/{DEFAULT_RETRIES}), "
-                    f"retrying — model={model!r} timeout={_timeout}s error={e}"
+                    f"LLM call transient error ({type(e).__name__}, attempt {attempt}/{DEFAULT_RETRIES}), "
+                    f"retrying in {_backoff}s — model={model!r} timeout={_timeout}s error={e}"
                 )
+                time.sleep(_backoff)
                 continue
             logger.warning(
                 f"LLM call failed after {DEFAULT_RETRIES} attempts ({_timeout}s timeout) "

--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -4,8 +4,11 @@ Keeps litellm import isolated so the rest of the codebase doesn't depend on it d
 and makes the call easy to mock in tests.
 """
 
+import datetime
+import email.utils
 import logging
 import os
+import random
 import time
 
 from loguru import logger
@@ -30,6 +33,7 @@ DEFAULT_LOCAL_TIMEOUT = int(os.getenv('LLM_LOCAL_TIMEOUT', 1800))
 _NO_TEMPERATURE_MODEL_KEYWORDS = ('flash-lite', 'thinking-exp', 'o1', 'o3', 'o4')
 
 DEFAULT_RETRIES = 3
+DEFAULT_MAX_RETRY_DELAY = 15.0
 
 
 class _LoguruInterceptHandler(logging.Handler):
@@ -66,6 +70,85 @@ def _install_litellm_debug():
 
     _debug_installed = True
     logger.info("LLM client: litellm debug logging routed through loguru")
+
+
+def _parse_retry_after(retry_val) -> float | None:
+    """Parse a Retry-After header value per RFC 9110 into seconds (float).
+
+    Can be either:
+      - delta-seconds (e.g. 5, "5", "12.5")
+      - HTTP-date (e.g. "Wed, 21 Oct 2026 07:28:00 GMT")
+    Returns delay in seconds if positive and valid, else None.
+    """
+    if retry_val is None:
+        return None
+    if isinstance(retry_val, (int, float)):
+        return float(retry_val) if retry_val > 0 else None
+    if isinstance(retry_val, str):
+        val = retry_val.strip()
+        if not val:
+            return None
+        try:
+            sec = float(val)
+            return sec if sec > 0 else None
+        except ValueError:
+            pass
+        try:
+            dt = email.utils.parsedate_to_datetime(val)
+            if dt is not None:
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=datetime.timezone.utc)
+                now = datetime.datetime.now(datetime.timezone.utc)
+                delta = (dt - now).total_seconds()
+                return delta if delta > 0 else None
+        except Exception:
+            pass
+    return None
+
+
+def _extract_retry_after_from_exception(exc) -> float | None:
+    """Extract retry delay (seconds) from exception if present."""
+    # 1. Direct attribute on exception (e.g. exc.retry_after)
+    direct = getattr(exc, 'retry_after', None)
+    parsed = _parse_retry_after(direct)
+    if parsed is not None:
+        return parsed
+
+    # 2. Response headers (exc.response.headers)
+    resp = getattr(exc, 'response', None)
+    if resp is not None:
+        headers = getattr(resp, 'headers', None)
+        if headers and hasattr(headers, 'get'):
+            parsed = _parse_retry_after(headers.get('retry-after') or headers.get('Retry-After'))
+            if parsed is not None:
+                return parsed
+
+    # 3. Direct headers dict on exception (exc.headers)
+    headers = getattr(exc, 'headers', None)
+    if headers and hasattr(headers, 'get'):
+        parsed = _parse_retry_after(headers.get('retry-after') or headers.get('Retry-After'))
+        if parsed is not None:
+            return parsed
+
+    return None
+
+
+def _calculate_backoff(
+    exc, attempt: int, max_delay: float = DEFAULT_MAX_RETRY_DELAY
+) -> tuple[float, bool]:
+    """Calculate backoff delay in seconds with jitter, capped at max_delay.
+
+    Returns (delay_seconds, is_from_retry_after).
+    """
+    ra = _extract_retry_after_from_exception(exc)
+    jitter = random.uniform(0.1, 0.5)
+    if ra is not None:
+        delay = min(ra + jitter, max_delay)
+        return round(delay, 2), True
+
+    base = min(2 ** (attempt - 1), 8)
+    delay = min(base + jitter, max_delay)
+    return round(delay, 2), False
 
 
 def completion(  # noqa: C901
@@ -195,10 +278,11 @@ def completion(  # noqa: C901
             except Exception:
                 pass
             if attempt < DEFAULT_RETRIES:
-                _backoff = min(2 ** (attempt - 1), 8)
+                _backoff, _is_ra = _calculate_backoff(e, attempt)
+                _source_msg = "honoring Retry-After" if _is_ra else "exponential backoff"
                 logger.warning(
                     f"LLM call transient error ({type(e).__name__}, attempt {attempt}/{DEFAULT_RETRIES}), "
-                    f"retrying in {_backoff}s — model={model!r} timeout={_timeout}s error={e}"
+                    f"retrying in {_backoff}s ({_source_msg}) — model={model!r} timeout={_timeout}s error={e}"
                 )
                 time.sleep(_backoff)
                 continue

--- a/changedetectionio/llm/client.py
+++ b/changedetectionio/llm/client.py
@@ -4,8 +4,6 @@ Keeps litellm import isolated so the rest of the codebase doesn't depend on it d
 and makes the call easy to mock in tests.
 """
 
-import datetime
-import email.utils
 import logging
 import os
 import random
@@ -72,83 +70,24 @@ def _install_litellm_debug():
     logger.info("LLM client: litellm debug logging routed through loguru")
 
 
-def _parse_retry_after(retry_val) -> float | None:
-    """Parse a Retry-After header value per RFC 9110 into seconds (float).
+def _get_retry_delay(exc, attempt: int, max_delay: float = DEFAULT_MAX_RETRY_DELAY) -> float | None:
+    """Return backoff delay in seconds with jitter, or None if Retry-After exceeds max_delay (abort)."""
+    ra = getattr(exc, 'retry_after', None)
+    if ra is None:
+        headers = getattr(getattr(exc, 'response', None), 'headers', None) or getattr(exc, 'headers', None) or {}
+        ra = headers.get('retry-after') or headers.get('Retry-After') if hasattr(headers, 'get') else None
 
-    Can be either:
-      - delta-seconds (e.g. 5, "5", "12.5")
-      - HTTP-date (e.g. "Wed, 21 Oct 2026 07:28:00 GMT")
-    Returns delay in seconds if positive and valid, else None.
-    """
-    if retry_val is None:
-        return None
-    if isinstance(retry_val, (int, float)):
-        return float(retry_val) if retry_val > 0 else None
-    if isinstance(retry_val, str):
-        val = retry_val.strip()
-        if not val:
-            return None
-        try:
-            sec = float(val)
-            return sec if sec > 0 else None
-        except ValueError:
-            pass
-        try:
-            dt = email.utils.parsedate_to_datetime(val)
-            if dt is not None:
-                if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=datetime.timezone.utc)
-                now = datetime.datetime.now(datetime.timezone.utc)
-                delta = (dt - now).total_seconds()
-                return delta if delta > 0 else None
-        except Exception:
-            pass
-    return None
-
-
-def _extract_retry_after_from_exception(exc) -> float | None:
-    """Extract retry delay (seconds) from exception if present."""
-    # 1. Direct attribute on exception (e.g. exc.retry_after)
-    direct = getattr(exc, 'retry_after', None)
-    parsed = _parse_retry_after(direct)
-    if parsed is not None:
-        return parsed
-
-    # 2. Response headers (exc.response.headers)
-    resp = getattr(exc, 'response', None)
-    if resp is not None:
-        headers = getattr(resp, 'headers', None)
-        if headers and hasattr(headers, 'get'):
-            parsed = _parse_retry_after(headers.get('retry-after') or headers.get('Retry-After'))
-            if parsed is not None:
-                return parsed
-
-    # 3. Direct headers dict on exception (exc.headers)
-    headers = getattr(exc, 'headers', None)
-    if headers and hasattr(headers, 'get'):
-        parsed = _parse_retry_after(headers.get('retry-after') or headers.get('Retry-After'))
-        if parsed is not None:
-            return parsed
-
-    return None
-
-
-def _calculate_backoff(
-    exc, attempt: int, max_delay: float = DEFAULT_MAX_RETRY_DELAY
-) -> tuple[float, bool]:
-    """Calculate backoff delay in seconds with jitter, capped at max_delay.
-
-    Returns (delay_seconds, is_from_retry_after).
-    """
-    ra = _extract_retry_after_from_exception(exc)
-    jitter = random.uniform(0.1, 0.5)
     if ra is not None:
-        delay = min(ra + jitter, max_delay)
-        return round(delay, 2), True
+        try:
+            sec = float(ra)
+            if sec > max_delay:
+                return None  # Server asked for longer than ceiling; abort immediately
+            return round(min(sec + random.uniform(0.1, 0.5), max_delay), 2)
+        except (ValueError, TypeError):
+            pass
 
-    base = min(2 ** (attempt - 1), 8)
-    delay = min(base + jitter, max_delay)
-    return round(delay, 2), False
+    base = 2 ** (attempt - 1)
+    return round(min(base + random.uniform(0, base), max_delay), 2)
 
 
 def completion(  # noqa: C901
@@ -160,15 +99,17 @@ def completion(  # noqa: C901
     max_tokens: int = None,
     extra_body: dict = None,
     debug: bool = False,
+    retries: int = None,
 ) -> tuple[str, int, int, int]:
     """
     Call the LLM and return (response_text, total_tokens, input_tokens, output_tokens).
-    Retries up to DEFAULT_RETRIES times on timeout or connection errors.
+    Retries up to retries times on timeout, connection, or transient errors.
     Token counts are 0 if the provider doesn't return usage data.
     Raises on network/auth errors — callers handle gracefully.
 
     timeout: seconds for the request. Local endpoints get a longer value than cloud —
     see evaluator.resolve_llm_timeout().
+    retries: number of retry attempts. Use 0 for user-facing interactive paths.
     """
     try:
         import litellm
@@ -179,6 +120,7 @@ def completion(  # noqa: C901
         _install_litellm_debug()
 
     _timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
+    max_attempts = (retries + 1) if retries is not None else DEFAULT_RETRIES
 
     kwargs = {
         'model': model,
@@ -221,7 +163,7 @@ def completion(  # noqa: C901
     logger.trace(messages)
 
     attempt = 0
-    while attempt < DEFAULT_RETRIES:
+    while attempt < max_attempts:
         attempt += 1
         try:
             response = litellm.completion(**kwargs)
@@ -269,25 +211,31 @@ def completion(  # noqa: C901
             return text, total_tokens, input_tokens, output_tokens
 
         except _retryable as e:
-            # litellm formats its Timeout message with None when the provider doesn't
-            # propagate the timeout value — patch the exception args in-place so every
-            # caller that logs str(e) sees the real number.
-            _fix = f'after {_timeout} seconds'
-            try:
-                e.args = tuple(str(a).replace('after None seconds', _fix) for a in e.args)
-            except Exception:
-                pass
-            if attempt < DEFAULT_RETRIES:
-                _backoff, _is_ra = _calculate_backoff(e, attempt)
-                _source_msg = "honoring Retry-After" if _is_ra else "exponential backoff"
+            # litellm formats its Timeout message with 'after None seconds' when the
+            # provider doesn't propagate the timeout value — patch the exception args
+            # in-place so callers that log str(e) see the configured timeout.
+            if isinstance(e, litellm.Timeout):
+                _fix = f'after {_timeout} seconds'
+                try:
+                    e.args = tuple(str(a).replace('after None seconds', _fix) for a in e.args)
+                except Exception:
+                    pass
+            if attempt < max_attempts:
+                delay = _get_retry_delay(e, attempt)
+                if delay is None:
+                    logger.warning(
+                        f"LLM call {type(e).__name__} Retry-After exceeds ceiling ({DEFAULT_MAX_RETRY_DELAY}s), "
+                        f"aborting retry — model={model!r} error={e}"
+                    )
+                    raise
                 logger.warning(
-                    f"LLM call transient error ({type(e).__name__}, attempt {attempt}/{DEFAULT_RETRIES}), "
-                    f"retrying in {_backoff}s ({_source_msg}) — model={model!r} timeout={_timeout}s error={e}"
+                    f"LLM call transient error ({type(e).__name__}, attempt {attempt}/{max_attempts}), "
+                    f"retrying in {delay}s — model={model!r} timeout={_timeout}s error={e}"
                 )
-                time.sleep(_backoff)
+                time.sleep(delay)
                 continue
             logger.warning(
-                f"LLM call failed after {DEFAULT_RETRIES} attempts ({_timeout}s timeout) "
+                f"LLM call failed after {attempt} attempt(s) ({_timeout}s timeout) "
                 f"model={model!r} error={e}"
             )
             raise

--- a/changedetectionio/llm/evaluator.py
+++ b/changedetectionio/llm/evaluator.py
@@ -724,7 +724,7 @@ def build_summary_cache_prompt(effective_prompt: str, max_summary_tokens: int,
     )
 
 
-def summarise_change(watch, datastore, diff: str, current_snapshot: str = '') -> str:
+def summarise_change(watch, datastore, diff: str, current_snapshot: str = '', retries: int = None) -> str:
     """
     Generate a plain-language summary of the change using the watch's
     llm_change_summary prompt (cascades from tag if not set on watch).
@@ -783,6 +783,7 @@ def summarise_change(watch, datastore, diff: str, current_snapshot: str = '') ->
             ),
             extra_body=_extra_body,
             debug=settings.debug,
+            retries=retries,
         )
         raw, tokens = _resp[0], _resp[1]
         input_tokens  = _resp[2] if len(_resp) > 2 else 0
@@ -808,7 +809,7 @@ def summarise_change(watch, datastore, diff: str, current_snapshot: str = '') ->
 # Live-preview extraction (current content, no diff)
 # ---------------------------------------------------------------------------
 
-def preview_extract(watch, datastore, content: str) -> dict | None:
+def preview_extract(watch, datastore, content: str, retries: int = None) -> dict | None:
     """
     For the live-preview endpoint: extract relevant information from the
     *current* page content according to the watch's intent.
@@ -848,6 +849,7 @@ def preview_extract(watch, datastore, content: str) -> dict | None:
             max_tokens=apply_local_token_multiplier(JSON_RESPONSE_MAX_TOKENS, cfg),
             extra_body=_thinking_extra_body(cfg['model'], settings.thinking_budget),
             debug=settings.debug,
+            retries=retries,
         )
         accumulate_global_tokens(datastore, tokens, model=cfg['model'])
         result = parse_preview_response(raw)

--- a/changedetectionio/processors/text_json_diff/__init__.py
+++ b/changedetectionio/processors/text_json_diff/__init__.py
@@ -187,7 +187,7 @@ def prepare_filter_prevew(datastore, watch_uuid, form_data):
     try:
         from changedetectionio.llm.evaluator import preview_extract
         if text_after_filter and text_after_filter.strip() not in ('', 'Empty content'):
-            llm_evaluation = preview_extract(tmp_watch, datastore, content=text_after_filter)
+            llm_evaluation = preview_extract(tmp_watch, datastore, content=text_after_filter, retries=0)
     except Exception as e:
         logger.warning(f"LLM preview evaluation failed for {watch_uuid}: {e}")
 

--- a/changedetectionio/tests/test_llm_all_changes_diff.py
+++ b/changedetectionio/tests/test_llm_all_changes_diff.py
@@ -55,7 +55,7 @@ def test_all_changes_sends_multi_segment_diff_to_llm(
 
     captured_diff = {}
 
-    def fake_summarise(watch, datastore, diff, current_snapshot=None):
+    def fake_summarise(watch, datastore, diff, current_snapshot=None, **kwargs):
         captured_diff['diff'] = diff
         return 'Multi-step summary.'
 
@@ -93,7 +93,7 @@ def test_default_mode_sends_single_diff_to_llm(
 
     captured_diff = {}
 
-    def fake_summarise(watch, datastore, diff, current_snapshot=None):
+    def fake_summarise(watch, datastore, diff, current_snapshot=None, **kwargs):
         captured_diff['diff'] = diff
         return 'Single-range summary.'
 
@@ -125,7 +125,7 @@ def test_all_changes_and_direct_use_separate_cache_keys(
 
     call_count = {'n': 0}
 
-    def fake_summarise(watch, datastore, diff, current_snapshot=None):
+    def fake_summarise(watch, datastore, diff, current_snapshot=None, **kwargs):
         call_count['n'] += 1
         return f'Summary call #{call_count["n"]}'
 
@@ -162,7 +162,7 @@ def test_all_changes_result_is_cached(
 
     call_count = {'n': 0}
 
-    def fake_summarise(watch, datastore, diff, current_snapshot=None):
+    def fake_summarise(watch, datastore, diff, current_snapshot=None, **kwargs):
         call_count['n'] += 1
         return 'Cached multi-step summary.'
 

--- a/changedetectionio/tests/unit/test_llm_client_retry.py
+++ b/changedetectionio/tests/unit/test_llm_client_retry.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest.mock import MagicMock, call, patch
+import litellm
+
+from changedetectionio.llm import client as m
+
+
+class TestLLMClientRetryHandling(unittest.TestCase):
+    def _mock_success_response(
+        self, text="test response", total_tokens=50, input_tokens=30, output_tokens=20
+    ):
+        mock_resp = MagicMock()
+        mock_resp.choices = [
+            MagicMock(message=MagicMock(content=text, parts=None), finish_reason="stop")
+        ]
+        mock_usage = MagicMock()
+        mock_usage.total_tokens = total_tokens
+        mock_usage.prompt_tokens = input_tokens
+        mock_usage.completion_tokens = output_tokens
+        mock_resp.usage = mock_usage
+        return mock_resp
+
+    def _make_error(self, err_cls, message="Transient error"):
+        return err_cls(
+            message=message,
+            model="gemini/gemini-2.5-flash",
+            llm_provider="gemini",
+            response=MagicMock(),
+        )
+
+    @patch("time.sleep")
+    def test_retry_on_service_unavailable_succeeds(self, mock_sleep):
+        exc = self._make_error(litellm.ServiceUnavailableError, "503 Service Unavailable")
+        mock_resp = self._mock_success_response("recovered response")
+
+        with patch("litellm.completion", side_effect=[exc, mock_resp]) as mock_call:
+            text, total_tok, in_tok, out_tok = m.completion(
+                model="gemini/gemini-2.5-flash",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            self.assertEqual(text, "recovered response")
+            self.assertEqual(mock_call.call_count, 2)
+            mock_sleep.assert_called_once_with(1)
+
+    @patch("time.sleep")
+    def test_retry_on_rate_limit_succeeds(self, mock_sleep):
+        exc = self._make_error(litellm.RateLimitError, "429 Rate limit reached")
+        mock_resp = self._mock_success_response("recovered after rate limit")
+
+        with patch("litellm.completion", side_effect=[exc, mock_resp]) as mock_call:
+            text, total_tok, in_tok, out_tok = m.completion(
+                model="gemini/gemini-2.5-flash",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            self.assertEqual(text, "recovered after rate limit")
+            self.assertEqual(mock_call.call_count, 2)
+            mock_sleep.assert_called_once_with(1)
+
+    @patch("time.sleep")
+    def test_retry_on_internal_server_error_succeeds(self, mock_sleep):
+        exc = self._make_error(litellm.InternalServerError, "500 Internal Server Error")
+        mock_resp = self._mock_success_response("recovered from 500")
+
+        with patch("litellm.completion", side_effect=[exc, mock_resp]) as mock_call:
+            text, _, _, _ = m.completion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            self.assertEqual(text, "recovered from 500")
+            self.assertEqual(mock_call.call_count, 2)
+            mock_sleep.assert_called_once_with(1)
+
+    @patch("time.sleep")
+    def test_retry_exhausted_raises_after_default_retries(self, mock_sleep):
+        exc = self._make_error(litellm.ServiceUnavailableError, "503 persistent overload")
+
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.ServiceUnavailableError):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, m.DEFAULT_RETRIES)
+            self.assertEqual(mock_sleep.call_count, m.DEFAULT_RETRIES - 1)
+            self.assertEqual(mock_sleep.call_args_list, [call(1), call(2)])
+
+    @patch("time.sleep")
+    def test_non_retryable_error_raises_immediately(self, mock_sleep):
+        exc = self._make_error(litellm.AuthenticationError, "401 Invalid API key")
+
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.AuthenticationError):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, 1)
+            mock_sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changedetectionio/tests/unit/test_llm_client_retry.py
+++ b/changedetectionio/tests/unit/test_llm_client_retry.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from unittest.mock import MagicMock, call, patch
 import litellm
@@ -20,16 +21,85 @@ class TestLLMClientRetryHandling(unittest.TestCase):
         mock_resp.usage = mock_usage
         return mock_resp
 
-    def _make_error(self, err_cls, message="Transient error"):
-        return err_cls(
+    def _make_error(self, err_cls, message="Transient error", headers=None, retry_after=None):
+        mock_resp = MagicMock()
+        if headers is not None:
+            mock_resp.headers = headers
+        else:
+            mock_resp.headers = {}
+        err = err_cls(
             message=message,
             model="gemini/gemini-2.5-flash",
             llm_provider="gemini",
-            response=MagicMock(),
+            response=mock_resp,
         )
+        if retry_after is not None:
+            err.retry_after = retry_after
+        return err
 
+    def test_parse_retry_after_numeric(self):
+        self.assertEqual(m._parse_retry_after(5), 5.0)
+        self.assertEqual(m._parse_retry_after(3.5), 3.5)
+        self.assertEqual(m._parse_retry_after("7"), 7.0)
+        self.assertEqual(m._parse_retry_after(" 12.5 "), 12.5)
+        self.assertIsNone(m._parse_retry_after(0))
+        self.assertIsNone(m._parse_retry_after("-1"))
+        self.assertIsNone(m._parse_retry_after(""))
+        self.assertIsNone(m._parse_retry_after(None))
+        self.assertIsNone(m._parse_retry_after("invalid"))
+
+    def test_parse_retry_after_http_date(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        future = (now + datetime.timedelta(seconds=15)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+        past = (now - datetime.timedelta(seconds=10)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        parsed_future = m._parse_retry_after(future)
+        self.assertIsNotNone(parsed_future)
+        self.assertTrue(10.0 <= parsed_future <= 16.0)
+
+        parsed_past = m._parse_retry_after(past)
+        self.assertIsNone(parsed_past)
+
+    @patch("random.uniform", return_value=0.25)
+    def test_calculate_backoff_from_exception_attribute(self, mock_jitter):
+        exc = self._make_error(litellm.RateLimitError, retry_after=4)
+        delay, is_ra = m._calculate_backoff(exc, attempt=1)
+        self.assertTrue(is_ra)
+        self.assertEqual(delay, 4.25)
+
+    @patch("random.uniform", return_value=0.2)
+    def test_calculate_backoff_from_response_headers(self, mock_jitter):
+        exc = self._make_error(
+            litellm.ServiceUnavailableError, headers={"retry-after": "6"}
+        )
+        delay, is_ra = m._calculate_backoff(exc, attempt=1)
+        self.assertTrue(is_ra)
+        self.assertEqual(delay, 6.2)
+
+    @patch("random.uniform", return_value=0.3)
+    def test_calculate_backoff_capped_at_max_delay(self, mock_jitter):
+        exc = self._make_error(litellm.RateLimitError, retry_after=3600)
+        delay, is_ra = m._calculate_backoff(exc, attempt=1, max_delay=15.0)
+        self.assertTrue(is_ra)
+        self.assertEqual(delay, 15.0)
+
+    @patch("random.uniform", return_value=0.15)
+    def test_calculate_backoff_fallback_exponential(self, mock_jitter):
+        exc = self._make_error(litellm.InternalServerError)
+        delay1, is_ra1 = m._calculate_backoff(exc, attempt=1)
+        delay2, is_ra2 = m._calculate_backoff(exc, attempt=2)
+        delay3, is_ra3 = m._calculate_backoff(exc, attempt=3)
+
+        self.assertFalse(is_ra1)
+        self.assertEqual(delay1, 1.15)
+        self.assertFalse(is_ra2)
+        self.assertEqual(delay2, 2.15)
+        self.assertFalse(is_ra3)
+        self.assertEqual(delay3, 4.15)
+
+    @patch("random.uniform", return_value=0.1)
     @patch("time.sleep")
-    def test_retry_on_service_unavailable_succeeds(self, mock_sleep):
+    def test_retry_on_service_unavailable_succeeds(self, mock_sleep, mock_jitter):
         exc = self._make_error(litellm.ServiceUnavailableError, "503 Service Unavailable")
         mock_resp = self._mock_success_response("recovered response")
 
@@ -40,11 +110,16 @@ class TestLLMClientRetryHandling(unittest.TestCase):
             )
             self.assertEqual(text, "recovered response")
             self.assertEqual(mock_call.call_count, 2)
-            mock_sleep.assert_called_once_with(1)
+            mock_sleep.assert_called_once_with(1.1)
 
+    @patch("random.uniform", return_value=0.2)
     @patch("time.sleep")
-    def test_retry_on_rate_limit_succeeds(self, mock_sleep):
-        exc = self._make_error(litellm.RateLimitError, "429 Rate limit reached")
+    def test_retry_on_rate_limit_honors_retry_after(self, mock_sleep, mock_jitter):
+        exc = self._make_error(
+            litellm.RateLimitError,
+            "429 Rate limit reached",
+            headers={"retry-after": "5"},
+        )
         mock_resp = self._mock_success_response("recovered after rate limit")
 
         with patch("litellm.completion", side_effect=[exc, mock_resp]) as mock_call:
@@ -54,10 +129,11 @@ class TestLLMClientRetryHandling(unittest.TestCase):
             )
             self.assertEqual(text, "recovered after rate limit")
             self.assertEqual(mock_call.call_count, 2)
-            mock_sleep.assert_called_once_with(1)
+            mock_sleep.assert_called_once_with(5.2)
 
+    @patch("random.uniform", return_value=0.1)
     @patch("time.sleep")
-    def test_retry_on_internal_server_error_succeeds(self, mock_sleep):
+    def test_retry_on_internal_server_error_succeeds(self, mock_sleep, mock_jitter):
         exc = self._make_error(litellm.InternalServerError, "500 Internal Server Error")
         mock_resp = self._mock_success_response("recovered from 500")
 
@@ -68,10 +144,11 @@ class TestLLMClientRetryHandling(unittest.TestCase):
             )
             self.assertEqual(text, "recovered from 500")
             self.assertEqual(mock_call.call_count, 2)
-            mock_sleep.assert_called_once_with(1)
+            mock_sleep.assert_called_once_with(1.1)
 
+    @patch("random.uniform", return_value=0.0)
     @patch("time.sleep")
-    def test_retry_exhausted_raises_after_default_retries(self, mock_sleep):
+    def test_retry_exhausted_raises_after_default_retries(self, mock_sleep, mock_jitter):
         exc = self._make_error(litellm.ServiceUnavailableError, "503 persistent overload")
 
         with patch("litellm.completion", side_effect=exc) as mock_call:
@@ -82,7 +159,7 @@ class TestLLMClientRetryHandling(unittest.TestCase):
                 )
             self.assertEqual(mock_call.call_count, m.DEFAULT_RETRIES)
             self.assertEqual(mock_sleep.call_count, m.DEFAULT_RETRIES - 1)
-            self.assertEqual(mock_sleep.call_args_list, [call(1), call(2)])
+            self.assertEqual(mock_sleep.call_args_list, [call(1.0), call(2.0)])
 
     @patch("time.sleep")
     def test_non_retryable_error_raises_immediately(self, mock_sleep):

--- a/changedetectionio/tests/unit/test_llm_client_retry.py
+++ b/changedetectionio/tests/unit/test_llm_client_retry.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 from unittest.mock import MagicMock, call, patch
 import litellm
@@ -37,64 +36,40 @@ class TestLLMClientRetryHandling(unittest.TestCase):
             err.retry_after = retry_after
         return err
 
-    def test_parse_retry_after_numeric(self):
-        self.assertEqual(m._parse_retry_after(5), 5.0)
-        self.assertEqual(m._parse_retry_after(3.5), 3.5)
-        self.assertEqual(m._parse_retry_after("7"), 7.0)
-        self.assertEqual(m._parse_retry_after(" 12.5 "), 12.5)
-        self.assertIsNone(m._parse_retry_after(0))
-        self.assertIsNone(m._parse_retry_after("-1"))
-        self.assertIsNone(m._parse_retry_after(""))
-        self.assertIsNone(m._parse_retry_after(None))
-        self.assertIsNone(m._parse_retry_after("invalid"))
-
-    def test_parse_retry_after_http_date(self):
-        now = datetime.datetime.now(datetime.timezone.utc)
-        future = (now + datetime.timedelta(seconds=15)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-        past = (now - datetime.timedelta(seconds=10)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-
-        parsed_future = m._parse_retry_after(future)
-        self.assertIsNotNone(parsed_future)
-        self.assertTrue(10.0 <= parsed_future <= 16.0)
-
-        parsed_past = m._parse_retry_after(past)
-        self.assertIsNone(parsed_past)
-
     @patch("random.uniform", return_value=0.25)
-    def test_calculate_backoff_from_exception_attribute(self, mock_jitter):
+    def test_get_retry_delay_from_exception_attribute(self, mock_jitter):
         exc = self._make_error(litellm.RateLimitError, retry_after=4)
-        delay, is_ra = m._calculate_backoff(exc, attempt=1)
-        self.assertTrue(is_ra)
+        delay = m._get_retry_delay(exc, attempt=1)
         self.assertEqual(delay, 4.25)
 
     @patch("random.uniform", return_value=0.2)
-    def test_calculate_backoff_from_response_headers(self, mock_jitter):
+    def test_get_retry_delay_from_response_headers(self, mock_jitter):
         exc = self._make_error(
             litellm.ServiceUnavailableError, headers={"retry-after": "6"}
         )
-        delay, is_ra = m._calculate_backoff(exc, attempt=1)
-        self.assertTrue(is_ra)
+        delay = m._get_retry_delay(exc, attempt=1)
         self.assertEqual(delay, 6.2)
 
-    @patch("random.uniform", return_value=0.3)
-    def test_calculate_backoff_capped_at_max_delay(self, mock_jitter):
+    def test_get_retry_delay_exceeding_max_delay_returns_none(self):
         exc = self._make_error(litellm.RateLimitError, retry_after=3600)
-        delay, is_ra = m._calculate_backoff(exc, attempt=1, max_delay=15.0)
-        self.assertTrue(is_ra)
-        self.assertEqual(delay, 15.0)
+        delay = m._get_retry_delay(exc, attempt=1, max_delay=15.0)
+        self.assertIsNone(delay)
+
+    @patch("random.uniform", return_value=0.3)
+    def test_get_retry_delay_within_max_delay(self, mock_jitter):
+        exc = self._make_error(litellm.RateLimitError, retry_after=10)
+        delay = m._get_retry_delay(exc, attempt=1, max_delay=15.0)
+        self.assertEqual(delay, 10.3)
 
     @patch("random.uniform", return_value=0.15)
-    def test_calculate_backoff_fallback_exponential(self, mock_jitter):
+    def test_get_retry_delay_fallback_exponential(self, mock_jitter):
         exc = self._make_error(litellm.InternalServerError)
-        delay1, is_ra1 = m._calculate_backoff(exc, attempt=1)
-        delay2, is_ra2 = m._calculate_backoff(exc, attempt=2)
-        delay3, is_ra3 = m._calculate_backoff(exc, attempt=3)
+        delay1 = m._get_retry_delay(exc, attempt=1)
+        delay2 = m._get_retry_delay(exc, attempt=2)
+        delay3 = m._get_retry_delay(exc, attempt=3)
 
-        self.assertFalse(is_ra1)
         self.assertEqual(delay1, 1.15)
-        self.assertFalse(is_ra2)
         self.assertEqual(delay2, 2.15)
-        self.assertFalse(is_ra3)
         self.assertEqual(delay3, 4.15)
 
     @patch("random.uniform", return_value=0.1)
@@ -170,6 +145,39 @@ class TestLLMClientRetryHandling(unittest.TestCase):
                 m.completion(
                     model="gemini/gemini-2.5-flash",
                     messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, 1)
+            mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_retry_after_exceeding_max_delay_aborts_immediately(self, mock_sleep):
+        exc = self._make_error(
+            litellm.RateLimitError,
+            "429 Rate limit reached",
+            headers={"retry-after": "60"},
+        )
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.RateLimitError):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, 1)
+            mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_completion_with_zero_retries_fails_immediately(self, mock_sleep):
+        exc = self._make_error(
+            litellm.RateLimitError,
+            "429 Quota exhausted",
+            headers={"retry-after": "5"},
+        )
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.RateLimitError):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hello"}],
+                    retries=0,
                 )
             self.assertEqual(mock_call.call_count, 1)
             mock_sleep.assert_not_called()

--- a/changedetectionio/tests/unit/test_llm_client_retry.py
+++ b/changedetectionio/tests/unit/test_llm_client_retry.py
@@ -174,6 +174,70 @@ class TestLLMClientRetryHandling(unittest.TestCase):
             self.assertEqual(mock_call.call_count, 1)
             mock_sleep.assert_not_called()
 
+    @patch("random.uniform", return_value=0.1)
+    @patch("time.sleep")
+    def test_param_strip_does_not_consume_transient_retry_budget(
+        self, mock_sleep, mock_jitter
+    ):
+        # Stripping sampling params refunds the attempt, so the whole transient
+        # budget is still available afterwards: DEFAULT_RETRIES + 1 calls.
+        bad_request = self._make_error(
+            litellm.BadRequestError, "400 temperature is not supported"
+        )
+        unavailable = self._make_error(
+            litellm.ServiceUnavailableError, "503 Service Unavailable"
+        )
+        mock_resp = self._mock_success_response("recovered after strip")
+
+        with patch(
+            "litellm.completion",
+            side_effect=[bad_request, unavailable, unavailable, mock_resp],
+        ) as mock_call:
+            text, _, _, _ = m.completion(
+                model="gemini/gemini-2.5-flash",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        self.assertEqual(text, "recovered after strip")
+        self.assertEqual(mock_call.call_count, m.DEFAULT_RETRIES + 1)
+        self.assertEqual(mock_sleep.call_args_list, [call(1.1), call(2.1)])
+
+        # The refund is only correct if the strip really happened: the first
+        # call still carries temperature, the ones after it do not.
+        self.assertEqual(mock_call.call_args_list[0].kwargs.get("temperature"), 0)
+        for subsequent in mock_call.call_args_list[1:]:
+            self.assertNotIn("temperature", subsequent.kwargs)
+
+    @patch("time.sleep")
+    def test_bad_request_after_param_strip_raises(self, mock_sleep):
+        # The second 400 has nothing left to drop, so it propagates instead of
+        # refunding another attempt.
+        exc = self._make_error(litellm.BadRequestError, "400 invalid request")
+
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.BadRequestError):
+                m.completion(
+                    model="gemini/gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, 2)
+            mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_bad_request_with_nothing_to_strip_raises_immediately(self, mock_sleep):
+        # This o1-preview request carries no sampling params, so there is
+        # nothing to drop and no attempt to refund.
+        exc = self._make_error(litellm.BadRequestError, "400 unsupported parameter")
+
+        with patch("litellm.completion", side_effect=exc) as mock_call:
+            with self.assertRaises(litellm.BadRequestError):
+                m.completion(
+                    model="o1-preview",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+            self.assertEqual(mock_call.call_count, 1)
+            mock_sleep.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #4383 

### Summary of Changes
- **Expanded Transient Error Retries**: Catches `litellm.ServiceUnavailableError` (HTTP 503 / model overloaded), `litellm.RateLimitError` (HTTP 429), and `litellm.InternalServerError` (HTTP 500) alongside existing timeouts and connection errors.
- **Streamlined `Retry-After` Support**:
  - Single, compact helper (`_get_retry_delay()`) extracting provider wait times from `exc.retry_after`, `exc.response.headers`, or `exc.headers`.
  - Handles standard numeric seconds (integer / float) without external dependencies or heavy date-parsing logic.
- **Ceiling & Immediate Abort**:
  - Enforces a 15.0s ceiling (`DEFAULT_MAX_RETRY_DELAY = 15.0`) to protect worker threads.
  - If `Retry-After` exceeds 15.0s, the client aborts immediately rather than sleeping 15s and making redundant upstream calls.
- **Fast-Fail (`retries=0`) for Interactive UI Callers**:
  - Added optional `retries: int = None` to `completion()`, preserving default retry behavior for background workers.
  - UI callers pass `retries=0` from the diff "Summary" button, preview extraction, and settings connection test so hard quota/rate limit errors surface instantly without spinning.
  - Updated mock in `changedetectionio/tests/test_llm_all_changes_diff.py` with `**kwargs` to accept the new route parameter cleanly.
- **Proportional Jitter & Polish**:
  - Uses full/proportional jitter (`random.uniform(0, base)`) to effectively decorrelate worker retry bursts.
  - Removed unreachable `min(..., 8)` cap and gated timeout message patching strictly to `litellm.Timeout`.
- **Comprehensive Unit Tests**:
  - 15 unit tests in `changedetectionio/tests/unit/test_llm_client_retry.py` verifying header extraction, jitter, immediate abort on excessive `Retry-After`, zero retries for UI callers, exponential fallback, transient recovery, and non-retryable error handling.
  - Includes regression tests verifying that 400 sampling-param stripping refunds the attempt and preserves the full transient retry budget.