### PR TITLE
fix: search modal ignores X-Forwarded-Prefix and navigates to the host root

### DIFF
--- a/.github/workflows/test-stack-reusable-workflow.yml
+++ b/.github/workflows/test-stack-reusable-workflow.yml
@@ -396,6 +396,15 @@ jobs:
             exit 1
           fi
 
+          # base_path drives client-side navigation (search modal), it must carry the prefix
+          if grep -q 'const base_path = "/changedet-sub"' /tmp/nginx-test-subpath.html; then
+            echo "✓ base_path reflects X-Forwarded-Prefix"
+          else
+            echo "ERROR: base_path does not reflect X-Forwarded-Prefix"
+            grep -o 'const base_path = .*' /tmp/nginx-test-subpath.html || true
+            exit 1
+          fi
+
           echo "✓ Subpath reverse proxy working correctly"
 
       - name: Test API through reverse proxy subpath

--- a/changedetectionio/templates/base.html
+++ b/changedetectionio/templates/base.html
@@ -36,6 +36,9 @@
     <script>
         const csrftoken="{{ csrf_token() }}";
         const socketio_url="{{ get_socketio_path() }}/socket.io";
+        // Sub-path prefix when deployed behind a reverse proxy (USE_X_SETTINGS /
+        // X-Forwarded-Prefix sets SCRIPT_NAME), empty string otherwise.
+        const base_path = {{ request.script_root.rstrip('/')|tojson }};
         const is_authenticated = {% if current_user.is_authenticated or not has_password %}true{% else %}false{% endif %};
         // Translatable strings for modal.js (ModalDialog). Defined here in a Jinja
         // template so Babel extract_messages picks them up; modal.js reads this

--- a/changedetectionio/tests/test_search.py
+++ b/changedetectionio/tests/test_search.py
@@ -71,3 +71,12 @@ def test_search_in_tag_limit(client, live_server, measure_memory_usage, datastor
     assert urls[0].split(' ')[0].encode('utf-8') in res.data, urls[0].encode('utf-8')
     assert urls[1].split(' ')[0].encode('utf-8') not in res.data, urls[0].encode('utf-8')
 
+
+def test_search_modal_base_path(client, live_server, measure_memory_usage, datastore_path):
+    # search-modal.js navigates to base_path + '/?q=...', so base_path has to carry the
+    # reverse-proxy sub-path (SCRIPT_NAME), otherwise search jumps to the host root.
+    res = client.get(url_for("watchlist.index"))
+    assert b'const base_path = "";' in res.data
+
+    res = client.get("/", base_url="http://localhost/sub-path")
+    assert b'const base_path = "/sub-path";' in res.data


### PR DESCRIPTION
### The problem

`search-modal.js` builds the search results URL from a `base_path` global:

```js
// Use base_path if available (for sub-path deployments like /enlighten-richerx)
const basePath = typeof base_path !== 'undefined' ? base_path : '';
window.location.href = basePath + '/?' + params.toString();
```

`base_path` is never defined anywhere in the project though — that reference is the only occurrence in the tree. It therefore always falls back to `''`, and submitting the search modal navigates to `https://<host>/?q=...`.

On a sub-path deployment (`USE_X_SETTINGS=1` with `X-Forwarded-Prefix`, e.g. served under `/changedetection`) that leaves the app entirely, so the search modal is unusable. The rest of the page is unaffected because it goes through `url_for()`, which ProxyFix already prefixes via `SCRIPT_NAME`.

### Steps to reproduce

1. Run behind a reverse proxy with `USE_X_SETTINGS=1` and `proxy_set_header X-Forwarded-Prefix /changedetection;`
2. Open the search modal (Alt+S or `/`), type anything and submit
3. The browser goes to `/?q=...` instead of `/changedetection/?q=...`

Appending `?q=...` to the sub-path URL by hand works fine, so only the client-side navigation is affected.

### The fix

Define `base_path` in `base.html` alongside the other server-provided globals, from `request.script_root`. ProxyFix (`x_prefix=1`) sets `SCRIPT_NAME` from `X-Forwarded-Prefix`, so this is the sub-path when deployed under one and `""` otherwise. The `rstrip('/')` keeps the result correct when the prefix happens to be configured with a trailing slash.

The server side already honours `?q=`, so nothing else needed changing.

### Tests

Added `test_search_modal_base_path` to `test_search.py`, covering both the root and the sub-path deployment (the sub-path case is driven with `base_url=` so it does not require ProxyFix to be active). It fails without the template change.

The nginx reverse proxy job already serves the app under `/changedet-sub` with `X-Forwarded-Prefix`, so I also asserted there that the rendered `base_path` carries the prefix — that covers the real deployment shape end to end.