### PR TITLE
Fix TestHistoryPathTraversal on macOS, and cover the containment check

### DIFF
--- a/changedetectionio/tests/unit/test_watch_model.py
+++ b/changedetectionio/tests/unit/test_watch_model.py
@@ -370,6 +370,23 @@ class TestHistoryPathTraversal(unittest.TestCase):
         history = watch.history
         self.assertEqual(history, {}, "Path traversal entry must be rejected")
 
+    def test_parent_dir_entry_is_rejected_by_the_containment_check(self):
+        """A bare '..' is the shortest entry that reaches and fails the containment check.
+
+        os.path.basename() reduces '/etc/passwd' and '../../etc/passwd' to
+        'passwd', so those two stop at the os.path.exists() check below the
+        guard rather than at the guard itself. '..' survives basename() intact
+        and resolves to the parent of data_dir, which does exist, so the
+        containment check is what rejects it. Not the only such input —
+        '../..' and 'foo/..' collapse to the same thing — and not the only
+        reason the check exists: it also blocks a filename inside data_dir
+        that is itself a symlink pointing outside.
+        """
+        watch = self._make_watch()
+        self._write_history_txt(watch, ['1000000000,..\n'])
+        history = watch.history
+        self.assertEqual(history, {}, "Parent-directory entry must be rejected")
+
     def test_normal_snapshot_entry_is_accepted(self):
         """A bare filename written by save_history_blob must still load correctly."""
         import uuid as uuid_builder

--- a/changedetectionio/tests/unit/test_watch_model.py
+++ b/changedetectionio/tests/unit/test_watch_model.py
@@ -377,8 +377,11 @@ class TestHistoryPathTraversal(unittest.TestCase):
         watch.save_history_blob(contents="hello world", timestamp=1000000000, snapshot_id=str(uuid_builder.uuid4()))
         history = watch.history
         self.assertEqual(len(history), 1, "Normal snapshot entry must be accepted")
+        # Watch.history resolves entries with os.path.realpath, so compare against a
+        # resolved data_dir. On macOS the datastore lives under /tmp, which is a symlink
+        # to /private/tmp, and an unresolved comparison fails there for a correct path.
         self.assertTrue(
-            list(history.values())[0].startswith(watch.data_dir),
+            list(history.values())[0].startswith(os.path.realpath(watch.data_dir)),
             "Resolved path must be inside the watch data directory"
         )
 


### PR DESCRIPTION
Two changes to `TestHistoryPathTraversal`: one fixes a failure on macOS, the other covers a guard that currently has no test behind it.

### 1. The macOS failure

`changedetectionio/tests/unit/` fails at `test_normal_snapshot_entry_is_accepted`:

```
AssertionError: False is not true : Resolved path must be inside the watch data directory
```

`Watch.history` resolves entries with `os.path.realpath`, but the test compared that resolved path against an **unresolved** `watch.data_dir`. On macOS the datastore lands under `/tmp`, a symlink to `/private/tmp`, so the assertion fails for a path that really is inside the directory.

The guard is correct — it realpaths both sides and appends `os.sep`, which is what defeats the `/data/abc` vs `/data/abcdef` prefix case. Only the test compared unlike things. Now it resolves `data_dir` the same way the production code does.

### 2. A guard with no coverage

I checked this class still fails when it should, by disabling the containment check in `Watch.history`:

```python
if not resolved_path.startswith(safe_data_dir + os.sep) and resolved_path != safe_data_dir:
```

**Every existing test still passed with that check disabled.**

The reason is the line above it. `os.path.basename()` reduces both traversal fixtures to a plain filename, so they never reach the containment check — they stop at the `os.path.exists()` check below it:

| history entry | after `basename()` | reaches containment check? | exists? |
|---|---|---|---|
| `/etc/passwd` | `passwd` | no — already inside data_dir | False |
| `../../etc/passwd` | `passwd` | no — already inside data_dir | False |
| `..` | `..` | **yes** | **True** |

A bare `..` is the shortest fixture that reaches the check and is blocked by it: it survives `basename()` intact and resolves to the *parent* of `data_dir`, which exists. It isn't the only such input — `../..`, `foo/..` and `../foo/..` all collapse to the same thing — and it isn't the only reason the check exists. The other case is the one the source comment calls out: a filename inside `data_dir` that is itself a symlink pointing outside. That one is harder to build a hermetic test around, so this covers the `..` case only.

So this adds `test_parent_dir_entry_is_rejected_by_the_containment_check`. With the containment check disabled it is the only test in the class that fails; with it restored all seven pass.

To be clear, **this is not a vulnerability report.** The current code is safe: `basename()` is the first line of defence and neutralises textual traversal in a history entry, and the containment check catches what is left — a bare `..`, and symlink escapes inside `data_dir`. They defend different things, which is exactly why the second one having no test is worth fixing: a regression in that one line would not have been caught.

### Checks

`changedetectionio/tests/unit/` — **304 passed** on macOS (Python 3.14), 100 subtests passed. Before this it was 302 passed / 1 failed. No behaviour change on Linux, where `/tmp` is not a symlink. `ruff check --select E9,F63,F7,F82,INT` clean.
