### PR TITLE
feat(ui): show count badges in minimal sidebar

### DIFF
--- a/changedetectionio/static/styles/scss/parts/_action_sidebar.scss
+++ b/changedetectionio/static/styles/scss/parts/_action_sidebar.scss
@@ -281,6 +281,12 @@ ul.action-sidebar-list {
   }
 }
 
+// Count badges (unread, queue) are always visible in minimal mode so users
+// can see at a glance how many items need attention without expanding the rail.
+body.actionsidebar-minimal .action-badge--count {
+  opacity: 1;
+}
+
 // When the inner block expands in MINIMAL mode, reveal every label/badge
 // together with a smooth enter. Always-expanded mode handles labels via the
 // `body.actionside-bar-on` block below — no hover gate needed there.


### PR DESCRIPTION
## User problem

In minimal sidebar mode, count badges (unread changes, queue size) are hidden until hover. Users cannot see at a glance how many items need attention without expanding the rail.

Closes #4413

## What changes

- Add CSS rule to make count badges (.action-badge--count) always visible in minimal mode
- Other badges (like 'soon') remain hidden until hover

## What deliberately does not

- Does not change the expanded sidebar behavior
- Does not change the hover behavior for non-count badges
- Does not modify any Python logic or tests

## Compatibility and migration impact

- No breaking changes: pure CSS styling change
- Backward-compatible: minimal sidebar now shows counts, which was the requested feature

## Tests

- No specific sidebar CSS tests exist in the repo
- This is a visual styling change, not logic
- The existing test suite covers sidebar link visibility (test_add_watch_ui_browser.py)

## Visual verification

- Minimal sidebar now shows count badges (unread, queue) at all times
- Hover still reveals labels and other badges as before