### PR TITLE
Add {{llm_unavailable}} notification token for when the AI intent filter could not run

### DIFF
--- a/changedetectionio/llm/evaluator.py
+++ b/changedetectionio/llm/evaluator.py
@@ -901,13 +901,15 @@ def evaluate_change(watch, datastore, diff: str, current_snapshot: str = '') -> 
             f"LLM evaluate_change skipped for {watch.get('uuid')}: monthly budget {budget:,} reached "
             f"({used:,} used this month) — passing change through as important"
         )
-        # Fail open: don't suppress notifications when budget is exhausted
-        return {'important': True, 'summary': ''}
+        # Fail open: don't suppress notifications when budget is exhausted.
+        # 'unavailable' marks that no AI decision was made, so the notification
+        # can say so instead of looking like a filter that passed the change.
+        return {'important': True, 'summary': '', 'unavailable': 'monthly token budget reached'}
 
     # Check per-watch cumulative budget before making the call
     if not _check_token_budget(watch, cfg):
         # Already over budget — fail open (don't suppress notification)
-        return {'important': True, 'summary': ''}
+        return {'important': True, 'summary': '', 'unavailable': 'per-watch token budget reached'}
 
     url = watch.get('url', '')
     title = watch.get('page_title') or watch.get('title') or ''
@@ -944,7 +946,7 @@ def evaluate_change(watch, datastore, diff: str, current_snapshot: str = '') -> 
         logger.warning(f"LLM evaluation failed for {watch.get('uuid')}: {e}")
         # On failure: don't suppress the notification — pass through as important
         watch['llm_last_tokens_used'] = 0
-        return {'important': True, 'summary': ''}
+        return {'important': True, 'summary': '', 'unavailable': f'provider error ({type(e).__name__})'}
 
     # Accumulate token usage: per-watch limit and global monthly budget
     _check_token_budget(watch, cfg, tokens)

--- a/changedetectionio/llm/evaluator.py
+++ b/changedetectionio/llm/evaluator.py
@@ -946,7 +946,7 @@ def evaluate_change(watch, datastore, diff: str, current_snapshot: str = '') -> 
         logger.warning(f"LLM evaluation failed for {watch.get('uuid')}: {e}")
         # On failure: don't suppress the notification — pass through as important
         watch['llm_last_tokens_used'] = 0
-        return {'important': True, 'summary': '', 'unavailable': f'provider error ({type(e).__name__})'}
+        return {'important': True, 'summary': '', 'unavailable': f'evaluation error ({type(e).__name__})'}
 
     # Accumulate token usage: per-watch limit and global monthly budget
     _check_token_budget(watch, cfg, tokens)

--- a/changedetectionio/notification/handler.py
+++ b/changedetectionio/notification/handler.py
@@ -385,9 +385,14 @@ def process_notification(n_object: NotificationContextData, datastore):
 
     # Lazily populate llm_summary / llm_intent if used in notification template
     scan_text = n_object.get('notification_body', '') + n_object.get('notification_title', '')
-    if 'llm_summary' in scan_text or 'llm_intent' in scan_text or 'raw_diff' in scan_text:
+    if ('llm_summary' in scan_text or 'llm_intent' in scan_text or 'raw_diff' in scan_text
+            or 'llm_unavailable' in scan_text):
         n_object['llm_summary'] = _llm_change_summary or (n_object.get('_llm_result') or {}).get('summary', '')
         n_object['llm_intent'] = n_object.get('_llm_intent', '')
+        # Empty when the AI intent filter ran. Set to a short reason when it did
+        # not, so a provider outage or an exhausted budget doesn't reach the user
+        # looking like a filter that deliberately let the change through.
+        n_object['llm_unavailable'] = (n_object.get('_llm_result') or {}).get('unavailable', '')
 
     # Escape diff/snapshot variables before Jinja renders them into an HTML notification.
     # GHSA-q8xq-qg4x-wphg: inscriptis decodes HTML entities when converting text/html

--- a/changedetectionio/notification/handler.py
+++ b/changedetectionio/notification/handler.py
@@ -389,9 +389,10 @@ def process_notification(n_object: NotificationContextData, datastore):
             or 'llm_unavailable' in scan_text):
         n_object['llm_summary'] = _llm_change_summary or (n_object.get('_llm_result') or {}).get('summary', '')
         n_object['llm_intent'] = n_object.get('_llm_intent', '')
-        # Empty when the AI intent filter ran. Set to a short reason when it did
-        # not, so a provider outage or an exhausted budget doesn't reach the user
-        # looking like a filter that deliberately let the change through.
+        # Holds a short reason for the fail-open outcomes in evaluate_change()
+        # (budget reached, or an error during the call/parse); empty otherwise —
+        # including when AI is off or no evaluation ran at all. Lets an outage
+        # stop looking like a filter that deliberately passed the change.
         n_object['llm_unavailable'] = (n_object.get('_llm_result') or {}).get('unavailable', '')
 
     # Escape diff/snapshot variables before Jinja renders them into an HTML notification.

--- a/changedetectionio/notification_service.py
+++ b/changedetectionio/notification_service.py
@@ -236,6 +236,7 @@ class NotificationContextData(dict):
             'triggered_text': None,
             'llm_summary': None,     # AI plain-English summary of what changed (requires AI intent to be configured)
             'llm_intent': None,      # The intent that was evaluated (watch-level or inherited from tag)
+            'llm_unavailable': None, # Set when the AI intent filter could not produce a decision (see llm/evaluator.py)
             'uuid': 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',  # Converted to 'watch_uuid' in create_notification_parameters
             'watch_mime_type': None,
             'watch_tag': None,

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -125,6 +125,10 @@
                 <td><code>{{ '{{llm_intent}}' }}</code></td>
                 <td>{{ _('The AI Change Intent that was evaluated.') }}</td>
             </tr>
+            <tr>
+                <td><code>{{ '{{llm_unavailable}}' }}</code></td>
+                <td>{{ _('Empty when the AI Change Intent filter ran. When it could not run (provider error, or token budget reached) the change is passed through and this holds a short reason.') }}</td>
+            </tr>
             {% endif %}
                 {% if extra_notification_token_placeholder_info %}
                     {% for token in extra_notification_token_placeholder_info %}

--- a/changedetectionio/templates/_common_fields.html
+++ b/changedetectionio/templates/_common_fields.html
@@ -127,7 +127,7 @@
             </tr>
             <tr>
                 <td><code>{{ '{{llm_unavailable}}' }}</code></td>
-                <td>{{ _('Empty when the AI Change Intent filter ran. When it could not run (provider error, or token budget reached) the change is passed through and this holds a short reason.') }}</td>
+                <td>{{ _('Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a token budget reached) the change is passed through and this holds a short reason.') }}</td>
             </tr>
             {% endif %}
                 {% if extra_notification_token_placeholder_info %}

--- a/changedetectionio/tests/llm/test_evaluator.py
+++ b/changedetectionio/tests/llm/test_evaluator.py
@@ -322,6 +322,48 @@ class TestEvaluateChange:
         assert result['important'] is True
         assert 'Price dropped' in result['summary']
 
+    def test_provider_error_marks_result_unavailable(self):
+        """Fail-open still passes the change through, but says the filter didn't run."""
+        from changedetectionio.llm.evaluator import evaluate_change
+
+        ds = _make_datastore(llm_cfg={'model': 'gpt-4o-mini', 'api_key': 'sk-test'})
+        watch = _make_watch(llm_intent='flag price drops')
+
+        with patch('changedetectionio.llm.client.completion',
+                   side_effect=RuntimeError('provider exploded')):
+            result = evaluate_change(watch, ds, diff='- $500\n+ $400')
+
+        assert result['important'] is True
+        assert result['unavailable'] == 'provider error (RuntimeError)'
+
+    def test_budget_exhausted_marks_result_unavailable(self):
+        from changedetectionio.llm.evaluator import evaluate_change
+
+        ds = _make_datastore(llm_cfg={'model': 'gpt-4o-mini', 'api_key': 'sk-test'})
+        watch = _make_watch(llm_intent='flag price drops')
+
+        with patch('changedetectionio.llm.evaluator.is_global_token_budget_exceeded',
+                   return_value=True), \
+             patch('changedetectionio.llm.evaluator.get_global_token_budget_month',
+                   return_value=1000):
+            result = evaluate_change(watch, ds, diff='- $500\n+ $400')
+
+        assert result['important'] is True
+        assert result['unavailable'] == 'monthly token budget reached'
+
+    def test_successful_evaluation_is_not_marked_unavailable(self):
+        from changedetectionio.llm.evaluator import evaluate_change
+
+        ds = _make_datastore(llm_cfg={'model': 'gpt-4o-mini', 'api_key': 'sk-test'})
+        watch = _make_watch(llm_intent='flag price drops')
+
+        llm_response = '{"important": true, "summary": "Price dropped"}'
+        with patch('changedetectionio.llm.client.completion', return_value=(llm_response, 150)):
+            result = evaluate_change(watch, ds, diff='- $500\n+ $400')
+
+        assert result['important'] is True
+        assert 'unavailable' not in result
+
     def test_cache_hit_skips_llm_call(self):
         from changedetectionio.llm.evaluator import evaluate_change
         import hashlib
@@ -496,8 +538,11 @@ class TestTokenBudget:
             result = evaluate_change(watch, ds, diff='- $500\n+ $400')
             mock_llm.assert_not_called()
 
-        # Fail open: important=True so the notification is NOT suppressed
-        assert result == {'important': True, 'summary': ''}
+        # Fail open: important=True so the notification is NOT suppressed,
+        # and marked so the notification can say the filter didn't run.
+        assert result['important'] is True
+        assert result['summary'] == ''
+        assert result['unavailable'] == 'per-watch token budget reached'
 
 
 # ---------------------------------------------------------------------------

--- a/changedetectionio/tests/llm/test_evaluator.py
+++ b/changedetectionio/tests/llm/test_evaluator.py
@@ -334,7 +334,7 @@ class TestEvaluateChange:
             result = evaluate_change(watch, ds, diff='- $500\n+ $400')
 
         assert result['important'] is True
-        assert result['unavailable'] == 'provider error (RuntimeError)'
+        assert result['unavailable'] == 'evaluation error (RuntimeError)'
 
     def test_budget_exhausted_marks_result_unavailable(self):
         from changedetectionio.llm.evaluator import evaluate_change

--- a/changedetectionio/tests/llm/test_notification_tokens.py
+++ b/changedetectionio/tests/llm/test_notification_tokens.py
@@ -45,10 +45,12 @@ class TestHandlerLlmTokenPopulation:
         This is tested directly to validate the handler's token population.
         """
         scan_text = n_object.get('notification_body', '') + n_object.get('notification_title', '')
-        if 'llm_summary' in scan_text or 'llm_intent' in scan_text:
+        if ('llm_summary' in scan_text or 'llm_intent' in scan_text or 'raw_diff' in scan_text
+                or 'llm_unavailable' in scan_text):
             llm_result = n_object.get('_llm_result') or {}
             n_object['llm_summary'] = llm_result.get('summary', '')
             n_object['llm_intent'] = n_object.get('_llm_intent', '')
+            n_object['llm_unavailable'] = llm_result.get('unavailable', '')
         return n_object
 
     def test_llm_summary_populated_when_token_in_body(self):
@@ -68,6 +70,25 @@ class TestHandlerLlmTokenPopulation:
         )
         result = self._run_handler_llm_section(n)
         assert result['llm_intent'] == 'flag price drops'
+
+    def test_llm_unavailable_populated_when_filter_could_not_run(self):
+        n = _make_n_object(
+            notification_body='{{ llm_unavailable }}Change detected',
+            _llm_result={'important': True, 'summary': '',
+                         'unavailable': 'provider error (Timeout)'},
+            _llm_intent='flag price drops',
+        )
+        result = self._run_handler_llm_section(n)
+        assert result['llm_unavailable'] == 'provider error (Timeout)'
+
+    def test_llm_unavailable_empty_when_filter_ran(self):
+        n = _make_n_object(
+            notification_body='{{ llm_unavailable }}Change detected',
+            _llm_result={'important': True, 'summary': 'Price dropped'},
+            _llm_intent='flag price drops',
+        )
+        result = self._run_handler_llm_section(n)
+        assert result['llm_unavailable'] == ''
 
     def test_llm_summary_in_title(self):
         n = _make_n_object(

--- a/changedetectionio/tests/llm/test_notification_tokens.py
+++ b/changedetectionio/tests/llm/test_notification_tokens.py
@@ -71,15 +71,37 @@ class TestHandlerLlmTokenPopulation:
         result = self._run_handler_llm_section(n)
         assert result['llm_intent'] == 'flag price drops'
 
+    def test_llm_tokens_pass_the_notification_template_validator(self):
+        """A token the handler populates is useless if the form rejects it.
+
+        Mirrors forms.py ValidateJinja2Template: render, then check for
+        undeclared variables against the NotificationContextData defaults.
+        Catches a token added to handler.py but never registered.
+        """
+        from jinja2 import BaseLoader
+        from jinja2.meta import find_undeclared_variables
+        from changedetectionio.jinja2_custom.safe_jinja import create_jinja_env
+
+        env = create_jinja_env(loader=BaseLoader)
+        placeholders = NotificationContextData()
+        placeholders.set_random_for_validation()
+        env.globals.update(placeholders)
+
+        for token in ('llm_summary', 'llm_intent', 'llm_unavailable'):
+            tpl = '{{ %s }}' % token
+            env.from_string(tpl).render()
+            undeclared = find_undeclared_variables(env.parse(tpl))
+            assert not undeclared, f"{{{{ {token} }}}} is rejected by the notification validator"
+
     def test_llm_unavailable_populated_when_filter_could_not_run(self):
         n = _make_n_object(
             notification_body='{{ llm_unavailable }}Change detected',
             _llm_result={'important': True, 'summary': '',
-                         'unavailable': 'provider error (Timeout)'},
+                         'unavailable': 'evaluation error (Timeout)'},
             _llm_intent='flag price drops',
         )
         result = self._run_handler_llm_section(n)
-        assert result['llm_unavailable'] == 'provider error (Timeout)'
+        assert result['llm_unavailable'] == 'evaluation error (Timeout)'
 
     def test_llm_unavailable_empty_when_filter_ran(self):
         n = _make_n_object(

--- a/changedetectionio/translations/cs/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/cs/LC_MESSAGES/messages.po
@@ -4136,6 +4136,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/de/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/de/LC_MESSAGES/messages.po
@@ -4188,6 +4188,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_GB/LC_MESSAGES/messages.po
@@ -4128,6 +4128,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/en_US/LC_MESSAGES/messages.po
@@ -4128,6 +4128,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/es/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/es/LC_MESSAGES/messages.po
@@ -4201,6 +4201,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Advertencia: Contenido de"
 

--- a/changedetectionio/translations/fr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/fr/LC_MESSAGES/messages.po
@@ -4141,6 +4141,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/it/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/it/LC_MESSAGES/messages.po
@@ -4130,6 +4130,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 

--- a/changedetectionio/translations/ja/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ja/LC_MESSAGES/messages.po
@@ -4149,6 +4149,12 @@ msgstr ""
 msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
+#: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
 # 訳注: "Warning: Contents of [token1] and [token2] depend on how the difference algorithm perceives the change."
 # → 「警告： [token1] および [token2] の内容は、差分アルゴリズムが変更をどのように認識するかによって異なります。」
 # 主語の訳を後半にまとめた

--- a/changedetectionio/translations/ko/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ko/LC_MESSAGES/messages.po
@@ -4138,6 +4138,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr "평가에 사용된 AI 판단 기준입니다."
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "주의:"
 

--- a/changedetectionio/translations/messages.pot
+++ b/changedetectionio/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: changedetection.io 0.60.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-09-04 14:11+0200\n"
+"POT-Creation-Date: 2026-09-06 01:39-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4124,6 +4124,12 @@ msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
 msgid "The AI Change Intent that was evaluated."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html

--- a/changedetectionio/translations/pl/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/pl/LC_MESSAGES/messages.po
@@ -4296,6 +4296,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr "Oceniony zamiar zmiany AI."
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Ostrzeżenie: Treść"
 

--- a/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/pt_BR/LC_MESSAGES/messages.po
@@ -4178,6 +4178,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Aviso: O conteúdo de"
 

--- a/changedetectionio/translations/ru/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/ru/LC_MESSAGES/messages.po
@@ -4252,6 +4252,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr "Намерение изменения ИИ, которое было оценено."
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Внимание: Содержание"
 

--- a/changedetectionio/translations/tr/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/tr/LC_MESSAGES/messages.po
@@ -4181,6 +4181,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Uyarı: Şunun içerikleri"
 

--- a/changedetectionio/translations/uk/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/uk/LC_MESSAGES/messages.po
@@ -4160,6 +4160,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "Увага: Вміст"
 

--- a/changedetectionio/translations/zh/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh/LC_MESSAGES/messages.po
@@ -4134,6 +4134,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr "警告：以下内容"
 

--- a/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/changedetectionio/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -4134,6 +4134,12 @@ msgid "The AI Change Intent that was evaluated."
 msgstr ""
 
 #: changedetectionio/templates/_common_fields.html
+msgid ""
+"Empty in the normal case. When the AI Change Intent filter could not produce a decision (an evaluation error, or a "
+"token budget reached) the change is passed through and this holds a short reason."
+msgstr ""
+
+#: changedetectionio/templates/_common_fields.html
 msgid "Warning: Contents of"
 msgstr ""
 


### PR DESCRIPTION
The follow-up @apeabody suggested in #4383:

> Marking this legibly in the notification payload/context (e.g. indicating the AI intent filter couldn't run) would be a great product improvement, and would be great to explore in a follow-up PR.

### The gap

`evaluate_change()` fails open in three places — global budget reached, per-watch budget reached, and any exception escaping the completion/parsing block — each returning `{'important': True, 'summary': ''}`.

A successful evaluation that judges the change important returns the same shape. So the notification layer can't tell *"the AI judged this important"* from *"no usable decision was produced"*, and a provider outage reaches the user looking like a filter that deliberately let the change through.

### The change

Each of those three returns now carries a short reason:

```python
return {'important': True, 'summary': '', 'unavailable': f'evaluation error ({type(e).__name__})'}
```

exposed as `{{llm_unavailable}}`:

```
{% if llm_unavailable %}[AI filter unavailable: {{llm_unavailable}}]{% endif %}
{{watch_url}} changed
```

**Contract, stated narrowly:** the key holds a reason for *those three fail-open outcomes* and is empty otherwise. Empty does **not** mean "the model ran and answered" — AI being switched off, no intent configured, an oversized-input raise outside that handler, a cache hit, and the existing `important=False` parse fallback all leave it empty too. It's a positive signal for the fail-open cases, not a general evaluation-status flag.

It's additive, so the worker's `important` gate and existing templates are unaffected.

### Please look at these

**A token that isn't registered is unusable.** My first push populated `llm_unavailable` in `handler.py` but never added it to `NotificationContextData`. `ValidateJinja2Template` builds its allowed-token set from those defaults, so the form rejected `{{ llm_unavailable }}` with *"the following tokens used in the notification are not valid"* — the feature could not be saved at all. Fixed in 9b762cf, with a regression test that runs the validator over every `llm_*` token and fails without the registration. Flagging it because it's the kind of thing that would otherwise be found by a user rather than by CI.

**A modified test.** `test_evaluate_change_skips_call_when_per_period_over_budget` compared the result dict exactly; it now asserts the same two fields plus the marker.

**A test-file weakness I did not fully fix.** `test_notification_tokens.py` keeps its own copy of the handler's token-population logic instead of calling it, so those two token tests can't catch a broken production handler — which is exactly why the registration bug above slipped past them. I brought the copy closer to `handler.py` and added the validator test, which *is* a real regression test. A test that drives `process_notification()` with delivery mocked would be the proper fix; happy to add it here or leave it.

### Checks

`changedetectionio/tests/llm/` + `changedetectionio/tests/unit/`: **479 passed** (that total includes the 6 added here), 100 subtests passed, via

```
python -m pytest changedetectionio/tests/llm/ changedetectionio/tests/unit/ -o addopts=""
```

One unrelated pre-existing failure, `test_watch_model.py::TestHistoryPathTraversal::test_normal_snapshot_entry_is_accepted`, which fails identically on a clean checkout of this branch point — it compares a `realpath`'d result against an unresolved `data_dir`, so it fails on macOS where `/tmp` is a symlink to `/private/tmp`. The guard itself is correct. Separate one-line test fix if you want it.

`ruff check --select E9,F63,F7,F82,INT` clean. Translation catalogs regenerated with `extract_messages` / `update_catalog` / `compile_catalog` — CI verifies these are in sync, so they're included rather than left to a later pass. `dennis-cmd lint --strict` clean on both `.pot` and `.po`.
