### PR TITLE
UI - Search modal - fix Enter dismissing the form instead of searching

### DIFF
--- a/changedetectionio/static/js/search-modal.js
+++ b/changedetectionio/static/js/search-modal.js
@@ -62,6 +62,15 @@
 
     // Close modal when clicking the backdrop
     searchModal.addEventListener('click', function(e) {
+      // Only real pointer clicks can land on the backdrop. Keyboard-synthesised clicks
+      // report detail 0 and coordinates of 0,0, which the geometry test below reads as
+      // "outside the dialog" - and implicit form submission (Enter in the input) fires
+      // exactly such a click at the Search button. That closed the modal and blanked
+      // the input mid-dispatch, so the submit that followed hit an empty `required`
+      // field and was rejected: Enter appeared to just dismiss the form.
+      if (e.detail === 0) {
+        return;
+      }
       const rect = searchModal.getBoundingClientRect();
       const isInDialog = (
         rect.top <= e.clientY &&


### PR DESCRIPTION
## Problem

Pressing <kbd>Enter</kbd> in the search modal closed it without running the search — you had to click **Search** with the mouse.

## Cause

Implicit form submission fires a *click* at the submit button, and a keyboard-synthesised click carries `detail: 0` and coordinates of `0,0`.

The backdrop-click handler in `search-modal.js` decided "was this click outside the dialog?" purely from those coordinates:

```js
const rect = searchModal.getBoundingClientRect();
const isInDialog = (rect.top <= e.clientY && ... );
if (!isInDialog) { closeSearchModal(); }
```

`0,0` is outside the dialog's box, so the handler treated Enter's synthetic click as a backdrop click. It closed the dialog **and blanked the input** while the click was still bubbling — so by the time the default action ran, `q` was empty, `required` rejected it, and nothing was searched.

That's why the mouse worked and the keyboard didn't: a real click on the button reports real coordinates inside the dialog.

## Fix

Ignore clicks with `detail === 0` — only a real pointer can land on the backdrop.

## Verification

Driven with Chromium against a local instance, before and after:

| | before | after |
|---|---|---|
| Enter in search box | stays on `/`, modal closed, no search | lands on `/?q=<term>` |

And the behaviours the guard could plausibly have broken, all still fine after the change:

- mouse click on **Search** → `/?q=mouse-click`
- click on the backdrop → modal closes
- <kbd>Esc</kbd> → modal closes
- Enter on an empty box → no navigation, modal stays open (`required` still enforced)

## Note for a follow-up

`static/js/modal.js:114-124` uses the same coordinate-only backdrop test. It's less harmful there — Enter on the focused confirm button fires `handleClose(true)` first, and the stray `handleClose(false)` that follows is swallowed by the already-settled promise — but it's the same latent trap. Left alone here to keep this diff to the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)