### PR TITLE
Browser fetchers - Judge a fetch on the document we end up extracting, not the first navigation

### DIFF
--- a/.github/workflows/test-stack-reusable-workflow.yml
+++ b/.github/workflows/test-stack-reusable-workflow.yml
@@ -205,7 +205,7 @@ jobs:
           # keeps the run short. Each file is wrapped in its own log group and the failing one is
           # named explicitly, because everything after it is SKIPPED rather than run, and that is
           # otherwise easy to misread as "the whole browser suite broke".
-          for t in tests/fetchers/test_content.py tests/test_errorhandling.py tests/visualselector/test_fetch_data.py tests/fetchers/test_custom_js_before_content.py; do
+          for t in tests/fetchers/test_content.py tests/test_errorhandling.py tests/visualselector/test_fetch_data.py tests/fetchers/test_custom_js_before_content.py tests/fetchers/test_renavigation.py; do
             echo "::group::pytest $t"
             if ! docker run --rm -e "FLASK_SERVER_NAME=cdio" -e "PLAYWRIGHT_DRIVER_URL=ws://sockpuppetbrowser:3000" --network changedet-network --hostname=cdio test-changedetectionio \
                  bash -c "cd changedetectionio;pytest -vv --capture=tee-sys --showlocals --tb=long --live-server-host=0.0.0.0 --live-server-port=5004 $t"; then
@@ -253,7 +253,7 @@ jobs:
       - name: Pyppeteer - Specific tests in built container
         run: |
           # Fail fast, but name the file that failed - see the note in the playwright job above
-          for t in tests/fetchers/test_content.py tests/test_errorhandling.py tests/visualselector/test_fetch_data.py tests/fetchers/test_custom_js_before_content.py; do
+          for t in tests/fetchers/test_content.py tests/test_errorhandling.py tests/visualselector/test_fetch_data.py tests/fetchers/test_custom_js_before_content.py tests/fetchers/test_renavigation.py; do
             echo "::group::pytest $t"
             if ! docker run --rm -e "FLASK_SERVER_NAME=cdio" -e "FAST_PUPPETEER_CHROME_FETCHER=True" -e "PLAYWRIGHT_DRIVER_URL=ws://sockpuppetbrowser:3000" --network changedet-network --hostname=cdio test-changedetectionio \
                  bash -c "cd changedetectionio;pytest --live-server-host=0.0.0.0 --live-server-port=5004 $t"; then

--- a/changedetectionio/content_fetchers/playwright.py
+++ b/changedetectionio/content_fetchers/playwright.py
@@ -296,6 +296,20 @@ class fetcher(Fetcher):
 
             self.page = await context.new_page()
 
+            # Track the LATEST main-frame document response for the whole fetch, not just the one
+            # goto() returns. This app compares the text of the page the browser ends up on, and a
+            # site that gates with an interstitial (503/429 + meta-refresh) navigates to the real
+            # page *during* the extra_wait below - judging the fetch on the first response fails a
+            # watch whose content is present and fine. Same for plain client-side redirects.
+            # Shared with action_goto_url() so only one 'response' listener exists on the page.
+            from changedetectionio.browser_steps.browser_steps import track_latest_navigation_response
+            # Must be an identity check - the tracker hands back the same (initially empty, so
+            # falsy) dict the listener writes into, and `or {}` would quietly swap in a different
+            # one that never gets updated.
+            latest_navigation_response = track_latest_navigation_response(self.page)
+            if latest_navigation_response is None:
+                latest_navigation_response = {}
+
             # Listen for all console events and handle errors
             self.page.on("console", lambda msg: logger.debug(f"Playwright console: Watch URL: {url} {msg.type}: {msg.text} {msg.args}"))
 
@@ -335,6 +349,25 @@ class fetcher(Fetcher):
 
             extra_wait = int(os.getenv("WEBDRIVER_DELAY_BEFORE_CONTENT_READY", 5)) + self.render_extract_delay
             await self.page.wait_for_timeout(extra_wait * 1000)
+
+            # A meta-refresh or client-side redirect usually lands during that wait, so judge the
+            # fetch on the document we are actually about to extract rather than the first one.
+            latest = latest_navigation_response.get('response')
+            if latest is not None and latest is not response:
+                logger.debug(f"Page navigated again while waiting, judging the fetch on {latest.url} "
+                             f"(status {latest.status}) instead of the first response for {url}")
+                response = latest
+                try:
+                    self.headers = await response.all_headers()
+                except Exception as e:
+                    logger.debug(f"Could not refresh headers from the final document: {e}")
+
+            # Don't extract while a navigation is mid-flight, that is what produces
+            # "Execution context was destroyed, most likely because of a navigation"
+            try:
+                await self.page.wait_for_load_state('load', timeout=extra_wait * 1000)
+            except Exception as e:
+                logger.debug(f"Page did not reach a settled load state, continuing anyway: {e}")
 
             try:
                 self.status_code = response.status

--- a/changedetectionio/content_fetchers/puppeteer.py
+++ b/changedetectionio/content_fetchers/puppeteer.py
@@ -430,12 +430,15 @@ class fetcher(Fetcher):
         # Listen for first response to trigger frame handler setup
         self.page._client.on('Network.responseReceived', setup_frame_handlers_on_first_response)
 
-        # Chrome 153+ refuses to commit a navigation when an error status arrives with a
-        # zero-length body, so goto() raises net::ERR_HTTP_RESPONSE_CODE_FAILURE instead of handing
-        # back the response. The response was received fine, we just never get it as a return value,
-        # so keep the main-frame response from the 'response' event and use that instead - the
-        # status check below then reports a real "Error - 404" instead of a raw net:: string.
-        # Kept as the latest matching response so a redirect chain reports its final hop.
+        # Track the LATEST main-frame document response for the whole fetch, not just the one that
+        # goto() happens to return. This app compares the text of the page the browser ends up on,
+        # and plenty of sites navigate again after the first response:
+        #  - an interstitial answering 503/429 with a meta-refresh into the real 200 page, where
+        #    judging the first response fails a watch whose content is sitting right there
+        #  - a plain client-side redirect to another host (slated.com -> get.slated.com)
+        # It also covers Chrome 153+, which refuses to commit a navigation when an error status
+        # arrives with a zero-length body: goto() raises net::ERR_HTTP_RESPONSE_CODE_FAILURE rather
+        # than returning the response, but the response itself still arrives on this event.
         navigation_response = {}
 
         def _keep_navigation_response(response):
@@ -445,20 +448,63 @@ class fetcher(Fetcher):
 
         self.page.on('response', _keep_navigation_response)
 
+        # pyppeteer's navigation watcher is bound to the loaderId of the navigation it started. If
+        # the page replaces that document (redirect/interstitial) the 'load' it waits for never
+        # arrives for that loaderId, so goto() never returns - and with timeout=0 it would block
+        # until the hard PUPPETEER_MAX_PROCESSING_TIMEOUT_SECONDS kill, burning a worker slot for
+        # minutes on a page that is fully loaded. Bound it, then fall back to the document we can
+        # see. Verified against slated.com and getastra.com, which hang indefinitely otherwise.
+        nav_timeout = int(os.getenv("BROWSER_NAVIGATION_TIMEOUT_SECONDS", 30))
+
         response = None
         attempt=0
         try:
             while not response:
                 logger.debug(f"Attempting page fetch {url} attempt {attempt}")
                 asyncio.create_task(handle_frame_navigation())
+                # Race goto() against the main frame actually firing 'load'. In the re-navigation
+                # case goto() can never resolve, but the replacement document does fire 'load' -
+                # usually within a few seconds - so this returns then instead of sitting out the
+                # whole nav_timeout. Whichever arrives first means "the document is loaded".
+                main_frame_loaded = asyncio.Event()
+                main_frame_id = self.page.mainFrame._id
+
+                def _on_lifecycle(event):
+                    if event.get('name') == 'load' and event.get('frameId') == main_frame_id:
+                        main_frame_loaded.set()
+
+                self.page._client.on('Page.lifecycleEvent', _on_lifecycle)
+                goto_task = asyncio.ensure_future(self.page.goto(url, timeout=0))
+                load_task = asyncio.ensure_future(main_frame_loaded.wait())
                 try:
-                    response = await self.page.goto(url, timeout=0)
-                except Exception as e:
-                    if 'ERR_HTTP_RESPONSE_CODE_FAILURE' not in str(e) or not navigation_response:
-                        raise
-                    response = navigation_response['response']
-                    logger.debug(f"Navigation was aborted by the browser (empty body on an error status), "
-                                 f"recovered status {response.status} from the response event")
+                    done, _pending = await asyncio.wait({goto_task, load_task},
+                                                        timeout=nav_timeout,
+                                                        return_when=asyncio.FIRST_COMPLETED)
+
+                    if goto_task in done:
+                        try:
+                            response = goto_task.result()
+                        except Exception as e:
+                            if 'ERR_HTTP_RESPONSE_CODE_FAILURE' not in str(e) or not navigation_response:
+                                raise
+                            response = navigation_response['response']
+                            logger.debug(f"Navigation was aborted by the browser (empty body on an error status), "
+                                         f"recovered status {response.status} from the response event")
+                    else:
+                        # Either the replacement document loaded, or we ran out of patience
+                        response = navigation_response.get('response')
+                        if not response:
+                            raise BrowserFetchTimedOut(msg=f"Browser did not finish navigating to {url} within "
+                                                           f"{nav_timeout}s and no main-frame response was seen.")
+                        why = ("the page replaced the document it started on" if load_task in done
+                               else f"navigation did not settle within {nav_timeout}s")
+                        logger.warning(f"Continuing with the document actually loaded ({why}) - "
+                                       f"status {response.status} for {response.url}")
+                finally:
+                    self.page._client.remove_listener('Page.lifecycleEvent', _on_lifecycle)
+                    for t in (goto_task, load_task):
+                        if not t.done():
+                            t.cancel()
                 await asyncio.sleep(1 + extra_wait)
                 # Check if page still exists before sending command
                 if self.page and hasattr(self.page, '_client'):
@@ -472,6 +518,14 @@ class fetcher(Fetcher):
                     logger.warning(f"Content Fetcher > Response object was none (as in, the response from the browser was empty, not just the content) exiting attempt {attempt}")
                     raise EmptyReply(url=url, status_code=None)
                 attempt+=1
+
+            # The sleep above is where a meta-refresh interstitial typically swaps in the real page,
+            # so re-check which document we are actually on before judging the status code.
+            latest = navigation_response.get('response')
+            if latest is not None and latest is not response:
+                logger.debug(f"Page navigated again while waiting, judging the fetch on {latest.url} "
+                             f"(status {latest.status}) instead of {response.url} (status {response.status})")
+                response = latest
         finally:
             self.page.remove_listener('response', _keep_navigation_response)
 

--- a/changedetectionio/tests/fetchers/test_renavigation.py
+++ b/changedetectionio/tests/fetchers/test_renavigation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""The browser fetchers must judge a fetch on the document they end up extracting.
+
+Plenty of sites answer the first request with an interstitial carrying an error status and a
+client-side redirect, then serve the real page. Judging the fetch on the first navigation fails a
+watch whose content is present and fine (reported against fotokoch.de: 503 + meta refresh -> 200),
+and on the pyppeteer fetcher a replaced document used to hang goto() until the hard processing
+timeout because its navigation watcher is bound to the loaderId it started on.
+"""
+
+import os
+from flask import url_for
+from ..util import wait_for_all_checks
+
+
+def _cdio(url):
+    # The browser runs in another container in CI and reaches the test server as 'cdio'
+    return url.replace('localhost.localdomain', 'cdio').replace('localhost', 'cdio')
+
+
+def test_interstitial_redirect_is_followed(client, live_server, measure_memory_usage, datastore_path):
+    assert os.getenv('PLAYWRIGHT_DRIVER_URL'), "Needs PLAYWRIGHT_DRIVER_URL set for this test"
+
+    res = client.post(
+        url_for("settings.settings_page"),
+        data={
+            "application-empty_pages_are_a_change": "",
+            "requests-time_between_check-minutes": 180,
+            'application-fetch_backend': "html_webdriver",
+        },
+        follow_redirects=True
+    )
+    assert b"Settings updated." in res.data
+
+    test_url = _cdio(url_for('test_interstitial', key='renav', _external=True))
+
+    res = client.post(
+        url_for("imports.import_page"),
+        data={"urls": test_url},
+        follow_redirects=True
+    )
+    assert b"1 Imported" in res.data
+    wait_for_all_checks(client)
+
+    # The interstitial answered 503, so judging the first navigation would have failed the watch
+    uuid = next(iter(live_server.app.config['DATASTORE'].data['watching']))
+    watch = live_server.app.config['DATASTORE'].data['watching'][uuid]
+    assert not watch.get('last_error'), \
+        f"Watch was judged on the interstitial instead of the page it landed on: {watch.get('last_error')}"
+
+    res = client.get(url_for("watchlist.index"))
+    assert b'Error - 503' not in res.data
+
+    assert watch.history_n >= 1, "Fetch succeeded but no snapshot was stored"
+    snapshot = watch.get_history_snapshot(list(watch.history.keys())[-1])
+    assert 'The real page content is here' in snapshot
+    assert 'Browser check in progress' not in snapshot
+
+    client.post(url_for("ui.form_delete", uuid="all"), follow_redirects=True)

--- a/changedetectionio/tests/util.py
+++ b/changedetectionio/tests/util.py
@@ -249,6 +249,31 @@ def new_live_server_setup(live_server):
         import secrets
         return "Random content - {}\n".format(secrets.token_hex(64))
 
+    # Re-navigation gate: the first hit answers with an error status AND a client-side meta
+    # refresh, the second serves the real page. This mirrors sites that gate visitors they have
+    # not seen recently (reported against fotokoch.de, which answers 503 + meta refresh and then
+    # serves a 200). The browser follows the refresh, so the fetch has to be judged on the
+    # document we actually end up extracting rather than on the interstitial.
+    # Keyed on last-seen time rather than a hit count, so EVERY fresh check starts out gated -
+    # a counter would serve a clean 200 to the second check and let the test pass without the fix.
+    _interstitial_last_seen = {}
+
+    @live_server.app.route('/test-interstitial')
+    def test_interstitial():
+        key = request.args.get('key', 'default')
+        now = time.time()
+        seen_recently = (now - _interstitial_last_seen.get(key, 0)) < 10
+        _interstitial_last_seen[key] = now
+        if not seen_recently:
+            resp = make_response(
+                '<html><head><meta http-equiv="refresh" content="1"></head>'
+                '<body>Browser check in progress, you will be redirected</body></html>', 503)
+        else:
+            resp = make_response(
+                '<html><body><h1>The real page content is here</h1></body></html>', 200)
+        resp.headers['Content-Type'] = 'text/html'
+        return resp
+
     @live_server.app.route('/test-endpoint2')
     def test_endpoint2():
         return "<html><body>some basic content</body></html>"


### PR DESCRIPTION
Stacked on #4420 — please review/merge that first. The diff here is the re-navigation change only (6 files, +223/-27).

## The problem

The goal of this app is to compare the text of the page the browser lands on, even when the site navigates again after the first response. Both browser fetchers were bound to the **first** navigation, which surfaced as two separate-looking bug reports that turn out to share one cause.

### 1. pyppeteer hangs for the full 180s processing timeout

Reported against `https://slated.com/`, `https://getastra.com/`, `https://addupsolutions.com/`. The browser connects and the page loads fine, then the watch dies at exactly the max processing time with `xpath_data length returned empty`.

pyppeteer's navigation watcher waits for `load` on the loaderId **it** started. Traced with `Page.lifecycleEvent`:

```
0.24s  main frame networkIdle   loaderId=A0E0E0B2   <- navigation #1, never gets 'load'
2.72s  main frame init          loaderId=56D2B5EF   <- re-navigated to get.slated.com
3.49s  main frame load          loaderId=56D2B5EF   <- 'load' fires for document #2
25.2s  goto() still hanging, frame._loaderId is now 56D2B5EF
```

The site replaces the document, so the awaited `load` never arrives for the original loaderId. With `timeout=0` **and** `setDefaultNavigationTimeout(0)` there is nothing to break the wait, so `goto()` blocks until `PUPPETEER_MAX_PROCESSING_TIMEOUT_SECONDS` (180s) kills the fetch — burning a worker slot for three minutes on a page that is fully loaded and whose `page.content` returns immediately.

Worth noting for anyone reading the code: `Page.stopLoading` is **not** the culprit. Tested directly, it *rescues* a pending `goto()` (returns 200 the moment it is sent). Playwright does not have this bug at all — it resolves with the final URL and status.

### 2. Both fetchers reported the status of the interstitial

Reported by a user against `fotokoch.de`, which gates visitors it has not seen recently: the first request gets `503` + `<meta http-equiv="refresh" content="5">`, and five seconds later the same browser gets the real product page with `200`. The fetch was judged on the 503 and the watch failed, even though the content was present and complete. The only workaround was `ignore_status_codes`, which also silences genuine 404s and 500s on that watch forever.

## The fix

- **Latest document wins.** Both fetchers now track the latest main-frame document response and judge the fetch on that. The meta refresh lands during the existing `extra_wait`, so the `200` is what gets judged.
- **Bounded navigation.** pyppeteer races `goto()` against the main frame firing `load`, bounded by `BROWSER_NAVIGATION_TIMEOUT_SECONDS` (default 30), then falls back to the document it can actually see. Never 180s again.
- **Settled load state** before extraction on playwright, which is what produced `Execution context was destroyed, most likely because of a navigation` when the refresh collided with extraction.
- **One listener per page.** The tracker is installed once and shared between the fetcher and `action_goto_url()` rather than every navigation adding its own — `response` fires once per HTTP response, hundreds of times on a heavy page. Verified one listener remains after an install plus four navigations.

Selenium is unaffected either way: it hardcodes `status_code = 200` because WebDriver cannot see the HTTP status.

## Results

| URL | Before | After |
|---|---|---|
| slated.com | 180s timeout, no content | 200, 226KB, 5–35s |
| getastra.com | 180s timeout, no content | 200, 1.96MB, 8.1s |
| addupsolutions.com | 180s timeout, no content | 200, 368KB, 7.5s |
| genesis.global | ok | 200, 347KB, 5.6s |

## Testing

New `tests/fetchers/test_renavigation.py` covers the interstitial case end to end, registered in both the playwright and pyppeteer CI jobs. It was explicitly checked to **fail without the fix and pass with it**, on both fetchers.

Two things that had to be got right for the test to be worth anything:

- The test endpoint gates on **last-seen time**, not a hit count. With a counter the watch's second check gets a clean 200 and the test passes even with the fix disabled — which it did, until this was changed.
- `track_latest_navigation_response(page) or {}` makes the playwright fix a **silent no-op**: the tracker returns an initially empty (therefore falsy) dict, so `or {}` substitutes a different dict the listener never writes to. There is a comment on that line; it needs an `is None` check.

Suites: **11 passed** playwright, **11 passed** pyppeteer (full browser set), **494 passed** unit + llm.

Not verified: `fotokoch.de` itself returns 200 to this IP, so the original gate could not be reproduced directly — the regression test encodes the behaviour deterministically instead, which is more reliable than depending on a third party's bot heuristics. CI is the real check for the workflow registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
